### PR TITLE
chore: add PostHog and API URL configuration to eas.json

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -14,8 +14,11 @@
         "buildType": "apk"
       },
       "env": {
-        "EXPO_PUBLIC_WEB_URL": "https://staging.versemate.org",
-        "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
+        "APP_ENV": "development",
+        "EXPO_PUBLIC_API_URL": "https://api.verse-mate.apegro.dev",
+        "EXPO_PUBLIC_WEB_URL": "https://app.versemate.org",
+        "EXPO_PUBLIC_POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "EXPO_PUBLIC_POSTHOG_HOST": "https://us.i.posthog.com",
         "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false",
         "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }
@@ -34,8 +37,10 @@
       },
       "env": {
         "APP_ENV": "preview",
+        "EXPO_PUBLIC_API_URL": "https://api.verse-mate.apegro.dev",
         "EXPO_PUBLIC_WEB_URL": "https://app.versemate.org",
-        "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
+        "EXPO_PUBLIC_POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "EXPO_PUBLIC_POSTHOG_HOST": "https://us.i.posthog.com",
         "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "false",
         "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }
@@ -54,8 +59,10 @@
       },
       "env": {
         "APP_ENV": "production",
+        "EXPO_PUBLIC_API_URL": "https://api.verse-mate.apegro.dev",
         "EXPO_PUBLIC_WEB_URL": "https://app.versemate.org",
-        "EXPO_PUBLIC_POSTHOG_HOST": "https://app.posthog.com",
+        "EXPO_PUBLIC_POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
+        "EXPO_PUBLIC_POSTHOG_HOST": "https://us.i.posthog.com",
         "EXPO_PUBLIC_POSTHOG_SESSION_REPLAY": "true",
         "EXPO_PUBLIC_APPLE_SSO_ENABLED": "false"
       }

--- a/lib/api/client-interceptors.ts
+++ b/lib/api/client-interceptors.ts
@@ -146,8 +146,16 @@ async function responseInterceptor(
  *
  * Should be called once during app initialization, after QueryClient setup.
  * Configures both request and response interceptors on the global client instance.
+ * Also sets the baseUrl from environment variable (overrides hardcoded value in generated client).
  */
 export function setupClientInterceptors(): void {
+  // Override baseUrl from environment variable
+  // The generated client has a hardcoded baseUrl, but we want to use the env var for flexibility
+  const apiUrl = process.env.EXPO_PUBLIC_API_URL;
+  if (apiUrl) {
+    client.setConfig({ baseUrl: apiUrl });
+  }
+
   // Add request interceptor for token injection
   client.interceptors.request.use(requestInterceptor);
 


### PR DESCRIPTION
- Add EXPO_PUBLIC_POSTHOG_KEY and EXPO_PUBLIC_POSTHOG_HOST to all build profiles
- Add EXPO_PUBLIC_API_URL to all build profiles (development, preview, production)
- Fix API client to use EXPO_PUBLIC_API_URL at runtime via client.setConfig()
- Update PostHog host to US region (us.i.posthog.com)

The generated API client had a hardcoded baseUrl that didn't respect the environment variable. Now setupClientInterceptors() overrides it with the env var value at app startup.