### PR TITLE
fix: properly capture and track build ID for TestFlight submission

### DIFF
--- a/.github/workflows/expo-preview-build.yml
+++ b/.github/workflows/expo-preview-build.yml
@@ -48,6 +48,7 @@ jobs:
         run: npm test
 
       - name: Build iOS Preview
+        id: ios_build
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'ios' }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -55,7 +56,11 @@ jobs:
           APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
-          eas build --platform ios --profile preview --non-interactive --no-wait
+          # Capture build output and extract build ID
+          eas build --platform ios --profile preview --non-interactive --no-wait --json > build_output.json
+          BUILD_ID=$(cat build_output.json | jq -r '.id')
+          echo "iOS Build ID: $BUILD_ID"
+          echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
 
       - name: Build Android Preview
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}
@@ -75,38 +80,35 @@ jobs:
           ASC_APP_ID: ${{ secrets.ASC_APP_ID }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          echo "Waiting for iOS build to complete before submitting to TestFlight..."
-          # Wait for build to complete, then auto-submit
-          sleep 60  # Give build time to register
-          eas build:list --platform ios --status in-progress --non-interactive --json > builds.json || echo "[]" > builds.json
+          BUILD_ID="${{ steps.ios_build.outputs.build_id }}"
 
-          # Check if there are any in-progress builds
-          if [ "$(cat builds.json | jq '. | length')" -gt "0" ]; then
-            echo "Build in progress, waiting for completion..."
-            BUILD_ID=$(cat builds.json | jq -r '.[0].id')
-
-            # Wait for build to finish (max 45 minutes)
-            for i in {1..90}; do
-              sleep 30
-              eas build:view $BUILD_ID --json > build_status.json
-              STATUS=$(cat build_status.json | jq -r '.status')
-              echo "Build status: $STATUS"
-
-              if [ "$STATUS" = "FINISHED" ] || [ "$STATUS" = "finished" ]; then
-                echo "Build completed successfully!"
-                eas submit --platform ios --id $BUILD_ID --non-interactive
-                exit 0
-              elif [ "$STATUS" = "ERRORED" ] || [ "$STATUS" = "errored" ] || [ "$STATUS" = "CANCELED" ] || [ "$STATUS" = "canceled" ]; then
-                echo "Build failed with status: $STATUS"
-                exit 1
-              fi
-            done
-
-            echo "Build timeout - please check EAS dashboard"
+          if [ -z "$BUILD_ID" ]; then
+            echo "Error: Build ID not found from previous step"
             exit 1
-          else
-            echo "No in-progress builds found, submission will happen after build completes"
           fi
+
+          echo "Tracking iOS build: $BUILD_ID"
+          echo "Waiting for build to complete before submitting to TestFlight..."
+
+          # Wait for build to finish (max 45 minutes)
+          for i in {1..90}; do
+            sleep 30
+            eas build:view $BUILD_ID --json > build_status.json
+            STATUS=$(cat build_status.json | jq -r '.status')
+            echo "Build status: $STATUS (check $i/90)"
+
+            if [ "$STATUS" = "FINISHED" ] || [ "$STATUS" = "finished" ]; then
+              echo "Build completed successfully!"
+              eas submit --platform ios --id $BUILD_ID --non-interactive
+              exit 0
+            elif [ "$STATUS" = "ERRORED" ] || [ "$STATUS" = "errored" ] || [ "$STATUS" = "CANCELED" ] || [ "$STATUS" = "canceled" ]; then
+              echo "Build failed with status: $STATUS"
+              exit 1
+            fi
+          done
+
+          echo "Build timeout after 45 minutes - please check EAS dashboard"
+          exit 1
 
       - name: Android Build Info
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}


### PR DESCRIPTION
- Capture build ID from eas build command using --json flag
- Pass build ID between workflow steps using GITHUB_OUTPUT
- Track specific build instead of searching for any in-progress build
- Remove unreliable sleep + build:list approach
- Improves reliability of auto-submission to TestFlight

Fixes issue where workflow would exit with 'No in-progress builds found' because it wasn't tracking the specific build ID that was just triggered.