### PR TITLE
fix(auth): require explicit SSO opt-in and document env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,19 @@ EXPO_PUBLIC_POSTHOG_SESSION_REPLAY=false
 # For local development, you can leave the key empty or use a development project key
 # Session replay is disabled by default in development and preview builds
 # Session replay is enabled by default in production builds (configured in eas.json)
+
+# SSO Authentication Configuration
+# Google Sign-In (required for Google SSO to show)
+# Get your client ID from: https://console.cloud.google.com/apis/credentials
+EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID=
+EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID=
+
+# Apple Sign-In (iOS only)
+# Set to 'true' to enable Apple Sign-In button on iOS
+# No client ID needed - uses device Apple ID
+# Requires: backend configured to verify Apple identity tokens
+EXPO_PUBLIC_APPLE_SSO_ENABLED=false
+
+# Note: SSO buttons are hidden when not configured
+# Google: requires EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID (mobile + backend)
+# Apple: requires EXPO_PUBLIC_APPLE_SSO_ENABLED=true (backend only)

--- a/__tests__/hooks/auth/useAppleSignIn.test.ts
+++ b/__tests__/hooks/auth/useAppleSignIn.test.ts
@@ -24,7 +24,8 @@ jest.mock('expo-apple-authentication', () => ({
 jest.mock('expo-constants', () => ({
   expoConfig: {
     extra: {
-      // Apple SSO enabled by default (no explicit setting)
+      // Apple SSO requires explicit opt-in
+      EXPO_PUBLIC_APPLE_SSO_ENABLED: 'true',
     },
   },
 }));
@@ -50,11 +51,12 @@ describe('useAppleSignIn', () => {
   });
 
   describe('isAppleSignInEnabled', () => {
-    it('returns true on iOS by default', () => {
+    it('returns true on iOS when explicitly enabled', () => {
+      // expo-constants mock has EXPO_PUBLIC_APPLE_SSO_ENABLED: 'true'
       expect(isAppleSignInEnabled()).toBe(true);
     });
 
-    it('returns false on Android', () => {
+    it('returns false on Android even when enabled', () => {
       Object.defineProperty(Platform, 'OS', { value: 'android', writable: true });
       expect(isAppleSignInEnabled()).toBe(false);
     });

--- a/eas.json
+++ b/eas.json
@@ -16,7 +16,10 @@
       "env": {
         "EXPO_PUBLIC_POSTHOG_KEY": "",
         "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
-        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false"
+        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false",
+        "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "",
+        "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "",
+        "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }
     },
     "preview": {
@@ -35,7 +38,10 @@
         "APP_ENV": "preview",
         "EXPO_PUBLIC_POSTHOG_KEY": "",
         "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
-        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false"
+        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false",
+        "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "",
+        "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "",
+        "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }
     },
     "production": {
@@ -54,7 +60,10 @@
         "APP_ENV": "production",
         "EXPO_PUBLIC_POSTHOG_KEY": "",
         "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
-        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "true"
+        "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "true",
+        "EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID": "",
+        "EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID": "",
+        "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }
     }
   },

--- a/hooks/auth/useAppleSignIn.ts
+++ b/hooks/auth/useAppleSignIn.ts
@@ -30,7 +30,7 @@ export interface UseAppleSignInReturn {
 
 /**
  * Check if Apple Sign-In is enabled via environment variable
- * Defaults to true on iOS, always false on other platforms
+ * Requires explicit opt-in via EXPO_PUBLIC_APPLE_SSO_ENABLED=true
  */
 export function isAppleSignInEnabled(): boolean {
   // Apple Sign-In is iOS only
@@ -38,18 +38,13 @@ export function isAppleSignInEnabled(): boolean {
     return false;
   }
 
-  // Check if explicitly disabled via env var
+  // Require explicit opt-in via env var
   const enabledEnvVar =
     Constants.expoConfig?.extra?.EXPO_PUBLIC_APPLE_SSO_ENABLED ||
     process.env.EXPO_PUBLIC_APPLE_SSO_ENABLED;
 
-  // If env var is explicitly set to 'false', disable
-  if (enabledEnvVar === 'false') {
-    return false;
-  }
-
-  // Default to enabled on iOS
-  return true;
+  // Only enable if explicitly set to 'true'
+  return enabledEnvVar === 'true';
 }
 
 /**


### PR DESCRIPTION
Changes:
- Apple Sign-In now requires EXPO_PUBLIC_APPLE_SSO_ENABLED=true (previously defaulted to enabled on iOS, which would fail without config)
- Add review.md to .gitignore (PR agent generated file)
- Document all SSO env vars in .env.example with explanations
- Add SSO env vars to all eas.json build profiles

Environment variables for SSO:
- EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID (required for Google)
- EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID (optional, iOS-specific)
- EXPO_PUBLIC_APPLE_SSO_ENABLED (required, set to 'true' for Apple)