### PR TITLE
feat: implement circular Bible navigation

### DIFF
--- a/__tests__/app/bible/[bookId]/[chapterNumber].circular-fab.test.tsx
+++ b/__tests__/app/bible/[bookId]/[chapterNumber].circular-fab.test.tsx
@@ -1,0 +1,402 @@
+/**
+ * Tests for Bible Chapter Screen - Circular FAB Navigation Behavior
+ *
+ * Tests that FAB buttons work correctly with circular navigation:
+ * - Previous button navigates at Genesis 1 (no error haptic)
+ * - Next button navigates at Revelation 22 (no error haptic)
+ * - showPrevious and showNext props are always true
+ * - Medium impact haptic for all navigation (never error notification)
+ *
+ * @see Spec: agent-os/specs/circular-bible-navigation/spec.md
+ * @see Task Group 4: ChapterScreen FAB Behavior Updates
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+import { useLocalSearchParams } from 'expo-router';
+import type React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import ChapterScreen from '@/app/bible/[bookId]/[chapterNumber]';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { ToastProvider } from '@/contexts/ToastContext';
+import { useActiveTab, useBookProgress, useRecentBooks } from '@/hooks/bible';
+import {
+  useBibleByLine,
+  useBibleChapter,
+  useBibleDetailed,
+  useBibleSummary,
+  useBibleTestaments,
+  usePrefetchNextChapter,
+  usePrefetchPreviousChapter,
+  useSaveLastRead,
+} from '@/src/api';
+
+// Centralized mocks - see hooks/bible/__mocks__/index.ts and __tests__/mocks/
+jest.mock('@/hooks/bible');
+jest.mock('@/src/api', () => require('../../../mocks/api-hooks.mock').default);
+jest.mock('expo-router', () => require('../../../mocks/expo-router.mock').default);
+jest.mock('@react-native-community/netinfo', () => ({
+  addEventListener: jest.fn(() => jest.fn()),
+  fetch: jest.fn(() => Promise.resolve({ isInternetReachable: true })),
+}));
+
+// Component-specific mocks
+jest.mock('@/hooks/bible/use-fab-visibility', () => ({
+  useFABVisibility: jest.fn(() => ({
+    visible: true,
+    handleScroll: jest.fn(),
+    handleTap: jest.fn(),
+  })),
+}));
+jest.mock('@/components/bible/OfflineIndicator', () => ({
+  OfflineIndicator: () => null,
+}));
+jest.mock('@/hooks/use-bible-version', () => ({
+  useBibleVersion: () => ({ bibleVersion: 'niv', isLoading: false }),
+}));
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: () => ({ user: null, isLoading: false, isAuthenticated: false }),
+}));
+jest.mock('@/hooks/bible/use-highlights', () => ({
+  useHighlights: () => ({
+    chapterHighlights: [],
+    addHighlight: jest.fn(),
+    updateHighlightColor: jest.fn(),
+    deleteHighlight: jest.fn(),
+  }),
+}));
+jest.mock('@/hooks/bible/use-auto-highlights', () => ({
+  useAutoHighlights: () => ({ autoHighlights: [] }),
+}));
+jest.mock('@/contexts/AuthContext', () => ({
+  useAuth: jest.fn(() => ({
+    isAuthenticated: false,
+    user: null,
+    isLoading: false,
+    login: jest.fn(),
+    logout: jest.fn(),
+    signup: jest.fn(),
+  })),
+}));
+
+// Mock haptics - important for testing circular navigation behavior
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+  NotificationFeedbackType: {
+    Success: 'success',
+    Warning: 'warning',
+    Error: 'error',
+  },
+}));
+
+// Mock ChapterPagerView to track ref usage
+const mockSetPage = jest.fn();
+const mockGoNext = jest.fn();
+const mockGoPrevious = jest.fn();
+
+jest.mock('@/components/bible/ChapterPagerView', () => {
+  const React = require('react');
+
+  const MockChapterPagerView = React.forwardRef((_props: any, ref: any) => {
+    const { View, Text } = require('react-native');
+
+    React.useImperativeHandle(ref, () => ({
+      setPage: mockSetPage,
+      goNext: mockGoNext,
+      goPrevious: mockGoPrevious,
+    }));
+
+    return (
+      <View testID="chapter-pager-view">
+        <Text>Mock ChapterPagerView</Text>
+      </View>
+    );
+  });
+
+  MockChapterPagerView.displayName = 'ChapterPagerView';
+
+  return {
+    ChapterPagerView: MockChapterPagerView,
+  };
+});
+
+// Mock chapter data for Genesis 1
+const mockGenesisChapter1 = {
+  bookId: 1,
+  bookName: 'Genesis',
+  chapterNumber: 1,
+  title: 'Genesis 1',
+  testament: 'OT' as const,
+  sections: [
+    {
+      subtitle: 'The Creation',
+      startVerse: 1,
+      endVerse: 31,
+      verses: [{ verseNumber: 1, text: 'In the beginning God created the heavens and the earth.' }],
+    },
+  ],
+};
+
+// Mock chapter data for Revelation 22
+const mockRevelationChapter22 = {
+  bookId: 66,
+  bookName: 'Revelation',
+  chapterNumber: 22,
+  title: 'Revelation 22',
+  testament: 'NT' as const,
+  sections: [
+    {
+      subtitle: 'The River of Life',
+      startVerse: 1,
+      endVerse: 21,
+      verses: [
+        { verseNumber: 1, text: 'Then the angel showed me the river of the water of life.' },
+      ],
+    },
+  ],
+};
+
+// Mock book metadata including Genesis and Revelation
+const mockBooksMetadata = [
+  {
+    id: 1,
+    name: 'Genesis',
+    testament: 'OT' as const,
+    chapterCount: 50,
+    verseCount: 1533,
+  },
+  {
+    id: 2,
+    name: 'Exodus',
+    testament: 'OT' as const,
+    chapterCount: 40,
+    verseCount: 1213,
+  },
+  {
+    id: 66,
+    name: 'Revelation',
+    testament: 'NT' as const,
+    chapterCount: 22,
+    verseCount: 404,
+  },
+];
+
+// Helper to render with providers
+function renderWithProviders(component: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider>
+        <SafeAreaProvider
+          initialMetrics={{
+            frame: { x: 0, y: 0, width: 390, height: 844 },
+            insets: { top: 47, left: 0, right: 0, bottom: 34 },
+          }}
+        >
+          <ToastProvider>{children}</ToastProvider>
+        </SafeAreaProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
+  );
+
+  return render(component, { wrapper: Wrapper });
+}
+
+describe('ChapterScreen - Circular FAB Navigation Behavior', () => {
+  let mockSaveLastRead: jest.Mock;
+  let mockPrefetchNext: jest.Mock;
+  let mockPrefetchPrevious: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSaveLastRead = jest.fn();
+    mockPrefetchNext = jest.fn();
+    mockPrefetchPrevious = jest.fn();
+
+    (useActiveTab as jest.Mock).mockReturnValue({
+      activeTab: 'summary',
+      setActiveTab: jest.fn(),
+      isLoading: false,
+      error: null,
+    });
+
+    (useSaveLastRead as jest.Mock).mockReturnValue({
+      mutate: mockSaveLastRead,
+    });
+
+    (useBibleTestaments as jest.Mock).mockReturnValue({
+      data: mockBooksMetadata,
+      isLoading: false,
+      error: null,
+    });
+
+    (useBookProgress as jest.Mock).mockReturnValue({
+      progress: {
+        percentage: 2,
+        currentChapter: 1,
+        totalChapters: 50,
+      },
+      isCalculating: false,
+    });
+
+    (useRecentBooks as jest.Mock).mockReturnValue({
+      recentBooks: [],
+      addRecentBook: jest.fn(),
+      isLoading: false,
+    });
+
+    // Mock useLastReadPosition
+    const { useLastReadPosition } = require('@/hooks/bible');
+    (useLastReadPosition as jest.Mock).mockReturnValue({
+      lastPosition: null,
+      savePosition: jest.fn(),
+      clearPosition: jest.fn(),
+      isLoading: false,
+      error: null,
+    });
+
+    (useBibleSummary as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    (useBibleByLine as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    (useBibleDetailed as jest.Mock).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+
+    (usePrefetchNextChapter as jest.Mock).mockReturnValue(mockPrefetchNext);
+    (usePrefetchPreviousChapter as jest.Mock).mockReturnValue(mockPrefetchPrevious);
+
+    const { useTopicsSearch } = require('@/src/api');
+    (useTopicsSearch as jest.Mock).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  describe('FAB Previous button at Genesis 1 (Bible start)', () => {
+    beforeEach(() => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        bookId: '1',
+        chapterNumber: '1',
+      });
+
+      (useBibleChapter as jest.Mock).mockReturnValue({
+        data: mockGenesisChapter1,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should trigger navigation when Previous button is pressed at Genesis 1', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const prevButton = getByTestId('previous-chapter-button');
+        fireEvent.press(prevButton);
+      });
+
+      // With circular navigation, Previous button should trigger goPrevious
+      expect(mockGoPrevious).toHaveBeenCalled();
+    });
+
+    it('should trigger medium haptic (not error) when Previous button is pressed at Genesis 1', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const prevButton = getByTestId('previous-chapter-button');
+        fireEvent.press(prevButton);
+      });
+
+      // Should trigger medium impact haptic for circular navigation
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+      // Should NOT trigger error notification haptic
+      expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('should have Previous button enabled at Genesis 1 (showPrevious=true)', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const prevButton = getByTestId('previous-chapter-button');
+        // Button should be enabled (not disabled) for circular navigation
+        expect(prevButton).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('FAB Next button at Revelation 22 (Bible end)', () => {
+    beforeEach(() => {
+      (useLocalSearchParams as jest.Mock).mockReturnValue({
+        bookId: '66',
+        chapterNumber: '22',
+      });
+
+      (useBibleChapter as jest.Mock).mockReturnValue({
+        data: mockRevelationChapter22,
+        isLoading: false,
+        error: null,
+      });
+    });
+
+    it('should trigger navigation when Next button is pressed at Revelation 22', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const nextButton = getByTestId('next-chapter-button');
+        fireEvent.press(nextButton);
+      });
+
+      // With circular navigation, Next button should trigger goNext
+      expect(mockGoNext).toHaveBeenCalled();
+    });
+
+    it('should trigger medium haptic (not error) when Next button is pressed at Revelation 22', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const nextButton = getByTestId('next-chapter-button');
+        fireEvent.press(nextButton);
+      });
+
+      // Should trigger medium impact haptic for circular navigation
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+      // Should NOT trigger error notification haptic
+      expect(Haptics.notificationAsync).not.toHaveBeenCalled();
+    });
+
+    it('should have Next button enabled at Revelation 22 (showNext=true)', async () => {
+      const { getByTestId } = renderWithProviders(<ChapterScreen />);
+
+      await waitFor(() => {
+        const nextButton = getByTestId('next-chapter-button');
+        // Button should be enabled (not disabled) for circular navigation
+        expect(nextButton).not.toBeDisabled();
+      });
+    });
+  });
+});

--- a/__tests__/components/bible/ChapterPagerView.circular.test.tsx
+++ b/__tests__/components/bible/ChapterPagerView.circular.test.tsx
@@ -1,0 +1,297 @@
+/**
+ * Tests for ChapterPagerView circular navigation behavior
+ *
+ * Tests that circular navigation at Bible boundaries works correctly:
+ * - getChapterForPosition returns valid chapters for out-of-bounds indices
+ * - Swiping backward from Genesis 1 shows Revelation 22 (not SwipeBoundaryPage)
+ * - Swiping forward from Revelation 22 shows Genesis 1 (not SwipeBoundaryPage)
+ * - Normal cross-book navigation continues to work
+ * - Haptic feedback fires on circular navigation
+ *
+ * @see Spec: agent-os/specs/circular-bible-navigation/spec.md
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+import React from 'react';
+import { ChapterPagerView } from '@/components/bible/ChapterPagerView';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { useBibleTestaments } from '@/src/api';
+import { mockTestamentBooks } from '../../mocks/data/bible-books.data';
+
+// Store mock functions for PagerView
+let mockSetPage: jest.Mock;
+let mockSetPageWithoutAnimation: jest.Mock;
+let capturedOnPageSelected: ((event: { nativeEvent: { position: number } }) => void) | null = null;
+
+// Mock react-native-pager-view to capture onPageSelected callback
+jest.mock('react-native-pager-view', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+
+  const MockPagerView = React.forwardRef(({ children, testID, onPageSelected }: any, ref: any) => {
+    // Store ref methods for testing
+    mockSetPage = jest.fn();
+    mockSetPageWithoutAnimation = jest.fn();
+
+    // Capture the onPageSelected callback so we can trigger it in tests
+    capturedOnPageSelected = onPageSelected;
+
+    React.useImperativeHandle(ref, () => ({
+      setPage: mockSetPage,
+      setPageWithoutAnimation: mockSetPageWithoutAnimation,
+    }));
+
+    return (
+      <View testID={testID || 'pager-view'}>
+        {React.Children.map(children, (child: any, index: number) => (
+          <View key={`page-${index}`} testID={`pager-page-${index}`}>
+            {child}
+          </View>
+        ))}
+      </View>
+    );
+  });
+
+  MockPagerView.displayName = 'PagerView';
+
+  return {
+    __esModule: true,
+    default: MockPagerView,
+  };
+});
+
+// Mock ChapterPage component to track what chapter is rendered
+jest.mock('@/components/bible/ChapterPage', () => ({
+  ChapterPage: ({ bookId, chapterNumber }: any) => {
+    const { Text } = require('react-native');
+    return (
+      <Text testID={`chapter-page-${bookId}-${chapterNumber}`}>
+        Book {bookId} Chapter {chapterNumber}
+      </Text>
+    );
+  },
+}));
+
+// Mock SwipeBoundaryPage to verify it's NOT rendered
+jest.mock('@/components/ui/SwipeBoundaryPage', () => ({
+  SwipeBoundaryPage: ({ direction, contentType, testID }: any) => {
+    const { Text } = require('react-native');
+    return (
+      <Text testID={testID || `swipe-boundary-${direction}`}>
+        SwipeBoundaryPage {direction} {contentType}
+      </Text>
+    );
+  },
+}));
+
+// Mock useBibleTestaments hook
+jest.mock('@/src/api/hooks', () => ({
+  useBibleTestaments: jest.fn(),
+}));
+
+// Mock Haptics
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: {
+    Light: 'light',
+    Medium: 'medium',
+    Heavy: 'heavy',
+  },
+}));
+
+const mockUseBibleTestaments = useBibleTestaments as jest.MockedFunction<typeof useBibleTestaments>;
+
+describe('ChapterPagerView circular navigation', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+      },
+    });
+
+    // Mock useBibleTestaments to return mock books
+    mockUseBibleTestaments.mockReturnValue({
+      data: mockTestamentBooks,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+    } as any);
+
+    jest.clearAllMocks();
+    capturedOnPageSelected = null;
+  });
+
+  const renderPagerView = (
+    initialBookId: number = 1,
+    initialChapter: number = 1,
+    onPageChange?: (bookId: number, chapterNumber: number) => void
+  ) => {
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider>
+          <ChapterPagerView
+            initialBookId={initialBookId}
+            initialChapter={initialChapter}
+            activeTab="summary"
+            activeView="bible"
+            onPageChange={onPageChange || jest.fn()}
+          />
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+  };
+
+  describe('getChapterForPosition circular wrapping', () => {
+    it('should render Revelation 22 for positions before Genesis 1 (absoluteIndex -1)', () => {
+      // Genesis 1 at center (index 3) means position 0 would be at absoluteIndex -3
+      // Position 2 would be at absoluteIndex -1
+      renderPagerView(1, 1);
+
+      // At Genesis 1 centered, positions 0, 1, 2 would have negative absolute indices
+      // These should now wrap to Revelation 22, 21, 20 (the last chapters)
+      // Position 0: absoluteIndex = 0 + (0 - 3) = -3 -> should wrap to 1186 (Rev 20)
+      // Position 1: absoluteIndex = 0 + (1 - 3) = -2 -> should wrap to 1187 (Rev 21)
+      // Position 2: absoluteIndex = 0 + (2 - 3) = -1 -> should wrap to 1188 (Rev 22)
+      expect(screen.getByTestId('chapter-page-66-22')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-66-21')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-66-20')).toBeTruthy();
+    });
+
+    it('should render Genesis 1 for positions after Revelation 22 (absoluteIndex 1189)', () => {
+      // Revelation 22 at center means positions 4, 5, 6 would have indices > 1188
+      renderPagerView(66, 22);
+
+      // At Revelation 22 centered (index 1188), positions 4, 5, 6 would exceed max
+      // Position 4: absoluteIndex = 1188 + (4 - 3) = 1189 -> should wrap to 0 (Gen 1)
+      // Position 5: absoluteIndex = 1188 + (5 - 3) = 1190 -> should wrap to 1 (Gen 2)
+      // Position 6: absoluteIndex = 1188 + (6 - 3) = 1191 -> should wrap to 2 (Gen 3)
+      expect(screen.getByTestId('chapter-page-1-1')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-1-2')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-1-3')).toBeTruthy();
+    });
+  });
+
+  describe('SwipeBoundaryPage not rendered for chapter navigation', () => {
+    it('should NOT render SwipeBoundaryPage when at Genesis 1', () => {
+      renderPagerView(1, 1);
+
+      // SwipeBoundaryPage should NOT be present
+      expect(screen.queryByTestId('chapter-page-boundary-0')).toBeNull();
+      expect(screen.queryByTestId('chapter-page-boundary-1')).toBeNull();
+      expect(screen.queryByTestId('chapter-page-boundary-2')).toBeNull();
+      expect(screen.queryByText(/SwipeBoundaryPage/)).toBeNull();
+    });
+
+    it('should NOT render SwipeBoundaryPage when at Revelation 22', () => {
+      renderPagerView(66, 22);
+
+      // SwipeBoundaryPage should NOT be present
+      expect(screen.queryByTestId('chapter-page-boundary-4')).toBeNull();
+      expect(screen.queryByTestId('chapter-page-boundary-5')).toBeNull();
+      expect(screen.queryByTestId('chapter-page-boundary-6')).toBeNull();
+      expect(screen.queryByText(/SwipeBoundaryPage/)).toBeNull();
+    });
+  });
+
+  describe('normal cross-book navigation still works', () => {
+    it('should render correct chapters around Genesis 50 to Exodus 1 boundary', () => {
+      renderPagerView(1, 50);
+
+      // Window around Genesis 50 should show:
+      // - Genesis 47, 48, 49, 50 (center), Exodus 1, 2, 3
+      expect(screen.getByTestId('chapter-page-1-47')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-1-48')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-1-49')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-1-50')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-2-1')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-2-2')).toBeTruthy();
+      expect(screen.getByTestId('chapter-page-2-3')).toBeTruthy();
+    });
+  });
+
+  describe('handlePageSelected circular navigation', () => {
+    it('should trigger haptic feedback on circular navigation from Genesis 1 backward', async () => {
+      const onPageChange = jest.fn();
+      renderPagerView(1, 1, onPageChange);
+
+      // Verify capturedOnPageSelected is set
+      expect(capturedOnPageSelected).not.toBeNull();
+
+      // Simulate swiping to position 0 (would be out of bounds without circular nav)
+      act(() => {
+        capturedOnPageSelected?.({ nativeEvent: { position: 0 } });
+      });
+
+      // Haptic feedback should be triggered for all page changes
+      await waitFor(() => {
+        expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+      });
+    });
+
+    it('should trigger haptic feedback on circular navigation from Revelation 22 forward', async () => {
+      const onPageChange = jest.fn();
+      renderPagerView(66, 22, onPageChange);
+
+      expect(capturedOnPageSelected).not.toBeNull();
+
+      // Simulate swiping to position 6 (would be out of bounds without circular nav)
+      act(() => {
+        capturedOnPageSelected?.({ nativeEvent: { position: 6 } });
+      });
+
+      // Haptic feedback should be triggered
+      await waitFor(() => {
+        expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+      });
+    });
+
+    it('should call onPageChange with circular wrapped chapter when swiping at boundary', async () => {
+      jest.useFakeTimers();
+      const onPageChange = jest.fn();
+      renderPagerView(1, 1, onPageChange);
+
+      expect(capturedOnPageSelected).not.toBeNull();
+
+      // Simulate swiping to position 0 (edge position at Genesis 1)
+      // This should wrap to Revelation 22 (the previous chapter in circular navigation)
+      act(() => {
+        capturedOnPageSelected?.({ nativeEvent: { position: 0 } });
+      });
+
+      // Haptics should fire immediately
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
+
+      // Advance timers to trigger the route update
+      act(() => {
+        jest.advanceTimersByTime(100);
+      });
+
+      // onPageChange should be called with the wrapped chapter (Revelation 20, since position 0 is -3 from center)
+      // absoluteIndex = 0 + (0 - 3) = -3 -> wraps to 1186 which is Revelation 20
+      await waitFor(() => {
+        expect(onPageChange).toHaveBeenCalledWith(66, 20);
+      });
+
+      jest.useRealTimers();
+    });
+  });
+
+  describe('circular window rendering verification', () => {
+    it('should render 7 pages with no SwipeBoundaryPage at any position', () => {
+      renderPagerView(1, 1);
+
+      // All 7 pager page containers should exist
+      for (let i = 0; i < 7; i++) {
+        expect(screen.getByTestId(`pager-page-${i}`)).toBeTruthy();
+      }
+
+      // No SwipeBoundaryPage should be rendered anywhere
+      expect(screen.queryByText(/SwipeBoundaryPage/)).toBeNull();
+    });
+  });
+});

--- a/__tests__/integration/circular-navigation.integration.test.ts
+++ b/__tests__/integration/circular-navigation.integration.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Integration Tests: Circular Bible Navigation
+ *
+ * Tests end-to-end circular navigation workflows at Bible boundaries:
+ * - Full round-trip: Genesis 1 -> Revelation 22 -> Genesis 1
+ * - Seamless transition with no visual indicators
+ * - Existing cross-book navigation unaffected
+ * - Route/URL updates correctly after circular navigation
+ *
+ * @see Spec: agent-os/specs/circular-bible-navigation/spec.md
+ * @see Task Group 5: Test Review & Gap Analysis
+ */
+
+import { renderHook } from '@testing-library/react-native';
+import { useChapterNavigation } from '@/hooks/bible/use-chapter-navigation';
+import {
+  getAbsolutePageIndex,
+  getChapterFromPageIndex,
+  wrapCircularIndex,
+} from '@/utils/bible/chapter-index-utils';
+import { mockTestamentBooks } from '../mocks/data/bible-books.data';
+
+describe('Circular Bible Navigation - Integration', () => {
+  /**
+   * Test 1: Full round-trip Genesis 1 -> Revelation 22 -> Genesis 1
+   *
+   * Verifies the complete circular workflow using multiple layers:
+   * - Utility functions for index calculation
+   * - Hook for navigation state
+   * - Validates that navigation wraps correctly in both directions
+   */
+  describe('Full circular round-trip workflow', () => {
+    it('should complete Genesis 1 -> Revelation 22 -> Genesis 1 round-trip', () => {
+      // Step 1: Start at Genesis 1
+      const genesis1Index = getAbsolutePageIndex(1, 1, mockTestamentBooks);
+      expect(genesis1Index).toBe(0);
+
+      // Step 2: Navigate backward from Genesis 1 (should wrap to Revelation 22)
+      const wrappedBackward = wrapCircularIndex(-1, mockTestamentBooks);
+      expect(wrappedBackward).toBe(1188); // Max index (Revelation 22)
+
+      const revFromBackward = getChapterFromPageIndex(wrappedBackward, mockTestamentBooks);
+      expect(revFromBackward).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      // Step 3: Verify hook returns correct navigation at Genesis 1
+      const { result: navAtGenesis1 } = renderHook(() =>
+        useChapterNavigation(1, 1, mockTestamentBooks)
+      );
+      expect(navAtGenesis1.current.prevChapter).toEqual({ bookId: 66, chapterNumber: 22 });
+      expect(navAtGenesis1.current.canGoPrevious).toBe(true);
+
+      // Step 4: Navigate forward from Revelation 22 (should wrap to Genesis 1)
+      const revelation22Index = getAbsolutePageIndex(66, 22, mockTestamentBooks);
+      expect(revelation22Index).toBe(1188);
+
+      const wrappedForward = wrapCircularIndex(1189, mockTestamentBooks);
+      expect(wrappedForward).toBe(0); // Genesis 1
+
+      const genFromForward = getChapterFromPageIndex(wrappedForward, mockTestamentBooks);
+      expect(genFromForward).toEqual({ bookId: 1, chapterNumber: 1 });
+
+      // Step 5: Verify hook returns correct navigation at Revelation 22
+      const { result: navAtRev22 } = renderHook(() =>
+        useChapterNavigation(66, 22, mockTestamentBooks)
+      );
+      expect(navAtRev22.current.nextChapter).toEqual({ bookId: 1, chapterNumber: 1 });
+      expect(navAtRev22.current.canGoNext).toBe(true);
+    });
+
+    it('should maintain consistent indices throughout multiple circular traversals', () => {
+      // Bible has 1189 chapters (indices 0-1188)
+      const totalChapters = 1189;
+
+      // Traverse forward past the boundary from Revelation 22 (index 1188)
+      const startIndex = 1188;
+
+      // Forward by 1: should be Genesis 1 (index 0)
+      const forward1 = wrapCircularIndex(startIndex + 1, mockTestamentBooks);
+      expect(forward1).toBe(0);
+
+      // Forward by 2: should be Genesis 2 (index 1)
+      const forward2 = wrapCircularIndex(startIndex + 2, mockTestamentBooks);
+      expect(forward2).toBe(1);
+
+      // Full circle from Genesis 1: 0 + 1189 should wrap back to 0
+      const fullCircleFromStart = wrapCircularIndex(0 + totalChapters, mockTestamentBooks);
+      expect(fullCircleFromStart).toBe(0);
+
+      // Backward from Genesis 1
+      const backward1 = wrapCircularIndex(-1, mockTestamentBooks);
+      expect(backward1).toBe(1188);
+
+      const backward2 = wrapCircularIndex(-2, mockTestamentBooks);
+      expect(backward2).toBe(1187);
+
+      // Backward by full Bible from index 0: should wrap back to 0
+      const backwardFull = wrapCircularIndex(0 - totalChapters, mockTestamentBooks);
+      expect(backwardFull).toBe(0);
+    });
+  });
+
+  /**
+   * Test 2: Seamless transition - no special visual indicators
+   *
+   * Verifies that circular navigation uses the same mechanisms as regular navigation
+   * (no special toasts, banners, or announcements)
+   */
+  describe('Seamless transition behavior', () => {
+    it('should use same navigation mechanism for circular as regular navigation', () => {
+      // Regular mid-Bible navigation
+      const { result: midNav } = renderHook(() => useChapterNavigation(1, 25, mockTestamentBooks));
+      expect(midNav.current.canGoNext).toBe(true);
+      expect(midNav.current.canGoPrevious).toBe(true);
+      expect(midNav.current.nextChapter).not.toBeNull();
+      expect(midNav.current.prevChapter).not.toBeNull();
+
+      // Circular navigation at Genesis 1
+      const { result: gen1Nav } = renderHook(() => useChapterNavigation(1, 1, mockTestamentBooks));
+      // Same structure - canGo* always true, chapters always defined
+      expect(gen1Nav.current.canGoNext).toBe(true);
+      expect(gen1Nav.current.canGoPrevious).toBe(true);
+      expect(gen1Nav.current.nextChapter).not.toBeNull();
+      expect(gen1Nav.current.prevChapter).not.toBeNull();
+
+      // Circular navigation at Revelation 22
+      const { result: rev22Nav } = renderHook(() =>
+        useChapterNavigation(66, 22, mockTestamentBooks)
+      );
+      // Same structure - canGo* always true, chapters always defined
+      expect(rev22Nav.current.canGoNext).toBe(true);
+      expect(rev22Nav.current.canGoPrevious).toBe(true);
+      expect(rev22Nav.current.nextChapter).not.toBeNull();
+      expect(rev22Nav.current.prevChapter).not.toBeNull();
+    });
+
+    it('should return valid chapter references (never null) at all positions', () => {
+      // Test various positions including boundaries
+      const testPositions = [
+        { bookId: 1, chapter: 1 }, // Genesis 1 (Bible start)
+        { bookId: 1, chapter: 50 }, // Genesis 50 (book boundary)
+        { bookId: 2, chapter: 1 }, // Exodus 1 (after book boundary)
+        { bookId: 39, chapter: 4 }, // Malachi 4 (OT/NT boundary)
+        { bookId: 40, chapter: 1 }, // Matthew 1 (NT start)
+        { bookId: 66, chapter: 22 }, // Revelation 22 (Bible end)
+      ];
+
+      for (const pos of testPositions) {
+        const { result } = renderHook(() =>
+          useChapterNavigation(pos.bookId, pos.chapter, mockTestamentBooks)
+        );
+
+        expect(result.current.nextChapter).not.toBeNull();
+        expect(result.current.prevChapter).not.toBeNull();
+        expect(result.current.canGoNext).toBe(true);
+        expect(result.current.canGoPrevious).toBe(true);
+      }
+    });
+  });
+
+  /**
+   * Test 3: Existing cross-book navigation unaffected
+   *
+   * Verifies that circular navigation only affects Bible boundaries,
+   * not regular cross-book navigation
+   */
+  describe('Cross-book navigation preservation', () => {
+    it('should maintain Genesis 50 -> Exodus 1 cross-book navigation', () => {
+      const { result } = renderHook(() => useChapterNavigation(1, 50, mockTestamentBooks));
+
+      // Next should be Exodus 1, not wrap to Genesis 1
+      expect(result.current.nextChapter).toEqual({ bookId: 2, chapterNumber: 1 });
+      expect(result.current.prevChapter).toEqual({ bookId: 1, chapterNumber: 49 });
+    });
+
+    it('should maintain Exodus 1 -> Genesis 50 cross-book navigation', () => {
+      const { result } = renderHook(() => useChapterNavigation(2, 1, mockTestamentBooks));
+
+      // Previous should be Genesis 50, not wrap to Revelation 22
+      expect(result.current.prevChapter).toEqual({ bookId: 1, chapterNumber: 50 });
+      expect(result.current.nextChapter).toEqual({ bookId: 2, chapterNumber: 2 });
+    });
+
+    it('should maintain OT/NT boundary (Malachi 4 -> Matthew 1) navigation', () => {
+      const { result: malachiNav } = renderHook(() =>
+        useChapterNavigation(39, 4, mockTestamentBooks)
+      );
+
+      expect(malachiNav.current.nextChapter).toEqual({ bookId: 40, chapterNumber: 1 });
+
+      const { result: matthewNav } = renderHook(() =>
+        useChapterNavigation(40, 1, mockTestamentBooks)
+      );
+
+      expect(matthewNav.current.prevChapter).toEqual({ bookId: 39, chapterNumber: 4 });
+    });
+
+    it('should handle single-chapter books correctly (not confuse with circular)', () => {
+      // Obadiah (book 31) has only 1 chapter
+      const { result: obadiahNav } = renderHook(() =>
+        useChapterNavigation(31, 1, mockTestamentBooks)
+      );
+
+      // Should navigate to adjacent books, not wrap circularly
+      expect(obadiahNav.current.nextChapter).toEqual({ bookId: 32, chapterNumber: 1 }); // Jonah 1
+      expect(obadiahNav.current.prevChapter).toEqual({ bookId: 30, chapterNumber: 9 }); // Amos 9
+    });
+  });
+
+  /**
+   * Test 4: Index calculations at boundaries
+   *
+   * Verifies that index utilities correctly handle boundary calculations
+   * for proper route/URL updates
+   */
+  describe('Index calculations for route updates', () => {
+    it('should calculate correct absolute indices at Bible boundaries', () => {
+      // Genesis 1 should be index 0
+      expect(getAbsolutePageIndex(1, 1, mockTestamentBooks)).toBe(0);
+
+      // Genesis 2 should be index 1
+      expect(getAbsolutePageIndex(1, 2, mockTestamentBooks)).toBe(1);
+
+      // Revelation 22 should be index 1188 (last)
+      expect(getAbsolutePageIndex(66, 22, mockTestamentBooks)).toBe(1188);
+
+      // Revelation 21 should be index 1187
+      expect(getAbsolutePageIndex(66, 21, mockTestamentBooks)).toBe(1187);
+    });
+
+    it('should convert wrapped indices back to correct chapter references', () => {
+      // Test wrapping from both directions
+      const wrappedToEnd = wrapCircularIndex(-1, mockTestamentBooks);
+      const chapterFromEnd = getChapterFromPageIndex(wrappedToEnd, mockTestamentBooks);
+      expect(chapterFromEnd).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      const wrappedToStart = wrapCircularIndex(1189, mockTestamentBooks);
+      const chapterFromStart = getChapterFromPageIndex(wrappedToStart, mockTestamentBooks);
+      expect(chapterFromStart).toEqual({ bookId: 1, chapterNumber: 1 });
+    });
+
+    it('should produce consistent results regardless of approach direction', () => {
+      // Approaching Revelation 22 from Revelation 21
+      const rev21Index = getAbsolutePageIndex(66, 21, mockTestamentBooks);
+      const nextFromRev21 = getChapterFromPageIndex(rev21Index + 1, mockTestamentBooks);
+      expect(nextFromRev21).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      // Approaching Revelation 22 by wrapping backward from Genesis 1
+      const wrappedToRev22 = wrapCircularIndex(-1, mockTestamentBooks);
+      const chapterFromWrap = getChapterFromPageIndex(wrappedToRev22, mockTestamentBooks);
+      expect(chapterFromWrap).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      // Both should resolve to the same book/chapter
+      expect(nextFromRev21).toEqual(chapterFromWrap);
+    });
+  });
+
+  /**
+   * Test 5: Navigation chain integrity
+   *
+   * Verifies that following the navigation chain leads to expected results
+   */
+  describe('Navigation chain integrity', () => {
+    it('should allow continuous forward navigation through Bible boundaries', () => {
+      // Start near the end: Revelation 21
+      const { result: rev21Nav } = renderHook(() =>
+        useChapterNavigation(66, 21, mockTestamentBooks)
+      );
+      expect(rev21Nav.current.nextChapter).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      // At Revelation 22
+      const { result: rev22Nav } = renderHook(() =>
+        useChapterNavigation(66, 22, mockTestamentBooks)
+      );
+      expect(rev22Nav.current.nextChapter).toEqual({ bookId: 1, chapterNumber: 1 });
+
+      // At Genesis 1 (after wrapping)
+      const { result: gen1AfterWrap } = renderHook(() =>
+        useChapterNavigation(1, 1, mockTestamentBooks)
+      );
+      expect(gen1AfterWrap.current.nextChapter).toEqual({ bookId: 1, chapterNumber: 2 });
+    });
+
+    it('should allow continuous backward navigation through Bible boundaries', () => {
+      // Start near the beginning: Genesis 2
+      const { result: gen2Nav } = renderHook(() => useChapterNavigation(1, 2, mockTestamentBooks));
+      expect(gen2Nav.current.prevChapter).toEqual({ bookId: 1, chapterNumber: 1 });
+
+      // At Genesis 1
+      const { result: gen1Nav } = renderHook(() => useChapterNavigation(1, 1, mockTestamentBooks));
+      expect(gen1Nav.current.prevChapter).toEqual({ bookId: 66, chapterNumber: 22 });
+
+      // At Revelation 22 (after wrapping backward)
+      const { result: rev22AfterWrap } = renderHook(() =>
+        useChapterNavigation(66, 22, mockTestamentBooks)
+      );
+      expect(rev22AfterWrap.current.prevChapter).toEqual({ bookId: 66, chapterNumber: 21 });
+    });
+  });
+});

--- a/__tests__/utils/wrap-circular-index.test.ts
+++ b/__tests__/utils/wrap-circular-index.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for wrapCircularIndex utility function
+ *
+ * Tests circular wrapping of Bible chapter indices:
+ * - Negative indices wrap to end of Bible (e.g., -1 -> 1188 for Revelation 22)
+ * - Indices beyond max wrap to beginning (e.g., 1189 -> 0 for Genesis 1)
+ * - Valid indices (0-1188) pass through unchanged
+ *
+ * @see Spec: agent-os/specs/circular-bible-navigation/spec.md
+ */
+
+import { wrapCircularIndex } from '@/utils/bible/chapter-index-utils';
+import { mockTestamentBooks } from '../mocks/data/bible-books.data';
+
+describe('wrapCircularIndex', () => {
+  describe('wrapping negative indices', () => {
+    it('should wrap index -1 to max index (1188 for Revelation 22)', () => {
+      const result = wrapCircularIndex(-1, mockTestamentBooks);
+      expect(result).toBe(1188);
+    });
+
+    it('should wrap index -2 to second-to-last chapter (1187 for Revelation 21)', () => {
+      const result = wrapCircularIndex(-2, mockTestamentBooks);
+      expect(result).toBe(1187);
+    });
+  });
+
+  describe('wrapping indices beyond max', () => {
+    it('should wrap index 1189 (max + 1) to 0 (Genesis 1)', () => {
+      const result = wrapCircularIndex(1189, mockTestamentBooks);
+      expect(result).toBe(0);
+    });
+
+    it('should wrap index 1190 (max + 2) to 1 (Genesis 2)', () => {
+      const result = wrapCircularIndex(1190, mockTestamentBooks);
+      expect(result).toBe(1);
+    });
+  });
+
+  describe('valid indices within range', () => {
+    it('should return 0 unchanged for Genesis 1', () => {
+      const result = wrapCircularIndex(0, mockTestamentBooks);
+      expect(result).toBe(0);
+    });
+
+    it('should return 1188 unchanged for Revelation 22', () => {
+      const result = wrapCircularIndex(1188, mockTestamentBooks);
+      expect(result).toBe(1188);
+    });
+
+    it('should return mid-range index unchanged', () => {
+      const result = wrapCircularIndex(500, mockTestamentBooks);
+      expect(result).toBe(500);
+    });
+  });
+
+  describe('edge cases with invalid metadata', () => {
+    it('should return -1 for undefined booksMetadata', () => {
+      const result = wrapCircularIndex(0, undefined);
+      expect(result).toBe(-1);
+    });
+
+    it('should return -1 for empty booksMetadata', () => {
+      const result = wrapCircularIndex(0, []);
+      expect(result).toBe(-1);
+    });
+  });
+});


### PR DESCRIPTION
Implement circular navigation at Bible boundaries so swiping backward from Genesis 1 navigates to Revelation 22, and swiping forward from Revelation 22 navigates to Genesis 1. This creates a "full circle" continuous reading experience and removes the previous safety screen placeholder.

Changes:
- Add wrapCircularIndex utility for circular index calculation
- Update useChapterNavigation hook for circular navigation at boundaries
- Modify ChapterPagerView to use circular rendering instead of boundary pages
- Simplify FAB handlers to always allow navigation (no error haptics)
- Add comprehensive tests (59 feature-specific tests)