### PR TITLE
fix: use authenticated user ID for save-last-read API calls

### DIFF
--- a/__tests__/features/bible-reading-integration.test.tsx
+++ b/__tests__/features/bible-reading-integration.test.tsx
@@ -44,10 +44,12 @@ jest.mock('react-native-safe-area-context', () => ({
   SafeAreaView: jest.fn(({ children }) => children),
   useSafeAreaInsets: jest.fn(() => ({ top: 0, right: 0, bottom: 0, left: 0 })),
 }));
+// Mock authenticated user for tests that verify reading position saving
+const mockAuthUserId = '550e8400-e29b-41d4-a716-446655440000';
 jest.mock('@/contexts/AuthContext', () => ({
   useAuth: jest.fn(() => ({
-    isAuthenticated: false,
-    user: null,
+    isAuthenticated: true,
+    user: { id: mockAuthUserId, email: 'test@example.com', firstName: 'Test', lastName: 'User' },
     isLoading: false,
     login: jest.fn(),
     logout: jest.fn(),
@@ -323,10 +325,10 @@ describe('Bible Reading Interface - Integration Tests', () => {
       expect(screen.getAllByText('The Creation')[0]).toBeTruthy();
     });
 
-    // 2. Verify reading position saved
+    // 2. Verify reading position saved with authenticated user's UUID
     const mockMutate = (useSaveLastRead as jest.Mock).mock.results[0].value.mutate;
     expect(mockMutate).toHaveBeenCalledWith({
-      user_id: 'guest',
+      user_id: mockAuthUserId,
       book_id: 1,
       chapter_number: 1,
     });
@@ -558,11 +560,11 @@ describe('Bible Reading Interface - Integration Tests', () => {
       { timeout: 10000 }
     );
 
-    // Verify reading position saved for Matthew
+    // Verify reading position saved for Matthew with authenticated user's UUID
     const mockMutate = (useSaveLastRead as jest.Mock).mock.results[0].value.mutate;
     expect(mockMutate).toHaveBeenCalledWith(
       expect.objectContaining({
-        user_id: 'guest',
+        user_id: mockAuthUserId,
         book_id: 40,
         chapter_number: 5,
       })

--- a/__tests__/hooks/bible/use-last-read.test.tsx
+++ b/__tests__/hooks/bible/use-last-read.test.tsx
@@ -15,6 +15,10 @@ import {
   setMockLastReadPosition,
 } from '../../mocks/handlers/bible.handlers';
 
+// Mock user UUIDs for testing
+const mockUserId1 = '550e8400-e29b-41d4-a716-446655440001';
+const mockUserId2 = '550e8400-e29b-41d4-a716-446655440002';
+
 describe('useLastRead', () => {
   let queryClient: QueryClient;
 
@@ -45,7 +49,7 @@ describe('useLastRead', () => {
     // Set mock last read position via MSW handler
     setMockLastReadPosition(1, 5);
 
-    const { result } = renderHook(() => useLastRead('guest'), { wrapper });
+    const { result } = renderHook(() => useLastRead(mockUserId1), { wrapper });
 
     // Wait for mutation to complete
     await waitFor(() => {
@@ -60,7 +64,7 @@ describe('useLastRead', () => {
 
   it('should return default position when no last read exists', async () => {
     // Don't set any mock position - handler returns default (Genesis 1)
-    const { result } = renderHook(() => useLastRead('guest'), { wrapper });
+    const { result } = renderHook(() => useLastRead(mockUserId1), { wrapper });
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
@@ -78,7 +82,7 @@ describe('useLastRead', () => {
 
     const { result, rerender } = renderHook((userId: string) => useLastRead(userId), {
       wrapper,
-      initialProps: 'guest',
+      initialProps: mockUserId1,
     });
 
     await waitFor(() => {
@@ -88,7 +92,7 @@ describe('useLastRead', () => {
     const firstData = result.current.data;
 
     // Rerender with same userId should not trigger new mutation
-    rerender('guest');
+    rerender(mockUserId1);
 
     // Data should remain the same
     expect(result.current.data).toBe(firstData);
@@ -107,7 +111,7 @@ describe('useLastRead', () => {
     // Set position for first user
     setMockLastReadPosition(1, 1);
 
-    const { result: result1 } = renderHook(() => useLastRead('user1'), { wrapper });
+    const { result: result1 } = renderHook(() => useLastRead(mockUserId1), { wrapper });
 
     await waitFor(() => {
       expect(result1.current.isSuccess).toBe(true);
@@ -121,7 +125,7 @@ describe('useLastRead', () => {
     // Change mock position for second user
     setMockLastReadPosition(66, 22);
 
-    const { result: result2 } = renderHook(() => useLastRead('user2'), { wrapper });
+    const { result: result2 } = renderHook(() => useLastRead(mockUserId2), { wrapper });
 
     await waitFor(() => {
       expect(result2.current.isSuccess).toBe(true);


### PR DESCRIPTION
Replace hardcoded 'guest' user_id with actual authenticated user's UUID. Only call saveLastRead API when user is authenticated, preventing UUID validation errors on the backend.

- Add useAuth hook to chapter screen
- Guard saveLastRead calls with user?.id check
- Update tests to cover authenticated and unauthenticated scenarios
