### PR TITLE
feat(deployment): add Android support to preview build script

### DIFF
--- a/.deployment/README.md
+++ b/.deployment/README.md
@@ -41,10 +41,13 @@ This directory contains comprehensive documentation and scripts for building and
 
 **Preview Build (Local Testing):**
 ```bash
-# Build iOS preview
+# Build iOS preview (default)
 bash .deployment/build-preview.sh
 
-# Submit to TestFlight
+# Build Android preview
+bash .deployment/build-preview.sh android
+
+# Submit iOS to TestFlight
 bash .deployment/submit-testflight.sh <build-id>
 ```
 
@@ -55,7 +58,8 @@ bash .deployment/submit-testflight.sh <build-id>
 # 2. Go to GitHub Actions → "Expo Production Build" → Run workflow
 
 # Via Local Script
-bash .deployment/build-production.sh
+bash .deployment/build-production.sh ios
+bash .deployment/build-production.sh android
 
 # Download for testing
 bash .deployment/download-build.sh <build-id>
@@ -69,29 +73,34 @@ All scripts are located in `.deployment/` directory and are used by both CI/CD a
 
 ### `build-preview.sh`
 
-Triggers an iOS preview build on EAS.
+Triggers a preview build on EAS for iOS or Android.
 
-**Purpose**: Internal testing builds that automatically submit to TestFlight
+**Purpose**: Internal testing builds (iOS auto-submits to TestFlight, Android available for download)
 
 **Usage:**
 ```bash
 export EXPO_TOKEN="your-expo-token"
+
+# iOS (default)
 bash .deployment/build-preview.sh
+
+# Android
+bash .deployment/build-preview.sh android
 ```
 
 **What it does:**
 - Triggers EAS build with `preview` profile
-- Uses `store` distribution for TestFlight compatibility
-- Captures build ID and saves to `build_id.txt`
-- Outputs build ID to stdout and `$GITHUB_OUTPUT` (if in CI)
+- Uses `store` distribution for TestFlight compatibility (iOS)
+- Captures build ID and saves to `build_id_preview_{platform}.txt`
+- Outputs build ID and URL to stdout and `$GITHUB_OUTPUT` (if in CI)
 
 **Output:**
 ```
-Starting iOS preview build...
-Build started successfully!
-Build ID: abc123-def456-ghi789
-View build: https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/abc123-def456-ghi789
-abc123-def456-ghi789
+==========================================
+Triggering ios Preview Build
+==========================================
+✅ ios Build ID: abc123-def456-ghi789
+🔗 Build URL: https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/abc123-def456-ghi789
 ```
 
 **Profile:** Uses `preview` profile from eas.json:
@@ -101,21 +110,26 @@ abc123-def456-ghi789
 
 ### `build-production.sh`
 
-Triggers an iOS production build on EAS.
+Triggers a production build on EAS for iOS or Android.
 
-**Purpose**: Production-ready builds for App Store release
+**Purpose**: Production-ready builds for App Store / Play Store release
 
 **Usage:**
 ```bash
 export EXPO_TOKEN="your-expo-token"
-bash .deployment/build-production.sh
+
+# iOS
+bash .deployment/build-production.sh ios
+
+# Android
+bash .deployment/build-production.sh android
 ```
 
 **What it does:**
 - Triggers EAS build with `production` profile
-- Uses `store` distribution for App Store
-- Captures build ID and saves to `build_id_production.txt`
-- Outputs build ID to stdout and `$GITHUB_OUTPUT` (if in CI)
+- Uses `store` distribution for App Store / Play Store
+- Captures build ID and saves to `build_id_production_{platform}.txt`
+- Outputs build ID and URL to stdout and `$GITHUB_OUTPUT` (if in CI)
 
 **Profile:** Uses `production` profile from eas.json:
 - Distribution: `store`
@@ -825,6 +839,12 @@ A: Check [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) and build logs
 ## Changelog
 
 ### Recent Updates
+
+**2025-12-08 - Android Support for Preview Builds**
+- Updated `build-preview.sh` to support both iOS and Android (via platform argument)
+- Updated `expo-preview-build.yml` workflow to use script for Android builds
+- Android builds now capture build ID properly for tracking
+- Added build summary step to preview workflow
 
 **2025-10-27 - Production Build Scripts Added**
 - Added `build-production.sh` for production builds

--- a/.deployment/build-preview.sh
+++ b/.deployment/build-preview.sh
@@ -1,12 +1,26 @@
 #!/bin/bash
+
+# Build script for preview builds
+# This script triggers a preview build on EAS and captures the build ID
+# Used by both CI/CD (GitHub Actions) and local development
+
 set -e
 
+# Get platform from argument (default: ios)
+PLATFORM="${1:-ios}"
+
+# Validate platform
+if [ "$PLATFORM" != "ios" ] && [ "$PLATFORM" != "android" ]; then
+  echo "Error: Invalid platform '$PLATFORM'. Must be 'ios' or 'android'"
+  exit 1
+fi
+
 echo "=========================================="
-echo "Triggering iOS Preview Build"
+echo "Triggering $PLATFORM Preview Build"
 echo "=========================================="
 
 # Trigger build and capture output
-eas build --platform ios --profile preview --non-interactive --no-wait --json > build_output.json 2>&1
+eas build --platform "$PLATFORM" --profile preview --non-interactive --no-wait --json > build_output.json 2>&1
 
 # Extract JSON array from output
 BUILD_ID=$(grep -A 100 '^\[' build_output.json | jq -r '.[0].id')
@@ -17,13 +31,19 @@ if [ -z "$BUILD_ID" ] || [ "$BUILD_ID" = "null" ]; then
   exit 1
 fi
 
-echo "✅ iOS Build ID: $BUILD_ID"
+echo "✅ $PLATFORM Build ID: $BUILD_ID"
 echo "🔗 Build URL: https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/$BUILD_ID"
 
-# Export for other scripts to use
-echo "$BUILD_ID" > .deployment/build_id.txt
+# Save build ID for later steps (platform-specific file)
+echo "$BUILD_ID" > ".deployment/build_id_preview_$PLATFORM.txt"
+
+# Also save to generic file for backwards compatibility (iOS only)
+if [ "$PLATFORM" = "ios" ]; then
+  echo "$BUILD_ID" > .deployment/build_id.txt
+fi
 
 # Export for GitHub Actions (if GITHUB_OUTPUT exists)
 if [ -n "$GITHUB_OUTPUT" ]; then
-  echo "build_id=$BUILD_ID" >> $GITHUB_OUTPUT
+  echo "build_id=$BUILD_ID" >> "$GITHUB_OUTPUT"
+  echo "build_url=https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/$BUILD_ID" >> "$GITHUB_OUTPUT"
 fi

--- a/.github/workflows/expo-preview-build.yml
+++ b/.github/workflows/expo-preview-build.yml
@@ -52,14 +52,14 @@ jobs:
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'ios' }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: bash .deployment/build-preview.sh
+        run: bash .deployment/build-preview.sh ios
 
       - name: Build Android Preview
+        id: android_build
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: |
-          eas build --platform android --profile preview --non-interactive --no-wait
+        run: bash .deployment/build-preview.sh android
 
       - name: Submit to TestFlight
         if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'ios' }}
@@ -67,10 +67,26 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/submit-testflight.sh "${{ steps.ios_build.outputs.build_id }}"
 
-      - name: Android Build Info
-        if: ${{ github.event.inputs.platform == 'all' || github.event.inputs.platform == 'android' }}
+      - name: Build Summary
         run: |
-          echo "Android preview build triggered!"
-          echo "Note: Android builds will be available for download from EAS dashboard"
-          echo "Play Store publication is not configured (account inactive)"
-          echo "Visit: https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds"
+          echo "=========================================="
+          echo "Preview Build Summary"
+          echo "=========================================="
+          echo ""
+          if [ "${{ github.event.inputs.platform }}" == "all" ] || [ "${{ github.event.inputs.platform }}" == "ios" ]; then
+            echo "📱 iOS Build:"
+            echo "   Build ID: ${{ steps.ios_build.outputs.build_id }}"
+            echo "   URL: ${{ steps.ios_build.outputs.build_url }}"
+            echo "   Status: Submitted to TestFlight"
+            echo ""
+          fi
+          if [ "${{ github.event.inputs.platform }}" == "all" ] || [ "${{ github.event.inputs.platform }}" == "android" ]; then
+            echo "🤖 Android Build:"
+            echo "   Build ID: ${{ steps.android_build.outputs.build_id }}"
+            echo "   URL: ${{ steps.android_build.outputs.build_url }}"
+            echo "   Status: Available for download from EAS dashboard"
+            echo "   Note: Play Store publication not configured (account inactive)"
+            echo ""
+          fi
+          echo "=========================================="
+          echo "Monitor all builds at: https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds"


### PR DESCRIPTION
- Update build-preview.sh to accept platform argument (ios/android)
- Update expo-preview-build.yml to use script for Android builds
- Android builds now properly capture build ID for tracking
- Add build summary step showing both platform build info
- Update deployment README with new usage examples