### PR TITLE
fix: extract build ID from eas build --json array output

### DIFF
--- a/.github/workflows/expo-preview-build.yml
+++ b/.github/workflows/expo-preview-build.yml
@@ -57,8 +57,17 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
           # Capture build output and extract build ID
-          eas build --platform ios --profile preview --non-interactive --no-wait --json > build_output.json
-          BUILD_ID=$(cat build_output.json | jq -r '.id')
+          eas build --platform ios --profile preview --non-interactive --no-wait --json > build_output.json 2>&1
+
+          # Extract JSON array from output (eas build --json includes human-readable output before JSON)
+          BUILD_ID=$(grep -A 100 '^\[' build_output.json | jq -r '.[0].id')
+
+          if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
+            echo "Error: Failed to extract build ID"
+            cat build_output.json
+            exit 1
+          fi
+
           echo "iOS Build ID: $BUILD_ID"
           echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ app-example
 
 # PR descriptions
 PR.md
+
+# Local workflow testing scripts
+test-workflow.sh
+test-json-extraction.sh


### PR DESCRIPTION
The eas build --json command outputs human-readable text followed by a JSON array. Previous approach failed because jq couldn't parse mixed output.

Changes:
- Use grep to extract JSON array portion from output
- Parse .[0].id from the array (not .id from object)
- Add validation to ensure BUILD_ID is not empty or null
- Add error handling with full output dump on failure
- Add test scripts to .gitignore for local workflow validation

Tested locally with mock and real eas build outputs.