### PR TITLE
feat(perf): Remove manual memoization in favor of React Compiler

### DIFF
--- a/app/about.tsx
+++ b/app/about.tsx
@@ -15,7 +15,6 @@ import { Ionicons } from '@expo/vector-icons';
 import Constants from 'expo-constants';
 import * as Haptics from 'expo-haptics';
 import { router, Stack } from 'expo-router';
-import { useMemo } from 'react';
 import { Image, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { type getColors, spacing } from '@/constants/bible-design-tokens';
@@ -24,7 +23,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 export default function AboutScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   const handleBackPress = async () => {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -10,7 +10,7 @@
  */
 
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -42,7 +42,7 @@ import { useLogin } from '@/hooks/useLogin';
  */
 export default function Login() {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const params = useLocalSearchParams<{ fromOnboarding?: string }>();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -10,7 +10,7 @@
  */
 
 import { router, useLocalSearchParams } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   KeyboardAvoidingView,
   Platform,
@@ -46,7 +46,7 @@ import { validatePassword } from '@/lib/auth/password-validation';
  */
 export default function Signup() {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const params = useLocalSearchParams<{ fromOnboarding?: string }>();
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -158,7 +158,7 @@ export default function ChapterScreen() {
 
   // Theme
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors, mode), [colors, mode]);
+  const styles = createStyles(colors, mode);
 
   // Device info for split view detection
   const { useSplitView, splitRatio, setSplitRatio, splitViewMode, setSplitViewMode } =

--- a/app/bookmarks.tsx
+++ b/app/bookmarks.tsx
@@ -24,7 +24,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
-import { useMemo } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -61,7 +60,7 @@ import { useBookmarks } from '@/hooks/bible/use-bookmarks';
 export default function Bookmarks() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { bookmarks, isFetchingBookmarks, removeBookmark } = useBookmarks();
   const { setActiveView } = useActiveView();

--- a/app/giving.tsx
+++ b/app/giving.tsx
@@ -15,7 +15,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, Stack } from 'expo-router';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ImageBackground,
   KeyboardAvoidingView,
@@ -38,7 +38,7 @@ export default function GivingScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { user, isAuthenticated } = useAuth();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   // Form state
   const [firstName, setFirstName] = useState('');

--- a/app/help.tsx
+++ b/app/help.tsx
@@ -16,7 +16,8 @@ import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Haptics from 'expo-haptics';
 import { router, Stack, useFocusEffect } from 'expo-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+// NOTE: useCallback is still used for some callbacks that are dependencies in effects
 import {
   ActivityIndicator,
   BackHandler,
@@ -59,7 +60,7 @@ export default function HelpScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const { isAuthenticated } = useAuth();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   // -- State --
   const [view, setView] = useState<ViewState>('list');

--- a/app/highlights/[bookId]/[chapterNumber].tsx
+++ b/app/highlights/[bookId]/[chapterNumber].tsx
@@ -102,7 +102,7 @@ export default function ChapterHighlightsScreen() {
   }>();
 
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const insets = useSafeAreaInsets();
   const parsedBookId = parseInt(bookId || '0', 10);
   const parsedChapterNumber = parseInt(chapterNumber || '0', 10);

--- a/app/highlights/index.tsx
+++ b/app/highlights/index.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -140,7 +140,7 @@ function groupHighlightsByChapter(highlights: Highlight[]): ChapterGroup[] {
  */
 export default function HighlightsScreen() {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const insets = useSafeAreaInsets();
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { allHighlights, isFetchingHighlights, refetchHighlights } = useHighlights();

--- a/app/manage-downloads.tsx
+++ b/app/manage-downloads.tsx
@@ -13,7 +13,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -190,7 +190,7 @@ export default function ManageDownloadsScreen() {
     }
   }, [isInitialized, refreshManifest]);
 
-  const handleRefresh = useCallback(async () => {
+  const handleRefresh = async () => {
     setIsRefreshing(true);
     try {
       await refreshManifest();
@@ -199,18 +199,18 @@ export default function ManageDownloadsScreen() {
     } finally {
       setIsRefreshing(false);
     }
-  }, [refreshManifest]);
+  };
 
-  const handleCheckForUpdates = useCallback(async () => {
+  const handleCheckForUpdates = async () => {
     try {
       await checkForUpdates();
       Alert.alert('Success', 'Content is up to date!');
     } catch {
       Alert.alert('Error', 'Failed to check for updates. Please try again.');
     }
-  }, [checkForUpdates]);
+  };
 
-  const handleDeleteAll = useCallback(() => {
+  const handleDeleteAll = () => {
     Alert.alert(
       'Delete All Offline Data',
       'Are you sure you want to delete all downloaded content? This cannot be undone.',
@@ -230,91 +230,73 @@ export default function ManageDownloadsScreen() {
         },
       ]
     );
-  }, [deleteAllData]);
+  };
 
-  const handleDownloadBible = useCallback(
-    async (versionKey: string) => {
-      setProcessingItem(`bible:${versionKey}`);
-      try {
-        await downloadBibleVersion(versionKey);
-      } catch {
-        Alert.alert('Error', 'Failed to download Bible version. Please try again.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [downloadBibleVersion]
-  );
+  const handleDownloadBible = async (versionKey: string) => {
+    setProcessingItem(`bible:${versionKey}`);
+    try {
+      await downloadBibleVersion(versionKey);
+    } catch {
+      Alert.alert('Error', 'Failed to download Bible version. Please try again.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
-  const handleDeleteBible = useCallback(
-    async (versionKey: string) => {
-      setProcessingItem(`bible:${versionKey}`);
-      try {
-        await deleteBibleVersion(versionKey);
-      } catch {
-        Alert.alert('Error', 'Failed to delete Bible version.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [deleteBibleVersion]
-  );
+  const handleDeleteBible = async (versionKey: string) => {
+    setProcessingItem(`bible:${versionKey}`);
+    try {
+      await deleteBibleVersion(versionKey);
+    } catch {
+      Alert.alert('Error', 'Failed to delete Bible version.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
-  const handleDownloadCommentary = useCallback(
-    async (languageCode: string) => {
-      setProcessingItem(`commentary:${languageCode}`);
-      try {
-        await downloadCommentaries(languageCode);
-      } catch {
-        Alert.alert('Error', 'Failed to download commentaries. Please try again.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [downloadCommentaries]
-  );
+  const handleDownloadCommentary = async (languageCode: string) => {
+    setProcessingItem(`commentary:${languageCode}`);
+    try {
+      await downloadCommentaries(languageCode);
+    } catch {
+      Alert.alert('Error', 'Failed to download commentaries. Please try again.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
-  const handleDeleteCommentary = useCallback(
-    async (languageCode: string) => {
-      setProcessingItem(`commentary:${languageCode}`);
-      try {
-        await deleteCommentaries(languageCode);
-      } catch {
-        Alert.alert('Error', 'Failed to delete commentaries.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [deleteCommentaries]
-  );
+  const handleDeleteCommentary = async (languageCode: string) => {
+    setProcessingItem(`commentary:${languageCode}`);
+    try {
+      await deleteCommentaries(languageCode);
+    } catch {
+      Alert.alert('Error', 'Failed to delete commentaries.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
-  const handleDownloadTopics = useCallback(
-    async (languageCode: string) => {
-      setProcessingItem(`topics:${languageCode}`);
-      try {
-        await downloadTopics(languageCode);
-      } catch {
-        Alert.alert('Error', 'Failed to download topics. Please try again.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [downloadTopics]
-  );
+  const handleDownloadTopics = async (languageCode: string) => {
+    setProcessingItem(`topics:${languageCode}`);
+    try {
+      await downloadTopics(languageCode);
+    } catch {
+      Alert.alert('Error', 'Failed to download topics. Please try again.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
-  const handleDeleteTopics = useCallback(
-    async (languageCode: string) => {
-      setProcessingItem(`topics:${languageCode}`);
-      try {
-        await deleteTopics(languageCode);
-      } catch {
-        Alert.alert('Error', 'Failed to delete topics.');
-      } finally {
-        setProcessingItem(null);
-      }
-    },
-    [deleteTopics]
-  );
+  const handleDeleteTopics = async (languageCode: string) => {
+    setProcessingItem(`topics:${languageCode}`);
+    try {
+      await deleteTopics(languageCode);
+    } catch {
+      Alert.alert('Error', 'Failed to delete topics.');
+    } finally {
+      setProcessingItem(null);
+    }
+  };
 
   const toggleSection = (section: 'bible' | 'commentary' | 'topics') => {
     setExpandedSections((prev) => ({

--- a/app/notes/[bookId]/[chapterNumber].tsx
+++ b/app/notes/[bookId]/[chapterNumber].tsx
@@ -21,7 +21,7 @@ export default function ChapterNotesScreen() {
   }>();
 
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const insets = useSafeAreaInsets();
   const parsedBookId = parseInt(bookId || '0', 10);
   const parsedChapterNumber = parseInt(chapterNumber || '0', 10);

--- a/app/notes/index.tsx
+++ b/app/notes/index.tsx
@@ -20,7 +20,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   ActivityIndicator,
   Pressable,
@@ -84,7 +84,7 @@ function groupNotesByChapter(notes: Note[]): ChapterGroup[] {
 export default function NotesScreen() {
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { notes, isFetchingNotes, refetchNotes } = useNotes();
 

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -18,6 +18,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { router, useFocusEffect } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react';
+// NOTE: useCallback is still used for useFocusEffect which requires it
 import {
   ActivityIndicator,
   Alert,
@@ -135,15 +136,15 @@ export default function SettingsScreen() {
     }
   }, [isAuthenticated]);
 
-  const hasProfileChanges = useCallback(() => {
+  const hasProfileChanges = () => {
     return (
       firstName !== (user?.firstName || '') ||
       lastName !== (user?.lastName || '') ||
       email !== (user?.email || '')
     );
-  }, [firstName, lastName, email, user]);
+  };
 
-  const saveProfile = useCallback(async () => {
+  const saveProfile = async () => {
     // Check for changes inline to avoid dependency on hasProfileChanges
     const hasChanges =
       firstName !== (user?.firstName || '') ||
@@ -220,17 +221,20 @@ export default function SettingsScreen() {
       setGlobalError(errorMessage);
       setSaveStatus('error');
     }
-  }, [firstName, lastName, email, user, restoreSession]);
+  };
 
   // Track pending changes
+  // Note: hasProfileChanges is auto-memoized by React Compiler
   useEffect(() => {
     hasPendingChangesRef.current = hasProfileChanges();
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization
   }, [hasProfileChanges]);
 
   // Store latest saveProfile in a ref to avoid re-running effect when it changes
   const saveProfileRef = useRef(saveProfile);
   useEffect(() => {
     saveProfileRef.current = saveProfile;
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization
   }, [saveProfile]);
 
   // Auto-save profile changes
@@ -253,6 +257,7 @@ export default function SettingsScreen() {
   }, [isAuthenticated, user, firstName, lastName, email]);
 
   // Save pending changes when screen loses focus
+  // Note: saveProfile is auto-memoized by React Compiler
   useFocusEffect(
     useCallback(() => {
       // Cleanup function runs when screen loses focus
@@ -262,6 +267,7 @@ export default function SettingsScreen() {
           saveProfile();
         }
       };
+      // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization
     }, [isAuthenticated, saveProfile])
   );
 

--- a/app/topics/[topicId].tsx
+++ b/app/topics/[topicId].tsx
@@ -21,7 +21,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Alert, Animated, Pressable, Share, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -75,7 +75,7 @@ type ViewMode = 'bible' | 'explanations';
  */
 export default function TopicDetailScreen() {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const { user } = useAuth();
   const { showToast } = useToast();
 
@@ -210,70 +210,58 @@ export default function TopicDetailScreen() {
   }, [activeTopicId, currentTopicCategory, activeTab, activeView]);
 
   // Handle back navigation
-  const handleBack = useCallback(() => {
+  const handleBack = () => {
     if (router.canGoBack()) {
       router.back();
     } else {
       router.replace('/');
     }
-  }, []);
+  };
 
   // Handle chapter selection from modal (redirect to Bible)
-  const handleSelectChapter = useCallback(
-    (bookId: number, chapter: number) => {
-      setIsNavigationModalOpen(false);
-      // Always default to Bible text view when navigating to Bible
-      setActiveView('bible');
-      router.push(`/bible/${bookId}/${chapter}`);
-    },
-    [setActiveView]
-  );
+  const handleSelectChapter = (bookId: number, chapter: number) => {
+    setIsNavigationModalOpen(false);
+    // Always default to Bible text view when navigating to Bible
+    setActiveView('bible');
+    router.push(`/bible/${bookId}/${chapter}`);
+  };
 
   // Handle topic selection from modal (navigate to different topic)
-  const handleSelectTopic = useCallback(
-    (newTopicId: string, _newCategory: TopicCategory) => {
-      setIsNavigationModalOpen(false);
-      // Always default to Bible text view when switching topics via modal
-      setActiveView('bible');
-      setActiveTopicId(newTopicId);
-      // URL will catch up via debounce
-    },
-    [setActiveView]
-  );
+  const handleSelectTopic = (newTopicId: string, _newCategory: TopicCategory) => {
+    setIsNavigationModalOpen(false);
+    // Always default to Bible text view when switching topics via modal
+    setActiveView('bible');
+    setActiveTopicId(newTopicId);
+    // URL will catch up via debounce
+  };
 
   // Handle tab change
-  const handleTabChange = useCallback(
-    (tab: ContentTabType) => {
-      setActiveTab(tab);
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    },
-    [setActiveTab]
-  );
+  const handleTabChange = (tab: ContentTabType) => {
+    setActiveTab(tab);
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+  };
 
   // Handle view mode change (Bible references vs Explanations)
-  const handleViewChange = useCallback(
-    (view: ViewMode) => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      setActiveView(view);
-    },
-    [setActiveView]
-  );
+  const handleViewChange = (view: ViewMode) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    setActiveView(view);
+  };
 
   /**
    * Handle page change from TopicPagerView swipe
    * Updates local state immediately to prevent flash
    * Global navigation - no category parameter needed
    */
-  const handlePageChange = useCallback((newTopicId: string) => {
+  const handlePageChange = (newTopicId: string) => {
     setActiveTopicId(newTopicId);
-  }, []);
+  };
 
   /**
    * Handle previous topic navigation via FAB button
    * Uses pagerRef.goPrevious for smooth animation in portrait, direct state update for split view
    * With circular navigation, prevTopic is always available - no error case needed
    */
-  const handlePrevious = useCallback(() => {
+  const handlePrevious = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     if (useSplitView && prevTopic) {
       // In split view, update local state directly
@@ -283,14 +271,14 @@ export default function TopicDetailScreen() {
       // This works correctly even if user has swiped manually
       pagerRef.current?.goPrevious();
     }
-  }, [prevTopic, useSplitView]);
+  };
 
   /**
    * Handle next topic navigation via FAB button
    * Uses pagerRef.goNext for smooth animation in portrait, direct state update for split view
    * With circular navigation, nextTopic is always available - no error case needed
    */
-  const handleNext = useCallback(() => {
+  const handleNext = () => {
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     if (useSplitView && nextTopic) {
       // In split view, update local state directly
@@ -300,10 +288,10 @@ export default function TopicDetailScreen() {
       // This works correctly even if user has swiped manually
       pagerRef.current?.goNext();
     }
-  }, [nextTopic, useSplitView]);
+  };
 
   // Handle share topic
-  const handleShare = useCallback(async () => {
+  const handleShare = async () => {
     // Extract topic from topicData
     const currentTopic =
       topicData?.topic && typeof topicData.topic === 'object' && 'name' in topicData.topic
@@ -339,41 +327,38 @@ export default function TopicDetailScreen() {
       // Trigger error haptic feedback
       await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     }
-  }, [topicData, currentTopicCategory]);
+  };
 
   /**
    * Handle scroll events from TopicPage for FAB visibility
    */
-  const handleScroll = useCallback(
-    (velocity: number, isAtBottom: boolean) => {
-      handleFABScroll(velocity, isAtBottom);
-    },
-    [handleFABScroll]
-  );
+  const handleScroll = (velocity: number, isAtBottom: boolean) => {
+    handleFABScroll(velocity, isAtBottom);
+  };
 
   /**
    * Handle verse press from TopicText component
    */
-  const handleVersePress = useCallback((verseData: VersePress) => {
+  const handleVersePress = (verseData: VersePress) => {
     setSelectedVerse(verseData);
     setTooltipVisible(true);
-  }, []);
+  };
 
   /**
    * Handle tooltip close
    */
-  const handleTooltipClose = useCallback(() => {
+  const handleTooltipClose = () => {
     setTooltipVisible(false);
     // Clear selected verse after animation completes
     setTimeout(() => setSelectedVerse(null), 300);
-  }, []);
+  };
 
   /**
    * Handle copy action from tooltip - show toast notification
    */
-  const handleCopy = useCallback(() => {
+  const handleCopy = () => {
     showToast('Verse copied to clipboard');
-  }, [showToast]);
+  };
 
   // Type guard for topic
   const topic =

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "verse-mate-mobile",
@@ -82,6 +83,7 @@
         "eslint": "^9.25.0",
         "eslint-config-biome": "^2.1.3",
         "eslint-config-expo": "~10.0.0",
+        "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "husky": "^9.1.7",
         "jest": "~29.7.0",
         "jest-expo": "~54.0.14",
@@ -98,7 +100,7 @@
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
-    "@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+    "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@babel/compat-data": ["@babel/compat-data@7.28.4", "", {}, "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw=="],
 
@@ -151,6 +153,8 @@
     "@babel/plugin-proposal-decorators": ["@babel/plugin-proposal-decorators@7.28.0", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1", "@babel/plugin-syntax-decorators": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zOiZqvANjWDUaUS9xMxbMcK/Zccztbe/6ikvUXaG9nsPH3w6qh5UaPGAnirI/WhIbZ8m3OHU0ReyPrknG+ZKeg=="],
 
     "@babel/plugin-proposal-export-default-from": ["@babel/plugin-proposal-export-default-from@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-hjlsMBl1aJc5lp8MoCDEZCiYzlgdRAShOjAfRw6X+GlpLpUPU7c3XNLsKFZbQk/1cRzBlJ7CXg3xJAJMrFa1Uw=="],
+
+    "@babel/plugin-proposal-private-methods": ["@babel/plugin-proposal-private-methods@7.18.6", "", { "dependencies": { "@babel/helper-create-class-features-plugin": "^7.18.6", "@babel/helper-plugin-utils": "^7.18.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA=="],
 
     "@babel/plugin-syntax-async-generators": ["@babel/plugin-syntax-async-generators@7.8.4", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.8.0" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw=="],
 
@@ -1270,6 +1274,8 @@
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
 
+    "eslint-plugin-react-compiler": ["eslint-plugin-react-compiler@19.1.0-rc.2", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "@babel/plugin-proposal-private-methods": "^7.18.6", "hermes-parser": "^0.25.1", "zod": "^3.22.4", "zod-validation-error": "^3.0.3" }, "peerDependencies": { "eslint": ">=7" } }, "sha512-oKalwDGcD+RX9mf3NEO4zOoUMeLvjSvcbbEOpquzmzqEEM2MQdp7/FY/Hx9NzmUwFzH1W9SKTz5fihfMldpEYw=="],
+
     "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@5.2.0", "", { "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0" } }, "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg=="],
 
     "eslint-scope": ["eslint-scope@8.4.0", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg=="],
@@ -1508,9 +1514,9 @@
 
     "headers-polyfill": ["headers-polyfill@4.0.3", "", {}, "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ=="],
 
-    "hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
-    "hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
 
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
@@ -1802,7 +1808,7 @@
 
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
-    "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -2554,11 +2560,11 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "@babel/core/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "zod-validation-error": ["zod-validation-error@3.5.4", "", { "peerDependencies": { "zod": "^3.24.4" } }, "sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -2571,12 +2577,6 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "@babel/template/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
-    "@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
-    "@babel/traverse--for-generate-function-map/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2598,6 +2598,8 @@
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
     "@expo/config/@expo/json-file": ["@expo/json-file@10.0.7", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw=="],
 
     "@expo/config-plugins/@expo/json-file": ["@expo/json-file@10.0.7", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw=="],
@@ -2610,7 +2612,7 @@
 
     "@expo/fingerprint/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
-    "@expo/metro-config/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+    "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/metro-config/@expo/env": ["@expo/env@2.0.7", "", { "dependencies": { "chalk": "^4.0.0", "debug": "^4.3.4", "dotenv": "~16.4.5", "dotenv-expand": "~11.0.6", "getenv": "^2.0.0" } }, "sha512-BNETbLEohk3HQ2LxwwezpG8pq+h7Fs7/vAMP3eAtFT1BCpprLYoBBFZH7gW4aqGfqOcVP4Lc91j014verrYNGg=="],
 
@@ -2618,7 +2620,11 @@
 
     "@expo/metro-config/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
+    "@expo/metro-config/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
+
     "@expo/metro-config/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -2640,6 +2646,8 @@
 
     "@react-native/codegen/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "@react-native/codegen/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
+
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
     "@react-native/dev-middleware/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
@@ -2647,8 +2655,6 @@
     "@react-navigation/native/fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "@storybook/react-native/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
-
-    "@testing-library/dom/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
@@ -2673,6 +2679,8 @@
     "babel-plugin-istanbul/istanbul-lib-instrument": ["istanbul-lib-instrument@5.2.1", "", { "dependencies": { "@babel/core": "^7.12.3", "@babel/parser": "^7.14.7", "@istanbuljs/schema": "^0.1.2", "istanbul-lib-coverage": "^3.2.0", "semver": "^6.3.0" } }, "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "babel-plugin-syntax-hermes-parser/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
 
     "better-opn/open": ["open@8.4.2", "", { "dependencies": { "define-lazy-prop": "^2.0.0", "is-docker": "^2.1.1", "is-wsl": "^2.2.0" } }, "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ=="],
 
@@ -2756,8 +2764,6 @@
 
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "jest-message-util/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
     "jest-resolve/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "jest-runner/source-map-support": ["source-map-support@0.5.13", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w=="],
@@ -2796,7 +2802,7 @@
 
     "log-update/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
-    "metro/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
@@ -2824,9 +2830,9 @@
 
     "ora/strip-ansi": ["strip-ansi@5.2.0", "", { "dependencies": { "ansi-regex": "^4.1.0" } }, "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA=="],
 
-    "parse-json/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
-
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
 
     "pkg-dir/find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
@@ -2902,8 +2908,6 @@
 
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
-
     "@babel/highlight/chalk/ansi-styles": ["ansi-styles@3.2.1", "", { "dependencies": { "color-convert": "^1.9.0" } }, "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA=="],
 
     "@babel/highlight/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
@@ -2916,15 +2920,21 @@
 
     "@expo/cli/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "@expo/config-plugins/@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
     "@expo/fingerprint/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@expo/metro-config/@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
+    "@expo/metro-config/hermes-parser/hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
 
     "@expo/metro-config/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
     "@jest/reporters/string-length/char-regex": ["char-regex@1.0.2", "", {}, "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw=="],
+
+    "@react-native/codegen/hermes-parser/hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
 
     "@react-native/dev-middleware/open/is-docker": ["is-docker@2.2.1", "", { "bin": { "is-docker": "cli.js" } }, "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ=="],
 
@@ -2945,6 +2955,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "babel-plugin-istanbul/istanbul-lib-instrument/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "babel-plugin-syntax-hermes-parser/hermes-parser/hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
 
     "better-opn/open/define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 

--- a/components/Button.tsx
+++ b/components/Button.tsx
@@ -1,5 +1,4 @@
 import type React from 'react';
-import { useMemo } from 'react';
 import { StyleSheet, Text, TouchableOpacity } from 'react-native';
 import type { getColors } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -26,7 +25,7 @@ export const Button: React.FC<ButtonProps> = ({
   testID,
 }) => {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   return (
     <TouchableOpacity

--- a/components/VerseCard.tsx
+++ b/components/VerseCard.tsx
@@ -1,5 +1,4 @@
 import type React from 'react';
-import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { getColors } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -26,7 +25,7 @@ export const VerseCard: React.FC<VerseCardProps> = ({
   testID,
 }) => {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const reference = `${book} ${chapter}:${verse}`;
 
   return (

--- a/components/auth/PasswordRequirements.tsx
+++ b/components/auth/PasswordRequirements.tsx
@@ -1,6 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
 import type React from 'react';
-import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import type { getColors } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -25,7 +24,7 @@ export interface PasswordRequirementsProps {
 
 export const PasswordRequirements: React.FC<PasswordRequirementsProps> = ({ password }) => {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const requirements = getPasswordRequirements(password);
 
   return (

--- a/components/auth/SSOButtons.tsx
+++ b/components/auth/SSOButtons.tsx
@@ -8,7 +8,6 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { useMemo } from 'react';
 import {
   ActivityIndicator,
   Platform,
@@ -92,7 +91,7 @@ export function SSOButtons({
   error,
 }: SSOButtonsProps) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   // Check which SSO providers are available
   const showGoogleButton = isGoogleSignInConfigured();

--- a/components/bible/AutoHighlightTooltip.tsx
+++ b/components/bible/AutoHighlightTooltip.tsx
@@ -12,7 +12,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -149,7 +149,7 @@ export function AutoHighlightTooltip({
   }, [byLineData, autoHighlight]);
 
   // Helper to animate open
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -164,40 +164,37 @@ export function AutoHighlightTooltip({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
   // Helper to animate close
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      // Force cleanup after 150ms to prevent "spring tail" blocking the UI
-      // This ensures the modal unmounts deterministically, fixing the double-click bug
-      setTimeout(() => {
-        setInternalVisible(false);
-        setExpanded(true); // Reset expansion state
-        expansionAnim.setValue(1);
-        hasTrackedOpen.current = false; // Reset tracking flag
-        if (callback) callback();
-      }, 150);
-    },
-    [backdropOpacity, slideAnim, screenHeight, expansionAnim]
-  );
+    // Force cleanup after 150ms to prevent "spring tail" blocking the UI
+    // This ensures the modal unmounts deterministically, fixing the double-click bug
+    setTimeout(() => {
+      setInternalVisible(false);
+      setExpanded(true); // Reset expansion state
+      expansionAnim.setValue(1);
+      hasTrackedOpen.current = false; // Reset tracking flag
+      if (callback) callback();
+    }, 150);
+  };
 
   // Handle expansion animation
   useEffect(() => {
@@ -230,14 +227,15 @@ export function AutoHighlightTooltip({
     } else if (internalVisible) {
       animateClose();
     }
-  }, [visible, animateOpen, animateClose, internalVisible, expansionAnim, autoHighlight]);
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
+  }, [visible, internalVisible, expansionAnim, autoHighlight, animateOpen, animateClose]);
 
   // Handle explicit dismiss (user action)
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = () => {
     animateClose(() => {
       onClose();
     });
-  }, [animateClose, onClose]);
+  };
 
   // Auto-close tooltip when switching to insight-only screen (right-full mode)
   // Tooltips are supported in split view and full Bible screen, but not in insight-only
@@ -245,6 +243,7 @@ export function AutoHighlightTooltip({
     if (visible && splitViewMode === 'right-full') {
       handleDismiss();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of handleDismiss
   }, [visible, splitViewMode, handleDismiss]);
 
   // Keep refs for PanResponder closure

--- a/components/bible/BibleContentPanel.tsx
+++ b/components/bible/BibleContentPanel.tsx
@@ -15,7 +15,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useMemo, useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { FloatingActionButtons } from '@/components/bible/FloatingActionButtons';
@@ -112,7 +112,7 @@ export function BibleContentPanel({
   const { mode, colors } = useTheme();
   const insets = useSafeAreaInsets();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
-  const styles = useMemo(() => createStyles(specs, colors, insets), [specs, colors, insets]);
+  const styles = createStyles(specs, colors, insets);
 
   // Ref for ChapterPagerView imperative control
   const pagerRef = useRef<ChapterPagerViewRef>(null);
@@ -121,7 +121,7 @@ export function BibleContentPanel({
   const { progress } = useBookProgress(bookId, chapterNumber, totalChapters);
 
   // Handle previous navigation
-  const handlePrevious = useCallback(() => {
+  const handlePrevious = () => {
     if (canGoPrevious) {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       pagerRef.current?.setPage(1); // Previous page in 5-page window
@@ -129,10 +129,10 @@ export function BibleContentPanel({
     } else {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     }
-  }, [canGoPrevious, onNavigatePrev]);
+  };
 
   // Handle next navigation
-  const handleNext = useCallback(() => {
+  const handleNext = () => {
     if (canGoNext) {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       pagerRef.current?.setPage(3); // Next page in 5-page window
@@ -140,7 +140,7 @@ export function BibleContentPanel({
     } else {
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Error);
     }
-  }, [canGoNext, onNavigateNext]);
+  };
 
   return (
     <View style={styles.container} testID={testID}>

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -14,7 +14,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
@@ -107,7 +107,7 @@ export function BibleExplanationsPanel({
   const language = typeof user?.preferred_language === 'string' ? user.preferred_language : 'en-US';
 
   // Animation for sliding tab indicator
-  const getTabIndex = useCallback((tab: ContentTabType) => TABS.findIndex((t) => t.id === tab), []);
+  const getTabIndex = (tab: ContentTabType) => TABS.findIndex((t) => t.id === tab);
   const slideAnim = useRef(new Animated.Value(getTabIndex(activeTab))).current;
   const [tabWidth, setTabWidth] = useState(0);
 
@@ -128,6 +128,7 @@ export function BibleExplanationsPanel({
       friction: 8,
       tension: 50,
     }).start();
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of getTabIndex
   }, [activeTab, slideAnim, getTabIndex]);
 
   // Fetch explanations based on active tab
@@ -181,13 +182,10 @@ export function BibleExplanationsPanel({
     (activeTab === 'detailed' && detailedLoading);
 
   // Handle tab change with haptic feedback
-  const handleTabChange = useCallback(
-    (tab: ContentTabType) => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-      onTabChange(tab);
-    },
-    [onTabChange]
-  );
+  const handleTabChange = (tab: ContentTabType) => {
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onTabChange(tab);
+  };
 
   // Get content string from data
   const content = useMemo(() => {
@@ -202,10 +200,10 @@ export function BibleExplanationsPanel({
    * Handle touch start - record time and position
    * Used to differentiate tap from scroll gestures
    */
-  const handleTouchStart = useCallback((event: GestureResponderEvent) => {
+  const handleTouchStart = (event: GestureResponderEvent) => {
     touchStartTime.current = Date.now();
     touchStartY.current = event.nativeEvent.pageY;
-  }, []);
+  };
 
   /**
    * Handle touch end - detect if it was a tap (not a scroll)
@@ -214,51 +212,45 @@ export function BibleExplanationsPanel({
    * - Movement < 10 pixels
    * Matches logic from ChapterPage.tsx for consistent behavior
    */
-  const handleTouchEnd = useCallback(
-    (event: GestureResponderEvent) => {
-      if (!onTap) return;
+  const handleTouchEnd = (event: GestureResponderEvent) => {
+    if (!onTap) return;
 
-      const touchDuration = Date.now() - touchStartTime.current;
-      const touchMovement = Math.abs(event.nativeEvent.pageY - touchStartY.current);
+    const touchDuration = Date.now() - touchStartTime.current;
+    const touchMovement = Math.abs(event.nativeEvent.pageY - touchStartY.current);
 
-      // Only trigger tap if it was quick and didn't move much
-      if (touchDuration < 200 && touchMovement < 10) {
-        onTap();
-      }
-    },
-    [onTap]
-  );
+    // Only trigger tap if it was quick and didn't move much
+    if (touchDuration < 200 && touchMovement < 10) {
+      onTap();
+    }
+  };
 
   /**
    * Handle scroll events - calculate velocity and check if at bottom
    * Matches logic from ChapterPage.tsx for consistent FAB behavior
    */
-  const handleInternalScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (!onScroll) return;
+  const handleInternalScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (!onScroll) return;
 
-      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
-      const currentScrollY = contentOffset.y;
-      const currentTime = Date.now();
+    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    const currentScrollY = contentOffset.y;
+    const currentTime = Date.now();
 
-      // Calculate scroll velocity (pixels per second)
-      const timeDelta = currentTime - lastScrollTime.current;
-      const scrollDelta = currentScrollY - lastScrollY.current;
-      const velocity = timeDelta > 0 ? (scrollDelta / timeDelta) * 1000 : 0;
+    // Calculate scroll velocity (pixels per second)
+    const timeDelta = currentTime - lastScrollTime.current;
+    const scrollDelta = currentScrollY - lastScrollY.current;
+    const velocity = timeDelta > 0 ? (scrollDelta / timeDelta) * 1000 : 0;
 
-      // Check if at bottom
-      const scrollHeight = contentSize.height - layoutMeasurement.height;
-      const isAtBottom = scrollHeight - currentScrollY <= BOTTOM_THRESHOLD;
+    // Check if at bottom
+    const scrollHeight = contentSize.height - layoutMeasurement.height;
+    const isAtBottom = scrollHeight - currentScrollY <= BOTTOM_THRESHOLD;
 
-      // Update refs
-      lastScrollY.current = currentScrollY;
-      lastScrollTime.current = currentTime;
+    // Update refs
+    lastScrollY.current = currentScrollY;
+    lastScrollTime.current = currentTime;
 
-      // Call parent callback
-      onScroll(velocity, isAtBottom);
-    },
-    [onScroll]
-  );
+    // Call parent callback
+    onScroll(velocity, isAtBottom);
+  };
 
   return (
     <View

--- a/components/bible/BibleNavigationModal.tsx
+++ b/components/bible/BibleNavigationModal.tsx
@@ -20,7 +20,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   Keyboard,
   Modal,
@@ -251,6 +251,7 @@ function BibleNavigationModalComponent({
   ]);
 
   const backdropOpacity = useDerivedValue(() => {
+    'worklet';
     return interpolate(translateY.value, [-1000, 0], [0, 1], Extrapolation.CLAMP);
   });
   const [internalVisible, setInternalVisible] = useState(visible);
@@ -1120,7 +1121,7 @@ function BibleNavigationModalComponent({
  * Memoized BibleNavigationModal to prevent unnecessary re-renders
  * when parent component updates but modal is not visible
  */
-export const BibleNavigationModal = memo(BibleNavigationModalComponent);
+export const BibleNavigationModal = BibleNavigationModalComponent;
 
 const createStyles = (
   colors: ReturnType<typeof getColors>,

--- a/components/bible/ChapterContentTabs.tsx
+++ b/components/bible/ChapterContentTabs.tsx
@@ -18,7 +18,7 @@
  */
 
 import * as Haptics from 'expo-haptics';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
 import {
   type getColors,
@@ -66,7 +66,7 @@ export function ChapterContentTabs({
   disabled = false,
 }: ChapterContentTabsProps) {
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors, mode), [colors, mode]);
+  const styles = createStyles(colors, mode);
 
   // Animation value for sliding indicator
   const slideAnim = useRef(new Animated.Value(getTabIndex(activeTab))).current;

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -18,7 +18,7 @@
  */
 
 import { router } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
@@ -115,7 +115,7 @@ function TabContent({
   filteredAutoHighlights?: AutoHighlight[];
 }) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]); // Use local createStyles for TabContent
+  const styles = createStyles(colors); // Use local createStyles for TabContent
 
   const isHidden = !visible;
   if (isHidden && !shouldRenderHidden) return null;
@@ -245,7 +245,7 @@ export interface ChapterPageProps {
  * />
  * ```
  */
-export const ChapterPage = React.memo(function ChapterPage({
+export function ChapterPage({
   bookId,
   chapterNumber,
   activeTab,
@@ -258,7 +258,7 @@ export const ChapterPage = React.memo(function ChapterPage({
   onTap,
 }: ChapterPageProps) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]); // Use local createStyles for ChapterPage
+  const styles = createStyles(colors); // Use local createStyles for ChapterPage
 
   // Use Reanimated ref for the animated ScrollView
   const animatedScrollRef = useAnimatedRef<Animated.ScrollView>();
@@ -441,7 +441,7 @@ export const ChapterPage = React.memo(function ChapterPage({
   /**
    * Attempt to scroll to target verse using Reanimated for smoothness
    */
-  const attemptScrollToVerse = useCallback(() => {
+  const attemptScrollToVerse = () => {
     if (activeView !== 'bible') return;
     if (!targetVerse || hasScrolledRef.current) return;
 
@@ -488,24 +488,22 @@ export const ChapterPage = React.memo(function ChapterPage({
         hasScrolledRef.current = true;
       }
     }
-  }, [activeView, targetVerse, animatedScrollRef]);
+  };
 
   /**
    * Handle content layout report from ChapterReader
    */
-  const handleContentLayout = useCallback(
-    (positions: Record<number, number>) => {
-      sectionPositionsRef.current = positions;
-      attemptScrollToVerse();
-    },
-    [attemptScrollToVerse]
-  );
+  const handleContentLayout = (positions: Record<number, number>) => {
+    sectionPositionsRef.current = positions;
+    attemptScrollToVerse();
+  };
 
   // Attempt scroll when targetVerse changes (if layouts are ready)
   useEffect(() => {
     if (targetVerse) {
       attemptScrollToVerse();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of attemptScrollToVerse
   }, [targetVerse, attemptScrollToVerse]);
 
   // Fallback: if initial layout was late, retry after mount
@@ -531,6 +529,7 @@ export const ChapterPage = React.memo(function ChapterPage({
       clearTimeout(timeout);
       clearInterval(interval);
     };
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of attemptScrollToVerse
   }, [attemptScrollToVerse]);
 
   /**
@@ -872,4 +871,4 @@ export const ChapterPage = React.memo(function ChapterPage({
         })()}
     </View>
   );
-});
+}

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -21,7 +21,7 @@
  * @see Task Group 3: Share Button and UI Integration
  */
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type NativeSyntheticEvent,
   StyleSheet,
@@ -260,7 +260,7 @@ export function ChapterReader({
 }: ChapterReaderProps) {
   const { colors, mode } = useTheme();
   const specs = getHeaderSpecs(mode);
-  const styles = useMemo(() => createStyles(colors, explanationsOnly), [colors, explanationsOnly]);
+  const styles = createStyles(colors, explanationsOnly);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
   const { showToast } = useToast();
 
@@ -344,17 +344,14 @@ export function ChapterReader({
   /**
    * Check if a verse group is visible in the viewport
    */
-  const isVerseVisible = useCallback(
-    (startVerse: number): boolean => {
-      const layout = sectionLayouts.current[startVerse];
-      if (!layout) {
-        // If layout not yet calculated, assume visible (safe default)
-        return true;
-      }
-      return isElementVisible(layout.y, layout.height, visibleYRange);
-    },
-    [visibleYRange]
-  );
+  const isVerseVisible = (startVerse: number): boolean => {
+    const layout = sectionLayouts.current[startVerse];
+    if (!layout) {
+      // If layout not yet calculated, assume visible (safe default)
+      return true;
+    }
+    return isElementVisible(layout.y, layout.height, visibleYRange);
+  };
 
   /**
    * Handle notes button press
@@ -367,7 +364,7 @@ export function ChapterReader({
    * Handle word selection from HighlightedText
    * Directly opens dictionary definition (no intermediate selection UI)
    */
-  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
+  const handleWordSelect = (selection: WordSelection, clearSelection: () => void) => {
     // Directly open definition
     setWordToDefine({
       word: selection.word,
@@ -377,7 +374,7 @@ export function ChapterReader({
 
     // Clear any selection highlight
     clearSelection();
-  }, []);
+  };
 
   /**
    * Handle tap on highlighted text
@@ -435,40 +432,37 @@ export function ChapterReader({
   /**
    * Handle close word definition tooltip
    */
-  const handleWordDefinitionClose = useCallback(() => {
+  const handleWordDefinitionClose = () => {
     setWordDefinitionVisible(false);
     setWordToDefine(null);
-  }, []);
+  };
 
   /**
    * Handle copy from word definition tooltip
    */
-  const handleWordDefinitionCopy = useCallback(() => {
+  const handleWordDefinitionCopy = () => {
     showToast('Copied to clipboard');
-  }, [showToast]);
+  };
 
   /**
    * Handle text layout event to capture line positions
    */
-  const handleTextLayout = useCallback(
-    (groupKey: string, event: NativeSyntheticEvent<TextLayoutEventData>) => {
-      const { lines } = event.nativeEvent;
-      let charOffset = 0;
-      const lineInfo = lines.map((line) => {
-        const info = {
-          text: line.text,
-          y: line.y,
-          height: line.height,
-          width: line.width,
-          startCharOffset: charOffset,
-        };
-        charOffset += line.text.length;
-        return info;
-      });
-      paragraphLineLayoutsRef.current.set(groupKey, lineInfo);
-    },
-    []
-  );
+  const handleTextLayout = (groupKey: string, event: NativeSyntheticEvent<TextLayoutEventData>) => {
+    const { lines } = event.nativeEvent;
+    let charOffset = 0;
+    const lineInfo = lines.map((line) => {
+      const info = {
+        text: line.text,
+        y: line.y,
+        height: line.height,
+        width: line.width,
+        startCharOffset: charOffset,
+      };
+      charOffset += line.text.length;
+      return info;
+    });
+    paragraphLineLayoutsRef.current.set(groupKey, lineInfo);
+  };
 
   return (
     <View style={styles.container} collapsable={false}>

--- a/components/bible/CharacterCounter.tsx
+++ b/components/bible/CharacterCounter.tsx
@@ -27,7 +27,6 @@
  * ```
  */
 
-import { useMemo } from 'react';
 import { StyleSheet, Text } from 'react-native';
 import { fontSizes, fontWeights, type getColors } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -56,7 +55,7 @@ export interface CharacterCounterProps {
  */
 export function CharacterCounter({ currentLength, maxLength, threshold }: CharacterCounterProps) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   // Hide counter if below threshold
   if (currentLength < threshold) {

--- a/components/bible/DictionaryModal.tsx
+++ b/components/bible/DictionaryModal.tsx
@@ -25,7 +25,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -79,7 +79,7 @@ interface DictionaryState {
  */
 export function DictionaryModal({ visible, word, strongsNumber, onClose }: DictionaryModalProps) {
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors, mode), [colors, mode]);
+  const styles = createStyles(colors, mode);
   const { showDefinition, hasDefinition, isAvailable: nativeAvailable } = useNativeDictionary();
 
   const [state, setState] = useState<DictionaryState>({
@@ -159,22 +159,22 @@ export function DictionaryModal({ visible, word, strongsNumber, onClose }: Dicti
   /**
    * Handle close button press
    */
-  const handleClose = useCallback(async () => {
+  const handleClose = async () => {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onClose();
-  }, [onClose]);
+  };
 
   /**
    * Handle "Open in Dictionary" button press
    */
-  const handleOpenNative = useCallback(async () => {
+  const handleOpenNative = async () => {
     await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     const shown = await showDefinition(word);
     if (shown) {
       // Optionally close modal after opening native dictionary
       // onClose();
     }
-  }, [word, showDefinition]);
+  };
 
   /**
    * Clean up word for display (capitalize first letter)

--- a/components/bible/FloatingActionButtons.tsx
+++ b/components/bible/FloatingActionButtons.tsx
@@ -16,7 +16,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { Platform, Pressable, StyleSheet } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { animationDurations, getFabSpecs, type ThemeMode } from '@/constants/bible-design-tokens';
@@ -53,7 +53,7 @@ export function FloatingActionButtons({
   visible = true,
 }: FloatingActionButtonsProps) {
   const { mode } = useTheme();
-  const styles = useMemo(() => createStyles(mode), [mode]);
+  const styles = createStyles(mode);
   const specs = getFabSpecs(mode);
 
   // Animated opacity value

--- a/components/bible/HighlightEditMenu.tsx
+++ b/components/bible/HighlightEditMenu.tsx
@@ -30,7 +30,6 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useMemo } from 'react';
 import {
   KeyboardAvoidingView,
   Modal,
@@ -86,7 +85,7 @@ export function HighlightEditMenu({
   // Calculate left padding to center over right panel in split view
   const leftPadding = useSplitView && splitViewMode !== 'left-full' ? windowWidth * splitRatio : 0;
 
-  const styles = useMemo(() => createStyles(colors, leftPadding), [colors, leftPadding]);
+  const styles = createStyles(colors, leftPadding);
 
   /**
    * Handle color change with haptic feedback

--- a/components/bible/HighlightOptionsModal.tsx
+++ b/components/bible/HighlightOptionsModal.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -235,7 +235,7 @@ export function HighlightOptionsModal({
   const slideAnim = useRef(new Animated.Value(screenHeight)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
 
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -250,38 +250,35 @@ export function HighlightOptionsModal({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      setTimeout(() => {
-        setInternalVisible(false);
-        setIsConfirmDeleteVisible(false);
-        setIsSuccessVisible(false);
-        setIsErrorVisible(false);
-        setStatusMessage('');
-        if (callback) callback();
-      }, 300);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+    setTimeout(() => {
+      setInternalVisible(false);
+      setIsConfirmDeleteVisible(false);
+      setIsSuccessVisible(false);
+      setIsErrorVisible(false);
+      setStatusMessage('');
+      if (callback) callback();
+    }, 300);
+  };
 
   useEffect(() => {
     if (visible && !internalVisible) {
@@ -293,6 +290,7 @@ export function HighlightOptionsModal({
     } else if (!visible && internalVisible) {
       animateClose(onClose);
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, internalVisible, animateOpen, animateClose, onClose]);
 
   const panResponder = useRef(

--- a/components/bible/NoteCard.tsx
+++ b/components/bible/NoteCard.tsx
@@ -30,7 +30,6 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { useMemo } from 'react';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { fontSizes, fontWeights, type getColors, spacing } from '@/constants/bible-design-tokens';
 import { NOTES_CONFIG } from '@/constants/notes';
@@ -77,7 +76,7 @@ export function NoteCard({
   isExpanded = false,
 }: NoteCardProps) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
 
   const isTruncated = note.content.length > truncateLength;
 

--- a/components/bible/NoteEditModal.tsx
+++ b/components/bible/NoteEditModal.tsx
@@ -15,7 +15,7 @@
 
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -65,7 +65,7 @@ export function NoteEditModal({
 }: NoteEditModalProps) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
-  const styles = useMemo(() => createStyles(colors, insets.bottom), [colors, insets.bottom]);
+  const styles = createStyles(colors, insets.bottom);
   const { showToast } = useToast();
   const { updateNote, isUpdatingNote } = useNotes();
   const { draftContent, isDraftRestored, saveDraft, clearDraft } = useNoteDraft(
@@ -116,7 +116,7 @@ export function NoteEditModal({
 
   // -- Animation Logic --
 
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -131,35 +131,32 @@ export function NoteEditModal({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Keyboard.dismiss();
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Keyboard.dismiss();
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      setTimeout(() => {
-        setInternalVisible(false);
-        if (callback) callback();
-      }, 200);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+    setTimeout(() => {
+      setInternalVisible(false);
+      if (callback) callback();
+    }, 200);
+  };
 
   useEffect(() => {
     if (visible) {
@@ -167,6 +164,7 @@ export function NoteEditModal({
     } else if (internalVisible) {
       animateClose();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, animateOpen, animateClose, internalVisible]);
 
   // -- Gestures --

--- a/components/bible/NoteOptionsModal.tsx
+++ b/components/bible/NoteOptionsModal.tsx
@@ -1,7 +1,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -234,7 +234,7 @@ export function NoteOptionsModal({
   const slideAnim = useRef(new Animated.Value(screenHeight)).current;
   const backdropOpacity = useRef(new Animated.Value(0)).current;
 
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -249,38 +249,35 @@ export function NoteOptionsModal({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      setTimeout(() => {
-        setInternalVisible(false);
-        setIsConfirmDeleteVisible(false);
-        setIsSuccessVisible(false);
-        setIsErrorVisible(false);
-        setStatusMessage('');
-        if (callback) callback();
-      }, 300);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+    setTimeout(() => {
+      setInternalVisible(false);
+      setIsConfirmDeleteVisible(false);
+      setIsSuccessVisible(false);
+      setIsErrorVisible(false);
+      setStatusMessage('');
+      if (callback) callback();
+    }, 300);
+  };
 
   useEffect(() => {
     if (visible && !internalVisible) {
@@ -292,6 +289,7 @@ export function NoteOptionsModal({
     } else if (!visible && internalVisible) {
       animateClose(onClose);
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, internalVisible, animateOpen, animateClose, onClose]);
 
   const panResponder = useRef(

--- a/components/bible/NoteViewModal.tsx
+++ b/components/bible/NoteViewModal.tsx
@@ -27,7 +27,7 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -84,7 +84,7 @@ export function NoteViewModal({
   onClose,
 }: NoteViewModalProps) {
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors, mode), [colors, mode]);
+  const styles = createStyles(colors, mode);
 
   // Animation state for swipe-to-dismiss
   const screenHeight = Dimensions.get('window').height;
@@ -93,7 +93,7 @@ export function NoteViewModal({
   const [internalVisible, setInternalVisible] = useState(false);
 
   // Animate open/close
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -108,33 +108,30 @@ export function NoteViewModal({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
-      setTimeout(() => {
-        setInternalVisible(false);
-        if (callback) callback();
-      }, 300);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
+    setTimeout(() => {
+      setInternalVisible(false);
+      if (callback) callback();
+    }, 300);
+  };
 
   useEffect(() => {
     if (visible && !internalVisible) {
@@ -142,13 +139,14 @@ export function NoteViewModal({
     } else if (!visible && internalVisible) {
       animateClose();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, internalVisible, animateOpen, animateClose]);
 
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = () => {
     animateClose(() => {
       onClose();
     });
-  }, [animateClose, onClose]);
+  };
 
   // Pan responder for swipe-to-dismiss – matches tooltip/menus behavior
   const panResponder = useRef(

--- a/components/bible/NotesModal.tsx
+++ b/components/bible/NotesModal.tsx
@@ -18,7 +18,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Keyboard,
@@ -75,7 +75,7 @@ export interface NotesModalProps {
  */
 export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }: NotesModalProps) {
   const { colors, mode } = useTheme();
-  const styles = useMemo(() => createStyles(colors, mode), [colors, mode]);
+  const styles = createStyles(colors, mode);
   const { addNote, isAddingNote, deleteNote } = useNotes();
   const { showToast } = useToast();
   const [newNoteContent, setNewNoteContent] = useState('');
@@ -101,7 +101,7 @@ export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }
   }, [visible]);
 
   // Animate open/close
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -116,30 +116,27 @@ export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: 600,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-        }),
-      ]).start();
-      setTimeout(() => {
-        setInternalVisible(false);
-        if (callback) callback();
-      }, 300);
-    },
-    [backdropOpacity, slideAnim]
-  );
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: 600,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+      }),
+    ]).start();
+    setTimeout(() => {
+      setInternalVisible(false);
+      if (callback) callback();
+    }, 300);
+  };
 
   useEffect(() => {
     if (visible && !internalVisible) {
@@ -147,6 +144,7 @@ export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }
     } else if (!visible && internalVisible) {
       animateClose();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, internalVisible, animateOpen, animateClose]);
 
   const handleDismiss = () => {

--- a/components/bible/SimpleColorPickerModal.tsx
+++ b/components/bible/SimpleColorPickerModal.tsx
@@ -12,7 +12,7 @@
  * - Identical animations/UX to AutoHighlightTooltip
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   Animated,
   Dimensions,
@@ -84,7 +84,7 @@ export function SimpleColorPickerModal({
   const slideAnim = useRef(new Animated.Value(screenHeight)).current;
 
   // Helper to animate open
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -99,37 +99,34 @@ export function SimpleColorPickerModal({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
   // Helper to animate close
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      // Force cleanup after 150ms to prevent "spring tail" blocking the UI
-      setTimeout(() => {
-        setInternalVisible(false);
-        setSelectedColor(DEFAULT_HIGHLIGHT_COLOR); // Reset color
-        if (callback) callback();
-      }, 150);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+    // Force cleanup after 150ms to prevent "spring tail" blocking the UI
+    setTimeout(() => {
+      setInternalVisible(false);
+      setSelectedColor(DEFAULT_HIGHLIGHT_COLOR); // Reset color
+      if (callback) callback();
+    }, 150);
+  };
 
   // Watch for prop changes to trigger animations
   useEffect(() => {
@@ -138,6 +135,7 @@ export function SimpleColorPickerModal({
     } else if (internalVisible) {
       animateClose();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, animateOpen, animateClose, internalVisible]);
 
   // Handle explicit dismiss (user action)

--- a/components/bible/SkeletonLoader.tsx
+++ b/components/bible/SkeletonLoader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { StyleSheet, View } from 'react-native';
 import Animated, {
   useAnimatedStyle,
@@ -28,7 +28,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 export function SkeletonLoader() {
   const { mode } = useTheme();
   const skeletonSpecs = getSkeletonSpecs(mode);
-  const styles = useMemo(() => createStyles(skeletonSpecs), [skeletonSpecs]);
+  const styles = createStyles(skeletonSpecs);
 
   const opacity = useSharedValue(1);
 

--- a/components/bible/WordDefinitionTooltip.tsx
+++ b/components/bible/WordDefinitionTooltip.tsx
@@ -18,7 +18,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -197,7 +197,7 @@ export function WordDefinitionTooltip({
   }, [visible, word, nativeAvailable, hasDefinition]);
 
   // Helper to animate open
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     Animated.parallel([
       Animated.timing(backdropOpacity, {
@@ -212,36 +212,33 @@ export function WordDefinitionTooltip({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
   // Helper to animate close
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+  const animateClose = (callback?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      // Force cleanup after 150ms (store ref for cleanup on unmount)
-      closeTimeoutRef.current = setTimeout(() => {
-        setInternalVisible(false);
-        if (callback) callback();
-      }, 150);
-    },
-    [backdropOpacity, slideAnim, screenHeight]
-  );
+    // Force cleanup after 150ms (store ref for cleanup on unmount)
+    closeTimeoutRef.current = setTimeout(() => {
+      setInternalVisible(false);
+      if (callback) callback();
+    }, 150);
+  };
 
   // Watch for prop changes to trigger animations
   useEffect(() => {
@@ -250,20 +247,22 @@ export function WordDefinitionTooltip({
     } else if (internalVisible) {
       animateClose();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of animateOpen/animateClose
   }, [visible, animateOpen, animateClose, internalVisible]);
 
   // Handle explicit dismiss (user action)
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = () => {
     animateClose(() => {
       onClose();
     });
-  }, [animateClose, onClose]);
+  };
 
   // Auto-close tooltip when switching to insight-only screen
   useEffect(() => {
     if (visible && splitViewMode === 'right-full') {
       handleDismiss();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of handleDismiss
   }, [visible, splitViewMode, handleDismiss]);
 
   /**

--- a/components/settings/AutoHighlightSettings.tsx
+++ b/components/settings/AutoHighlightSettings.tsx
@@ -8,7 +8,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { fontSizes, fontWeights, type getColors, spacing } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -50,7 +50,7 @@ export function AutoHighlightSettings({
   alwaysExpanded = false,
 }: AutoHighlightSettingsProps) {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const queryClient = useQueryClient();
   const [themes, setThemes] = useState<HighlightTheme[]>([]);
   const [isLoading, setIsLoading] = useState(true);

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -15,7 +15,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
@@ -89,16 +89,13 @@ export function TopicExplanationsPanel({
 }: TopicExplanationsPanelProps) {
   const { mode, colors } = useTheme();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
-  const { styles, markdownStyles } = useMemo(() => createStyles(specs, colors), [specs, colors]);
+  const { styles, markdownStyles } = createStyles(specs, colors);
   const insets = useSafeAreaInsets();
 
   const scrollViewRef = useRef<ScrollView>(null);
 
   // Animation for sliding tab indicator
-  const getTabIndex = useCallback(
-    (tab: ContentTabType) => TAB_OPTIONS.findIndex((t) => t.id === tab),
-    []
-  );
+  const getTabIndex = (tab: ContentTabType) => TAB_OPTIONS.findIndex((t) => t.id === tab);
   const slideAnim = useRef(new Animated.Value(getTabIndex(activeTab))).current;
   const [tabWidth, setTabWidth] = useState(0);
 
@@ -111,6 +108,7 @@ export function TopicExplanationsPanel({
       friction: 8,
       tension: 50,
     }).start();
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of getTabIndex
   }, [activeTab, slideAnim, getTabIndex]);
 
   // Get Bible version from settings
@@ -122,20 +120,17 @@ export function TopicExplanationsPanel({
   const topicData = rawTopicData as any;
 
   // Handle tab press with haptic feedback
-  const handleTabPress = useCallback(
-    (tab: ContentTabType) => {
-      if (tab !== activeTab) {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-        onTabChange(tab);
-        // Scroll to top when switching tabs
-        scrollViewRef.current?.scrollTo({ y: 0, animated: true });
-      }
-    },
-    [activeTab, onTabChange]
-  );
+  const handleTabPress = (tab: ContentTabType) => {
+    if (tab !== activeTab) {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onTabChange(tab);
+      // Scroll to top when switching tabs
+      scrollViewRef.current?.scrollTo({ y: 0, animated: true });
+    }
+  };
 
   // Get explanation content for active tab
-  const getExplanationContent = useCallback(() => {
+  const getExplanationContent = () => {
     if (!topicData?.explanation) return null;
 
     switch (activeTab) {
@@ -148,13 +143,13 @@ export function TopicExplanationsPanel({
       default:
         return null;
     }
-  }, [topicData, activeTab]);
+  };
 
   const explanationContent = getExplanationContent();
   const hasContent = explanationContent && typeof explanationContent === 'string';
 
   // Custom share handler for topics
-  const handleShare = useCallback(async () => {
+  const handleShare = async () => {
     if (!topicData) return;
 
     const { generateTopicShareUrl } = await import('@/utils/sharing/generate-topic-share-url');
@@ -188,7 +183,7 @@ export function TopicExplanationsPanel({
     } catch (error) {
       console.error('Failed to share topic:', error);
     }
-  }, [topicData, topicName, activeTab]);
+  };
 
   return (
     <View style={[styles.container, { paddingTop: insets.top + spacing.sm }]} testID={testID}>

--- a/components/topics/TopicPage.tsx
+++ b/components/topics/TopicPage.tsx
@@ -17,7 +17,7 @@
  * @see Spec: agent-os/specs/2025-12-08-topic-swipe-navigation/spec.md
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
@@ -132,7 +132,7 @@ export interface TopicPageProps {
  * />
  * ```
  */
-export const TopicPage = React.memo(function TopicPage({
+export function TopicPage({
   topicId,
   activeTab,
   activeView,
@@ -144,7 +144,7 @@ export const TopicPage = React.memo(function TopicPage({
   onVersePress,
 }: TopicPageProps) {
   const { colors } = useTheme();
-  const { styles, markdownStyles } = useMemo(() => createStyles(colors), [colors]);
+  const { styles, markdownStyles } = createStyles(colors);
 
   // TODO: Implement Bible version selection in Settings page
   // For now, hardcoded to NASB1995 (backend default)
@@ -218,10 +218,10 @@ export const TopicPage = React.memo(function TopicPage({
   /**
    * Handle touch start - record time and position
    */
-  const handleTouchStart = useCallback((event: GestureResponderEvent) => {
+  const handleTouchStart = (event: GestureResponderEvent) => {
     touchStartTime.current = Date.now();
     touchStartY.current = event.nativeEvent.pageY;
-  }, []);
+  };
 
   /**
    * Handle touch end - detect if it was a tap (not a scroll)
@@ -229,50 +229,44 @@ export const TopicPage = React.memo(function TopicPage({
    * - Touch duration < 200ms
    * - Movement < 10 pixels
    */
-  const handleTouchEnd = useCallback(
-    (event: GestureResponderEvent) => {
-      if (!onTap) return;
+  const handleTouchEnd = (event: GestureResponderEvent) => {
+    if (!onTap) return;
 
-      const touchDuration = Date.now() - touchStartTime.current;
-      const touchMovement = Math.abs(event.nativeEvent.pageY - touchStartY.current);
+    const touchDuration = Date.now() - touchStartTime.current;
+    const touchMovement = Math.abs(event.nativeEvent.pageY - touchStartY.current);
 
-      // Only trigger tap if it was quick and didn't move much
-      if (touchDuration < 200 && touchMovement < 10) {
-        onTap();
-      }
-    },
-    [onTap]
-  );
+    // Only trigger tap if it was quick and didn't move much
+    if (touchDuration < 200 && touchMovement < 10) {
+      onTap();
+    }
+  };
 
   /**
    * Handle scroll events - calculate velocity and detect bottom
    */
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      if (!onScroll) return;
+  const handleScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    if (!onScroll) return;
 
-      const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
-      const currentScrollY = contentOffset.y;
-      const currentTime = Date.now();
+    const { contentOffset, contentSize, layoutMeasurement } = event.nativeEvent;
+    const currentScrollY = contentOffset.y;
+    const currentTime = Date.now();
 
-      // Calculate scroll velocity (pixels per second)
-      const timeDelta = currentTime - lastScrollTime.current;
-      const scrollDelta = currentScrollY - lastScrollY.current; // Signed value to track direction
-      const velocity = timeDelta > 0 ? (scrollDelta / timeDelta) * 1000 : 0;
+    // Calculate scroll velocity (pixels per second)
+    const timeDelta = currentTime - lastScrollTime.current;
+    const scrollDelta = currentScrollY - lastScrollY.current; // Signed value to track direction
+    const velocity = timeDelta > 0 ? (scrollDelta / timeDelta) * 1000 : 0;
 
-      // Check if at bottom
-      const scrollHeight = contentSize.height - layoutMeasurement.height;
-      const isAtBottom = scrollHeight - currentScrollY <= BOTTOM_THRESHOLD;
+    // Check if at bottom
+    const scrollHeight = contentSize.height - layoutMeasurement.height;
+    const isAtBottom = scrollHeight - currentScrollY <= BOTTOM_THRESHOLD;
 
-      // Update refs
-      lastScrollY.current = currentScrollY;
-      lastScrollTime.current = currentTime;
+    // Update refs
+    lastScrollY.current = currentScrollY;
+    lastScrollTime.current = currentTime;
 
-      // Call parent callback
-      onScroll(velocity, isAtBottom);
-    },
-    [onScroll]
-  );
+    // Call parent callback
+    onScroll(velocity, isAtBottom);
+  };
 
   // Type guard for topic
   const topic =
@@ -526,7 +520,7 @@ export const TopicPage = React.memo(function TopicPage({
       )}
     </View>
   );
-});
+}
 
 /**
  * Creates all styles for TopicPage component

--- a/components/topics/TopicProgressBar.tsx
+++ b/components/topics/TopicProgressBar.tsx
@@ -44,7 +44,7 @@ export function TopicProgressBar({
 }: TopicProgressBarProps) {
   const { mode, colors } = useTheme();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
-  const styles = useMemo(() => createStyles(specs, colors), [specs, colors]);
+  const styles = createStyles(specs, colors);
 
   // Clamp progress between 0 and 100
   const clampedProgress = Math.max(0, Math.min(100, progress));

--- a/components/topics/TopicVerseTooltip.tsx
+++ b/components/topics/TopicVerseTooltip.tsx
@@ -18,7 +18,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -160,7 +160,7 @@ export function TopicVerseTooltip({
   }, [byLineData, chapterNumber, verseNumber]);
 
   // Helper to animate open
-  const animateOpen = useCallback(() => {
+  const animateOpen = () => {
     setInternalVisible(true);
     // Record the open timestamp for duration tracking
     openTimestampRef.current = Date.now();
@@ -178,56 +178,53 @@ export function TopicVerseTooltip({
         stiffness: 90,
       }),
     ]).start();
-  }, [backdropOpacity, slideAnim]);
+  };
 
   // Helper to animate close
-  const animateClose = useCallback(
-    (callback?: () => void) => {
-      // Calculate and track duration (Time-Based Analytics)
-      if (openTimestampRef.current && verseNumber) {
-        const durationMs = Date.now() - openTimestampRef.current;
-        const durationSeconds = Math.floor(durationMs / 1000);
+  const animateClose = (callback?: () => void) => {
+    // Calculate and track duration (Time-Based Analytics)
+    if (openTimestampRef.current && verseNumber) {
+      const durationMs = Date.now() - openTimestampRef.current;
+      const durationSeconds = Math.floor(durationMs / 1000);
 
-        // Only track if tooltip was open for >= 3 seconds (filter accidental taps)
-        if (durationSeconds >= TOOLTIP_DURATION_THRESHOLD_SECONDS) {
-          analytics.track(AnalyticsEvent.TOOLTIP_READING_DURATION, {
-            duration_seconds: durationSeconds,
-            bookId,
-            chapterNumber,
-            verseNumber,
-          });
-        }
+      // Only track if tooltip was open for >= 3 seconds (filter accidental taps)
+      if (durationSeconds >= TOOLTIP_DURATION_THRESHOLD_SECONDS) {
+        analytics.track(AnalyticsEvent.TOOLTIP_READING_DURATION, {
+          duration_seconds: durationSeconds,
+          bookId,
+          chapterNumber,
+          verseNumber,
+        });
       }
+    }
 
-      Animated.parallel([
-        Animated.timing(backdropOpacity, {
-          toValue: 0,
-          duration: 300,
-          useNativeDriver: true,
-        }),
-        Animated.spring(slideAnim, {
-          toValue: screenHeight,
-          useNativeDriver: true,
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-          restDisplacementThreshold: 40,
-          restSpeedThreshold: 40,
-        }),
-      ]).start();
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 300,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
 
-      // Force cleanup after 150ms to prevent "spring tail" blocking the UI
-      setTimeout(() => {
-        setInternalVisible(false);
-        setExpanded(true); // Reset to default state
-        expansionAnim.setValue(1);
-        hasTrackedOpen.current = false; // Reset tracking flag
-        openTimestampRef.current = null; // Reset open timestamp
-        if (callback) callback();
-      }, 150);
-    },
-    [backdropOpacity, slideAnim, screenHeight, expansionAnim, bookId, chapterNumber, verseNumber]
-  );
+    // Force cleanup after 150ms to prevent "spring tail" blocking the UI
+    setTimeout(() => {
+      setInternalVisible(false);
+      setExpanded(true); // Reset to default state
+      expansionAnim.setValue(1);
+      hasTrackedOpen.current = false; // Reset tracking flag
+      openTimestampRef.current = null; // Reset open timestamp
+      if (callback) callback();
+    }, 150);
+  };
 
   // Handle expansion animation
   useEffect(() => {
@@ -261,7 +258,9 @@ export function TopicVerseTooltip({
     }
   }, [
     visible,
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization
     animateOpen,
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization
     animateClose,
     internalVisible,
     expansionAnim,
@@ -271,17 +270,18 @@ export function TopicVerseTooltip({
   ]);
 
   // Handle explicit dismiss (user action)
-  const handleDismiss = useCallback(() => {
+  const handleDismiss = () => {
     animateClose(() => {
       onClose();
     });
-  }, [animateClose, onClose]);
+  };
 
   // Auto-close tooltip when switching to insight-only screen (right-full mode)
   useEffect(() => {
     if (visible && splitViewMode === 'right-full') {
       handleDismiss();
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of handleDismiss
   }, [visible, splitViewMode, handleDismiss]);
 
   // Build verse reference title

--- a/components/ui/ReadingProgressBar.tsx
+++ b/components/ui/ReadingProgressBar.tsx
@@ -46,7 +46,7 @@ export function ReadingProgressBar({
 }: ReadingProgressBarProps) {
   const { mode, colors } = useTheme();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
-  const styles = useMemo(() => createStyles(specs, colors), [specs, colors]);
+  const styles = createStyles(specs, colors);
 
   // Clamp progress between 0 and 100
   const clampedProgress = Math.max(0, Math.min(100, progress));

--- a/components/ui/SplitView.tsx
+++ b/components/ui/SplitView.tsx
@@ -86,7 +86,7 @@ export function SplitView({
   const { mode, colors } = useTheme();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
   const insets = useSafeAreaInsets();
-  const styles = useMemo(() => createStyles(specs, colors, insets), [specs, colors, insets]);
+  const styles = createStyles(specs, colors, insets);
 
   // Container dimensions
   const containerWidth = useSharedValue(0);

--- a/components/ui/TextInput.tsx
+++ b/components/ui/TextInput.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import type React from 'react';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import { TextInput as RNTextInput, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import type { getColors } from '@/constants/bible-design-tokens';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -74,7 +74,7 @@ export const TextInput: React.FC<TextInputProps> = ({
   textContentType,
 }) => {
   const { colors } = useTheme();
-  const styles = useMemo(() => createStyles(colors), [colors]);
+  const styles = createStyles(colors);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
   const togglePasswordVisibility = () => {

--- a/contexts/DeviceInfoContext.tsx
+++ b/contexts/DeviceInfoContext.tsx
@@ -6,7 +6,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import React, { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from 'react';
 import { Dimensions } from 'react-native';
 import {
   DEFAULT_SPLIT_RATIO,
@@ -111,23 +111,23 @@ export function DeviceInfoProvider({ children }: { children: React.ReactNode }) 
   }, []);
 
   // Update split ratio
-  const setSplitRatio = useCallback((ratio: number) => {
+  const setSplitRatio = (ratio: number) => {
     const clampedRatio = Math.max(0.1, Math.min(0.9, ratio));
     cachedSplitRatio = clampedRatio;
     setSplitRatioState(clampedRatio);
     AsyncStorage.setItem(SPLIT_RATIO_STORAGE_KEY, clampedRatio.toString()).catch((error) => {
       console.warn('Failed to save split ratio:', error);
     });
-  }, []);
+  };
 
   // Update view mode
-  const setSplitViewMode = useCallback((mode: SplitViewMode) => {
+  const setSplitViewMode = (mode: SplitViewMode) => {
     cachedSplitViewMode = mode;
     setSplitViewModeState(mode);
     AsyncStorage.setItem(SPLIT_VIEW_MODE_STORAGE_KEY, mode).catch((error) => {
       console.warn('Failed to save split view mode:', error);
     });
-  }, []);
+  };
 
   const value = {
     ...deviceInfo,

--- a/contexts/OfflineContext.tsx
+++ b/contexts/OfflineContext.tsx
@@ -6,14 +6,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import React, {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useState,
-  type ReactNode,
-} from 'react';
+import React, { createContext, useContext, useEffect, useState, type ReactNode } from 'react';
 import {
   type DownloadInfo,
   type OfflineManifest,
@@ -167,19 +160,19 @@ export function OfflineProvider({ children }: { children: ReactNode }) {
   }, []);
 
   // Set offline mode
-  const setOfflineModeEnabled = useCallback((enabled: boolean) => {
+  const setOfflineModeEnabled = (enabled: boolean) => {
     setOfflineModeEnabledState(enabled);
     AsyncStorage.setItem(OFFLINE_MODE_KEY, enabled.toString()).catch(console.warn);
-  }, []);
+  };
 
   // Set auto-sync
-  const setAutoSyncEnabled = useCallback((enabled: boolean) => {
+  const setAutoSyncEnabled = (enabled: boolean) => {
     setAutoSyncEnabledState(enabled);
     AsyncStorage.setItem(AUTO_SYNC_KEY, enabled.toString()).catch(console.warn);
-  }, []);
+  };
 
   // Refresh manifest and download info
-  const refreshManifest = useCallback(async () => {
+  const refreshManifest = async () => {
     try {
       const newManifest = await fetchManifest();
       setManifest(newManifest);
@@ -198,145 +191,127 @@ export function OfflineProvider({ children }: { children: ReactNode }) {
       console.error('Failed to refresh manifest:', error);
       throw error;
     }
-  }, []);
+  };
 
   // Download Bible version
-  const downloadBibleVersion = useCallback(
-    async (versionKey: string) => {
-      if (!manifest) {
-        await refreshManifest();
-      }
-      const currentManifest = manifest || (await fetchManifest());
+  const downloadBibleVersion = async (versionKey: string) => {
+    if (!manifest) {
+      await refreshManifest();
+    }
+    const currentManifest = manifest || (await fetchManifest());
 
-      setIsSyncing(true);
-      try {
-        await downloadBibleVersionService(versionKey, currentManifest, setSyncProgress);
+    setIsSyncing(true);
+    try {
+      await downloadBibleVersionService(versionKey, currentManifest, setSyncProgress);
 
-        // Update state
-        setDownloadedBibleVersions((prev) => [...new Set([...prev, versionKey])]);
-        const storage = await getTotalStorageUsed();
-        setTotalStorageUsed(storage);
+      // Update state
+      setDownloadedBibleVersions((prev) => [...new Set([...prev, versionKey])]);
+      const storage = await getTotalStorageUsed();
+      setTotalStorageUsed(storage);
 
-        // Refresh download info
-        const bibleInfo = await getBibleVersionsDownloadInfo(currentManifest);
-        setBibleVersionsInfo(bibleInfo);
-      } finally {
-        setIsSyncing(false);
-        setSyncProgress(null);
-      }
-    },
-    [manifest, refreshManifest]
-  );
+      // Refresh download info
+      const bibleInfo = await getBibleVersionsDownloadInfo(currentManifest);
+      setBibleVersionsInfo(bibleInfo);
+    } finally {
+      setIsSyncing(false);
+      setSyncProgress(null);
+    }
+  };
 
   // Download commentaries
-  const downloadCommentaries = useCallback(
-    async (languageCode: string) => {
-      if (!manifest) {
-        await refreshManifest();
-      }
-      const currentManifest = manifest || (await fetchManifest());
+  const downloadCommentaries = async (languageCode: string) => {
+    if (!manifest) {
+      await refreshManifest();
+    }
+    const currentManifest = manifest || (await fetchManifest());
 
-      setIsSyncing(true);
-      try {
-        await downloadCommentariesService(languageCode, currentManifest, setSyncProgress);
+    setIsSyncing(true);
+    try {
+      await downloadCommentariesService(languageCode, currentManifest, setSyncProgress);
 
-        // Update state
-        setDownloadedCommentaryLanguages((prev) => [...new Set([...prev, languageCode])]);
-        const storage = await getTotalStorageUsed();
-        setTotalStorageUsed(storage);
+      // Update state
+      setDownloadedCommentaryLanguages((prev) => [...new Set([...prev, languageCode])]);
+      const storage = await getTotalStorageUsed();
+      setTotalStorageUsed(storage);
 
-        // Refresh download info
-        const commInfo = await getCommentaryDownloadInfo(currentManifest);
-        setCommentaryInfo(commInfo);
-      } finally {
-        setIsSyncing(false);
-        setSyncProgress(null);
-      }
-    },
-    [manifest, refreshManifest]
-  );
+      // Refresh download info
+      const commInfo = await getCommentaryDownloadInfo(currentManifest);
+      setCommentaryInfo(commInfo);
+    } finally {
+      setIsSyncing(false);
+      setSyncProgress(null);
+    }
+  };
 
   // Download topics
-  const downloadTopics = useCallback(
-    async (languageCode: string) => {
-      if (!manifest) {
-        await refreshManifest();
-      }
-      const currentManifest = manifest || (await fetchManifest());
+  const downloadTopics = async (languageCode: string) => {
+    if (!manifest) {
+      await refreshManifest();
+    }
+    const currentManifest = manifest || (await fetchManifest());
 
-      setIsSyncing(true);
-      try {
-        await downloadTopicsService(languageCode, currentManifest, setSyncProgress);
+    setIsSyncing(true);
+    try {
+      await downloadTopicsService(languageCode, currentManifest, setSyncProgress);
 
-        // Update state
-        setDownloadedTopicLanguages((prev) => [...new Set([...prev, languageCode])]);
-        const storage = await getTotalStorageUsed();
-        setTotalStorageUsed(storage);
+      // Update state
+      setDownloadedTopicLanguages((prev) => [...new Set([...prev, languageCode])]);
+      const storage = await getTotalStorageUsed();
+      setTotalStorageUsed(storage);
 
-        // Refresh download info
-        const topicInfo = await getTopicsDownloadInfo(currentManifest);
-        setTopicsInfo(topicInfo);
-      } finally {
-        setIsSyncing(false);
-        setSyncProgress(null);
-      }
-    },
-    [manifest, refreshManifest]
-  );
+      // Refresh download info
+      const topicInfo = await getTopicsDownloadInfo(currentManifest);
+      setTopicsInfo(topicInfo);
+    } finally {
+      setIsSyncing(false);
+      setSyncProgress(null);
+    }
+  };
 
   // Delete Bible version
-  const deleteBibleVersion = useCallback(
-    async (versionKey: string) => {
-      await removeBibleVersion(versionKey);
-      setDownloadedBibleVersions((prev) => prev.filter((k) => k !== versionKey));
+  const deleteBibleVersion = async (versionKey: string) => {
+    await removeBibleVersion(versionKey);
+    setDownloadedBibleVersions((prev) => prev.filter((k) => k !== versionKey));
 
-      const storage = await getTotalStorageUsed();
-      setTotalStorageUsed(storage);
+    const storage = await getTotalStorageUsed();
+    setTotalStorageUsed(storage);
 
-      if (manifest) {
-        const bibleInfo = await getBibleVersionsDownloadInfo(manifest);
-        setBibleVersionsInfo(bibleInfo);
-      }
-    },
-    [manifest]
-  );
+    if (manifest) {
+      const bibleInfo = await getBibleVersionsDownloadInfo(manifest);
+      setBibleVersionsInfo(bibleInfo);
+    }
+  };
 
   // Delete commentaries
-  const deleteCommentaries = useCallback(
-    async (languageCode: string) => {
-      await removeCommentaries(languageCode);
-      setDownloadedCommentaryLanguages((prev) => prev.filter((c) => c !== languageCode));
+  const deleteCommentaries = async (languageCode: string) => {
+    await removeCommentaries(languageCode);
+    setDownloadedCommentaryLanguages((prev) => prev.filter((c) => c !== languageCode));
 
-      const storage = await getTotalStorageUsed();
-      setTotalStorageUsed(storage);
+    const storage = await getTotalStorageUsed();
+    setTotalStorageUsed(storage);
 
-      if (manifest) {
-        const commInfo = await getCommentaryDownloadInfo(manifest);
-        setCommentaryInfo(commInfo);
-      }
-    },
-    [manifest]
-  );
+    if (manifest) {
+      const commInfo = await getCommentaryDownloadInfo(manifest);
+      setCommentaryInfo(commInfo);
+    }
+  };
 
   // Delete topics
-  const deleteTopics = useCallback(
-    async (languageCode: string) => {
-      await removeTopics(languageCode);
-      setDownloadedTopicLanguages((prev) => prev.filter((c) => c !== languageCode));
+  const deleteTopics = async (languageCode: string) => {
+    await removeTopics(languageCode);
+    setDownloadedTopicLanguages((prev) => prev.filter((c) => c !== languageCode));
 
-      const storage = await getTotalStorageUsed();
-      setTotalStorageUsed(storage);
+    const storage = await getTotalStorageUsed();
+    setTotalStorageUsed(storage);
 
-      if (manifest) {
-        const topicInfo = await getTopicsDownloadInfo(manifest);
-        setTopicsInfo(topicInfo);
-      }
-    },
-    [manifest]
-  );
+    if (manifest) {
+      const topicInfo = await getTopicsDownloadInfo(manifest);
+      setTopicsInfo(topicInfo);
+    }
+  };
 
   // Delete all data
-  const deleteAllData = useCallback(async () => {
+  const deleteAllData = async () => {
     await deleteAllOfflineData();
     setDownloadedBibleVersions([]);
     setDownloadedCommentaryLanguages([]);
@@ -345,10 +320,10 @@ export function OfflineProvider({ children }: { children: ReactNode }) {
     setBibleVersionsInfo([]);
     setCommentaryInfo([]);
     setTopicsInfo([]);
-  }, []);
+  };
 
   // Check for updates
-  const checkForUpdates = useCallback(async () => {
+  const checkForUpdates = async () => {
     setIsSyncing(true);
     try {
       await checkAndSyncUpdates(setSyncProgress);
@@ -385,7 +360,7 @@ export function OfflineProvider({ children }: { children: ReactNode }) {
       setIsSyncing(false);
       setSyncProgress(null);
     }
-  }, [manifest]);
+  };
 
   const value: OfflineContextType = {
     // Mode

--- a/contexts/ToastContext.tsx
+++ b/contexts/ToastContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useState } from 'react';
+import React, { createContext, useContext, useState } from 'react';
 import { Toast } from '@/components/ui/Toast';
 
 interface ToastContextType {
@@ -13,15 +13,15 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [message, setMessage] = useState('');
   const [duration, setDuration] = useState(2000);
 
-  const showToast = useCallback((msg: string, dur = 2000) => {
+  const showToast = (msg: string, dur = 2000) => {
     setMessage(msg);
     setDuration(dur);
     setVisible(true);
-  }, []);
+  };
 
-  const hideToast = useCallback(() => {
+  const hideToast = () => {
     setVisible(false);
-  }, []);
+  };
 
   return (
     <ToastContext.Provider value={{ showToast, hideToast }}>

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,7 @@
 // https://docs.expo.dev/guides/using-eslint/
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
+const reactCompilerPlugin = require('eslint-plugin-react-compiler');
 const biomeConfig = require('eslint-config-biome');
 
 module.exports = defineConfig([
@@ -10,6 +11,9 @@ module.exports = defineConfig([
   // Custom configuration for React Native specific rules
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: {
+      'react-compiler': reactCompilerPlugin,
+    },
     languageOptions: {
       ecmaVersion: 'latest',
       sourceType: 'module',
@@ -23,6 +27,8 @@ module.exports = defineConfig([
       // React Native specific rules that complement Biome
       'react-hooks/exhaustive-deps': 'warn',
       'react-hooks/rules-of-hooks': 'error',
+      // React Compiler rules for Rules of React violations
+      'react-compiler/react-compiler': 'error',
     },
   },
 
@@ -64,6 +70,8 @@ module.exports = defineConfig([
     ],
     rules: {
       '@typescript-eslint/no-require-imports': 'off',
+      // Disable React Compiler rules for test files - they don't go through the compiler
+      'react-compiler/react-compiler': 'off',
     },
   },
 

--- a/hooks/auth/useAppleSignIn.ts
+++ b/hooks/auth/useAppleSignIn.ts
@@ -9,7 +9,7 @@
 
 import * as AppleAuthentication from 'expo-apple-authentication';
 import Constants from 'expo-constants';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Platform } from 'react-native';
 
 /**
@@ -96,16 +96,16 @@ export function useAppleSignIn(): UseAppleSignInReturn {
   /**
    * Reset error state
    */
-  const reset = useCallback(() => {
+  const reset = () => {
     setError(null);
-  }, []);
+  };
 
   /**
    * Trigger Apple Sign-In flow
    *
    * @returns Identity token on success, null on failure or cancellation
    */
-  const signIn = useCallback(async (): Promise<string | null> => {
+  const signIn = async (): Promise<string | null> => {
     if (!isAvailable) {
       setError('Apple Sign-In is not available');
       return null;
@@ -171,7 +171,7 @@ export function useAppleSignIn(): UseAppleSignInReturn {
     } finally {
       setIsLoading(false);
     }
-  }, [isAvailable]);
+  };
 
   return {
     signIn,

--- a/hooks/auth/useGoogleSignIn.ts
+++ b/hooks/auth/useGoogleSignIn.ts
@@ -8,7 +8,7 @@
  */
 
 import Constants from 'expo-constants';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // Safely import Google Sign-In module to prevent crashes in Expo Go
 // biome-ignore lint/suspicious/noExplicitAny: Dynamic import for optional native module
@@ -145,16 +145,16 @@ export function useGoogleSignIn(): UseGoogleSignInReturn {
   /**
    * Reset error state
    */
-  const reset = useCallback(() => {
+  const reset = () => {
     setError(null);
-  }, []);
+  };
 
   /**
    * Trigger Google Sign-In flow
    *
    * @returns ID token on success, null on failure or cancellation
    */
-  const signIn = useCallback(async (): Promise<string | null> => {
+  const signIn = async (): Promise<string | null> => {
     if (!GoogleSignin) {
       setError('Google Sign-In is not supported in this environment');
       return null;
@@ -239,7 +239,7 @@ export function useGoogleSignIn(): UseGoogleSignInReturn {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  };
 
   return {
     signIn,

--- a/hooks/auth/useSSOLogin.ts
+++ b/hooks/auth/useSSOLogin.ts
@@ -7,7 +7,7 @@
  * @see Task Group 5: Login/Signup Screen Integration
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { useAppleSignIn } from './useAppleSignIn';
 import { useGoogleSignIn } from './useGoogleSignIn';
@@ -93,23 +93,23 @@ export function useSSOLogin(): UseSSOLoginReturn {
   /**
    * Reset error state
    */
-  const resetError = useCallback(() => {
+  const resetError = () => {
     setError(null);
     googleSignIn.reset();
     appleSignIn.reset();
-  }, [googleSignIn, appleSignIn]);
+  };
 
   /**
    * Reset success state
    */
-  const resetSuccess = useCallback(() => {
+  const resetSuccess = () => {
     setIsSuccess(false);
-  }, []);
+  };
 
   /**
    * Sign in with Google
    */
-  const signInWithGoogle = useCallback(async () => {
+  const signInWithGoogle = async () => {
     setError(null);
     setIsSuccess(false);
     setIsGoogleLoading(true);
@@ -147,12 +147,12 @@ export function useSSOLogin(): UseSSOLoginReturn {
         setIsGoogleLoading(false);
       }
     }
-  }, [googleSignIn, loginWithSSO]);
+  };
 
   /**
    * Sign in with Apple
    */
-  const signInWithApple = useCallback(async () => {
+  const signInWithApple = async () => {
     setError(null);
     setIsSuccess(false);
     setIsAppleLoading(true);
@@ -190,7 +190,7 @@ export function useSSOLogin(): UseSSOLoginReturn {
         setIsAppleLoading(false);
       }
     }
-  }, [appleSignIn, loginWithSSO]);
+  };
 
   return {
     signInWithGoogle,

--- a/hooks/bible/use-active-tab.ts
+++ b/hooks/bible/use-active-tab.ts
@@ -22,7 +22,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import type { ContentTabType, UseActiveTabResult } from '@/types/bible';
 import { isContentTabType, STORAGE_KEYS } from '@/types/bible';
@@ -90,7 +90,7 @@ export function useActiveTab(): UseActiveTabResult {
     };
   }, []);
 
-  const setActiveTab = useCallback(async (tab: ContentTabType): Promise<void> => {
+  const setActiveTab = async (tab: ContentTabType): Promise<void> => {
     try {
       if (!isContentTabType(tab)) {
         throw new Error(`Invalid tab type: ${tab}. Must be 'summary', 'byline', or 'detailed'.`);
@@ -110,7 +110,7 @@ export function useActiveTab(): UseActiveTabResult {
       setError(storageError);
       console.error('useActiveTab: Failed to persist tab to storage:', storageError);
     }
-  }, []);
+  };
 
   return {
     activeTab,

--- a/hooks/bible/use-active-view.ts
+++ b/hooks/bible/use-active-view.ts
@@ -20,7 +20,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import type { UseActiveViewResult, ViewModeType } from '@/types/bible';
 import { isViewModeType, STORAGE_KEYS } from '@/types/bible';
@@ -85,7 +85,7 @@ export function useActiveView(): UseActiveViewResult {
   /**
    * Set active view and persist to AsyncStorage
    */
-  const setActiveView = useCallback(async (view: ViewModeType): Promise<void> => {
+  const setActiveView = async (view: ViewModeType): Promise<void> => {
     try {
       if (!isViewModeType(view)) {
         throw new Error(`Invalid view type: ${view}. Must be 'bible' or 'explanations'.`);
@@ -108,7 +108,7 @@ export function useActiveView(): UseActiveViewResult {
       setError(storageError);
       console.error('useActiveView: Failed to persist view to storage:', storageError);
     }
-  }, []);
+  };
 
   return {
     activeView,

--- a/hooks/bible/use-bookmarks.ts
+++ b/hooks/bible/use-bookmarks.ts
@@ -30,7 +30,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
@@ -267,130 +267,122 @@ export function useBookmarks(): UseBookmarksResult {
   /**
    * Check if a chapter is bookmarked
    */
-  const isBookmarked = useCallback(
-    (bookId: number, chapterNumber: number): boolean => {
-      return bookmarks.some((b) => b.book_id === bookId && b.chapter_number === chapterNumber);
-    },
-    [bookmarks]
-  );
+  const isBookmarked = (bookId: number, chapterNumber: number): boolean => {
+    return bookmarks.some((b) => b.book_id === bookId && b.chapter_number === chapterNumber);
+  };
 
   /**
    * Add a bookmark with optimistic update
    */
-  const addBookmark = useCallback(
-    async (bookId: number, chapterNumber: number): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to add bookmarks');
-        return;
-      }
+  const addBookmark = async (bookId: number, chapterNumber: number): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to add bookmarks');
+      return;
+    }
 
-      // Call mutation
-      await addMutation.mutateAsync({
-        body: {
-          user_id: user.id,
-          book_id: bookId,
-          chapter_number: chapterNumber,
-        },
-      } as PostBibleBookBookmarkAddData);
-    },
-    [isAuthenticated, user?.id, addMutation]
-  );
+    // Call mutation
+    await addMutation.mutateAsync({
+      body: {
+        user_id: user.id,
+        book_id: bookId,
+        chapter_number: chapterNumber,
+      },
+    } as PostBibleBookBookmarkAddData);
+  };
 
   /**
    * Remove a bookmark with optimistic update
    */
-  const removeBookmark = useCallback(
-    async (bookId: number, chapterNumber: number): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to remove bookmarks');
-        return;
-      }
+  const removeBookmark = async (bookId: number, chapterNumber: number): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to remove bookmarks');
+      return;
+    }
 
-      // Call mutation
-      await removeMutation.mutateAsync({
-        query: {
-          user_id: user.id,
-          book_id: String(bookId),
-          chapter_number: String(chapterNumber),
-        },
-      } as DeleteBibleBookBookmarkRemoveData);
-    },
-    [isAuthenticated, user?.id, removeMutation]
-  );
+    // Call mutation
+    await removeMutation.mutateAsync({
+      query: {
+        user_id: user.id,
+        book_id: String(bookId),
+        chapter_number: String(chapterNumber),
+      },
+    } as DeleteBibleBookBookmarkRemoveData);
+  };
 
   /**
    * Manually refetch bookmarks from API
    */
-  const refetchBookmarks = useCallback(async (): Promise<void> => {
+  const refetchBookmarks = async (): Promise<void> => {
     if (isAuthenticated && user?.id) {
       await refetch();
     }
-  }, [isAuthenticated, user?.id, refetch]);
+  };
 
   /**
    * Check if an insight is bookmarked
    */
-  const isInsightBookmarked = useCallback(
-    (bookId: number, chapterNumber: number, insightType: ContentTabType): boolean => {
-      return bookmarks.some(
-        (b: Bookmark) =>
-          b.book_id === bookId &&
-          b.chapter_number === chapterNumber &&
-          b.insight_type === insightType
-      );
-    },
-    [bookmarks]
-  );
+  const isInsightBookmarked = (
+    bookId: number,
+    chapterNumber: number,
+    insightType: ContentTabType
+  ): boolean => {
+    return bookmarks.some(
+      (b: Bookmark) =>
+        b.book_id === bookId && b.chapter_number === chapterNumber && b.insight_type === insightType
+    );
+  };
 
   /**
    * Add an insight bookmark with optimistic update
    */
-  const addInsightBookmark = useCallback(
-    async (bookId: number, chapterNumber: number, insightType: ContentTabType): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to add insight bookmarks');
-        return;
-      }
+  const addInsightBookmark = async (
+    bookId: number,
+    chapterNumber: number,
+    insightType: ContentTabType
+  ): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to add insight bookmarks');
+      return;
+    }
 
-      // Call mutation with insight_type
-      await addMutation.mutateAsync({
-        body: {
-          user_id: user.id,
-          book_id: bookId,
-          chapter_number: chapterNumber,
-          insight_type: insightType,
-        },
-      } as PostBibleBookBookmarkAddData);
-    },
-    [isAuthenticated, user?.id, addMutation]
-  );
+    // Call mutation with insight_type
+    await addMutation.mutateAsync({
+      body: {
+        user_id: user.id,
+        book_id: bookId,
+        chapter_number: chapterNumber,
+        insight_type: insightType,
+      },
+    } as PostBibleBookBookmarkAddData);
+  };
 
   /**
    * Remove an insight bookmark with optimistic update
    */
-  const removeInsightBookmark = useCallback(
-    async (bookId: number, chapterNumber: number, insightType: ContentTabType): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to remove insight bookmarks');
-        return;
-      }
+  const removeInsightBookmark = async (
+    bookId: number,
+    chapterNumber: number,
+    insightType: ContentTabType
+  ): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to remove insight bookmarks');
+      return;
+    }
 
-      // Call mutation with insight_type
-      await removeMutation.mutateAsync({
-        query: {
-          user_id: user.id,
-          book_id: String(bookId),
-          chapter_number: String(chapterNumber),
-          insight_type: insightType,
-        },
-      } as DeleteBibleBookBookmarkRemoveData);
-    },
-    [isAuthenticated, user?.id, removeMutation]
-  );
+    // Call mutation with insight_type
+    await removeMutation.mutateAsync({
+      query: {
+        user_id: user.id,
+        book_id: String(bookId),
+        chapter_number: String(chapterNumber),
+        insight_type: insightType,
+      },
+    } as DeleteBibleBookBookmarkRemoveData);
+  };
 
   // Combine auth and query loading states
   // Loading if:

--- a/hooks/bible/use-highlights.ts
+++ b/hooks/bible/use-highlights.ts
@@ -45,7 +45,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import type { HighlightColor } from '@/constants/highlight-colors';
 import { useAuth } from '@/contexts/AuthContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
@@ -462,110 +462,106 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
   /**
    * Check if a verse range has a highlight
    */
-  const isHighlighted = useCallback(
-    (startVerse: number, endVerse: number, startChar?: number, endChar?: number): boolean => {
-      const highlights = fetchAllHighlights ? allHighlights : chapterHighlights;
+  const isHighlighted = (
+    startVerse: number,
+    endVerse: number,
+    startChar?: number,
+    endChar?: number
+  ): boolean => {
+    const highlights = fetchAllHighlights ? allHighlights : chapterHighlights;
 
-      return highlights.some((h) => {
-        // Check verse range overlap
-        const verseOverlap = h.start_verse <= endVerse && h.end_verse >= startVerse;
+    return highlights.some((h) => {
+      // Check verse range overlap
+      const verseOverlap = h.start_verse <= endVerse && h.end_verse >= startVerse;
 
-        if (!verseOverlap) return false;
+      if (!verseOverlap) return false;
 
-        // If character positions are specified, only consider highlights with character positions
-        if (startChar !== undefined && endChar !== undefined) {
-          // If highlight doesn't have character positions, it doesn't match character-level query
-          if (h.start_char === null || h.end_char === null) return false;
+      // If character positions are specified, only consider highlights with character positions
+      if (startChar !== undefined && endChar !== undefined) {
+        // If highlight doesn't have character positions, it doesn't match character-level query
+        if (h.start_char === null || h.end_char === null) return false;
 
-          // Check character overlap
-          return (h.start_char as number) <= endChar && (h.end_char as number) >= startChar;
-        }
+        // Check character overlap
+        return (h.start_char as number) <= endChar && (h.end_char as number) >= startChar;
+      }
 
-        // For verse-level queries (no character positions), any verse overlap matches
-        return true;
-      });
-    },
-    [allHighlights, chapterHighlights, fetchAllHighlights]
-  );
+      // For verse-level queries (no character positions), any verse overlap matches
+      return true;
+    });
+  };
 
   /**
    * Add a highlight with optimistic update
    */
-  const addHighlight = useCallback(
-    async (params: AddHighlightParams): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to add highlights');
-        return;
-      }
+  const addHighlight = async (params: AddHighlightParams): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to add highlights');
+      return;
+    }
 
-      await addMutation.mutateAsync({
-        body: {
-          user_id: user.id,
-          book_id: params.bookId,
-          chapter_number: params.chapterNumber,
-          start_verse: params.startVerse,
-          end_verse: params.endVerse,
-          color: params.color,
-          start_char: params.startChar,
-          end_char: params.endChar,
-          selected_text: params.selectedText,
-        },
-      });
-    },
-    [isAuthenticated, user?.id, addMutation]
-  );
+    await addMutation.mutateAsync({
+      body: {
+        user_id: user.id,
+        book_id: params.bookId,
+        chapter_number: params.chapterNumber,
+        start_verse: params.startVerse,
+        end_verse: params.endVerse,
+        color: params.color,
+        start_char: params.startChar,
+        end_char: params.endChar,
+        selected_text: params.selectedText,
+      },
+    });
+  };
 
   /**
    * Update highlight color with optimistic update
    */
-  const updateHighlightColor = useCallback(
-    async (highlightId: number, color: HighlightColor): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to update highlights');
-        return;
-      }
+  const updateHighlightColor = async (
+    highlightId: number,
+    color: HighlightColor
+  ): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to update highlights');
+      return;
+    }
 
-      // Call mutation
-      await updateMutation.mutateAsync({
-        path: {
-          highlight_id: highlightId,
-        },
-        body: {
-          user_id: user.id,
-          color,
-        },
-      } as PutBibleHighlightByHighlightIdData);
-    },
-    [isAuthenticated, user?.id, updateMutation]
-  );
+    // Call mutation
+    await updateMutation.mutateAsync({
+      path: {
+        highlight_id: highlightId,
+      },
+      body: {
+        user_id: user.id,
+        color,
+      },
+    } as PutBibleHighlightByHighlightIdData);
+  };
 
   /**
    * Delete highlight with optimistic update
    */
-  const deleteHighlight = useCallback(
-    async (highlightId: number): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to delete highlights');
-        return;
-      }
+  const deleteHighlight = async (highlightId: number): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to delete highlights');
+      return;
+    }
 
-      // Call mutation
-      await deleteMutation.mutateAsync({
-        path: {
-          highlight_id: highlightId,
-        },
-      } as DeleteBibleHighlightByHighlightIdData);
-    },
-    [isAuthenticated, user?.id, deleteMutation]
-  );
+    // Call mutation
+    await deleteMutation.mutateAsync({
+      path: {
+        highlight_id: highlightId,
+      },
+    } as DeleteBibleHighlightByHighlightIdData);
+  };
 
   /**
    * Manually refetch highlights from API
    */
-  const refetchHighlights = useCallback(async (): Promise<void> => {
+  const refetchHighlights = async (): Promise<void> => {
     if (isAuthenticated && user?.id) {
       if (fetchAllHighlights) {
         await refetchAll();
@@ -573,7 +569,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
         await refetchChapter();
       }
     }
-  }, [isAuthenticated, user?.id, fetchAllHighlights, refetchAll, refetchChapter]);
+  };
 
   // Combine auth and query loading states
   const isFetchingHighlights =

--- a/hooks/bible/use-last-read-position.ts
+++ b/hooks/bible/use-last-read-position.ts
@@ -38,7 +38,7 @@
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { LastReadPosition, UseLastReadPositionResult } from '@/types/bible';
 import { STORAGE_KEYS } from '@/types/bible';
 
@@ -127,64 +127,61 @@ export function useLastReadPosition(): UseLastReadPositionResult {
    * Save current reading position to AsyncStorage
    * Automatically adds timestamp
    */
-  const savePosition = useCallback(
-    async (position: Omit<LastReadPosition, 'timestamp'>): Promise<void> => {
-      try {
-        // Validate position data based on type
-        if (position.type === 'bible') {
-          if (
-            typeof position.bookId !== 'number' ||
-            typeof position.chapterNumber !== 'number' ||
-            position.bookId < 1 ||
-            position.bookId > 66 ||
-            position.chapterNumber < 1
-          ) {
-            throw new Error(
-              'Invalid Bible position: bookId must be 1-66 and chapterNumber must be >= 1'
-            );
-          }
-        } else if (position.type === 'topic') {
-          if (typeof position.topicId !== 'string' || position.topicId.length === 0) {
-            throw new Error('Invalid topic position: topicId must be a non-empty string');
-          }
-        } else {
-          throw new Error(`Invalid position type: ${position.type}`);
+  const savePosition = async (position: Omit<LastReadPosition, 'timestamp'>): Promise<void> => {
+    try {
+      // Validate position data based on type
+      if (position.type === 'bible') {
+        if (
+          typeof position.bookId !== 'number' ||
+          typeof position.chapterNumber !== 'number' ||
+          position.bookId < 1 ||
+          position.bookId > 66 ||
+          position.chapterNumber < 1
+        ) {
+          throw new Error(
+            'Invalid Bible position: bookId must be 1-66 and chapterNumber must be >= 1'
+          );
         }
-
-        // Create position object with timestamp
-        const positionWithTimestamp: LastReadPosition = {
-          ...position,
-          timestamp: Date.now(),
-        };
-
-        // Update state immediately for responsive UI
-        setLastPosition(positionWithTimestamp);
-
-        // Persist to storage (async, but don't block UI)
-        await AsyncStorage.setItem(
-          STORAGE_KEYS.LAST_READ_POSITION,
-          JSON.stringify(positionWithTimestamp)
-        );
-
-        // Clear any previous errors
-        setError(null);
-      } catch (err) {
-        // Handle storage write error
-        const storageError =
-          err instanceof Error ? err : new Error('Failed to save last read position');
-        setError(storageError);
-
-        // Log error for debugging but don't throw (graceful degradation)
-        console.error('useLastReadPosition: Failed to persist position to storage:', storageError);
+      } else if (position.type === 'topic') {
+        if (typeof position.topicId !== 'string' || position.topicId.length === 0) {
+          throw new Error('Invalid topic position: topicId must be a non-empty string');
+        }
+      } else {
+        throw new Error(`Invalid position type: ${position.type}`);
       }
-    },
-    []
-  );
+
+      // Create position object with timestamp
+      const positionWithTimestamp: LastReadPosition = {
+        ...position,
+        timestamp: Date.now(),
+      };
+
+      // Update state immediately for responsive UI
+      setLastPosition(positionWithTimestamp);
+
+      // Persist to storage (async, but don't block UI)
+      await AsyncStorage.setItem(
+        STORAGE_KEYS.LAST_READ_POSITION,
+        JSON.stringify(positionWithTimestamp)
+      );
+
+      // Clear any previous errors
+      setError(null);
+    } catch (err) {
+      // Handle storage write error
+      const storageError =
+        err instanceof Error ? err : new Error('Failed to save last read position');
+      setError(storageError);
+
+      // Log error for debugging but don't throw (graceful degradation)
+      console.error('useLastReadPosition: Failed to persist position to storage:', storageError);
+    }
+  };
 
   /**
    * Clear saved reading position from AsyncStorage
    */
-  const clearPosition = useCallback(async (): Promise<void> => {
+  const clearPosition = async (): Promise<void> => {
     try {
       setLastPosition(null);
       await AsyncStorage.removeItem(STORAGE_KEYS.LAST_READ_POSITION);
@@ -195,7 +192,7 @@ export function useLastReadPosition(): UseLastReadPositionResult {
       setError(storageError);
       console.error('useLastReadPosition: Failed to clear position from storage:', storageError);
     }
-  }, []);
+  };
 
   return {
     lastPosition,

--- a/hooks/bible/use-notes.ts
+++ b/hooks/bible/use-notes.ts
@@ -39,7 +39,7 @@
  */
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
@@ -292,127 +292,114 @@ export function useNotes(): UseNotesResult {
   /**
    * Get notes filtered by chapter
    */
-  const getNotesByChapter = useCallback(
-    (bookId: number, chapterNumber: number): Note[] => {
-      return notes.filter(
-        (note) => note.book_id === bookId && note.chapter_number === chapterNumber
-      );
-    },
-    [notes]
-  );
+  const getNotesByChapter = (bookId: number, chapterNumber: number): Note[] => {
+    return notes.filter((note) => note.book_id === bookId && note.chapter_number === chapterNumber);
+  };
 
   /**
    * Check if a chapter has any notes
    */
-  const hasNotes = useCallback(
-    (bookId: number, chapterNumber: number): boolean => {
-      return notes.some((note) => note.book_id === bookId && note.chapter_number === chapterNumber);
-    },
-    [notes]
-  );
+  const hasNotes = (bookId: number, chapterNumber: number): boolean => {
+    return notes.some((note) => note.book_id === bookId && note.chapter_number === chapterNumber);
+  };
 
   /**
    * Add a note with optimistic update
    */
-  const addNote = useCallback(
-    async (bookId: number, chapterNumber: number, content: string): Promise<Note | null> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to add notes');
-        return null;
-      }
-
-      // Validate content
-      if (!content.trim()) {
-        console.error('Note content cannot be empty');
-        return null;
-      }
-
-      // Call mutation
-      const response = await addMutation.mutateAsync({
-        body: {
-          user_id: user.id,
-          book_id: bookId,
-          chapter_number: chapterNumber,
-          content: content.trim(),
-        },
-      } as PostBibleBookNoteAddData);
-
-      if (response?.note) {
-        return {
-          note_id: response.note.note_id,
-          content: response.note.content,
-          created_at: response.note.created_at,
-          updated_at: response.note.updated_at,
-          book_id: bookId,
-          chapter_number: chapterNumber,
-          book_name: '', // Will be populated by UI context
-          verse_number: typeof response.note.verse_id === 'number' ? response.note.verse_id : null,
-        };
-      }
-
+  const addNote = async (
+    bookId: number,
+    chapterNumber: number,
+    content: string
+  ): Promise<Note | null> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to add notes');
       return null;
-    },
-    [isAuthenticated, user?.id, addMutation]
-  );
+    }
+
+    // Validate content
+    if (!content.trim()) {
+      console.error('Note content cannot be empty');
+      return null;
+    }
+
+    // Call mutation
+    const response = await addMutation.mutateAsync({
+      body: {
+        user_id: user.id,
+        book_id: bookId,
+        chapter_number: chapterNumber,
+        content: content.trim(),
+      },
+    } as PostBibleBookNoteAddData);
+
+    if (response?.note) {
+      return {
+        note_id: response.note.note_id,
+        content: response.note.content,
+        created_at: response.note.created_at,
+        updated_at: response.note.updated_at,
+        book_id: bookId,
+        chapter_number: chapterNumber,
+        book_name: '', // Will be populated by UI context
+        verse_number: typeof response.note.verse_id === 'number' ? response.note.verse_id : null,
+      };
+    }
+
+    return null;
+  };
 
   /**
    * Update a note with optimistic update
    */
-  const updateNote = useCallback(
-    async (noteId: string, content: string): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to update notes');
-        return;
-      }
+  const updateNote = async (noteId: string, content: string): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to update notes');
+      return;
+    }
 
-      // Validate content
-      if (!content.trim()) {
-        console.error('Note content cannot be empty');
-        return;
-      }
+    // Validate content
+    if (!content.trim()) {
+      console.error('Note content cannot be empty');
+      return;
+    }
 
-      // Call mutation
-      await updateMutation.mutateAsync({
-        body: {
-          note_id: noteId,
-          content: content.trim(),
-        },
-      } as PutBibleBookNoteUpdateData);
-    },
-    [isAuthenticated, user?.id, updateMutation]
-  );
+    // Call mutation
+    await updateMutation.mutateAsync({
+      body: {
+        note_id: noteId,
+        content: content.trim(),
+      },
+    } as PutBibleBookNoteUpdateData);
+  };
 
   /**
    * Delete a note with optimistic update
    */
-  const deleteNote = useCallback(
-    async (noteId: string): Promise<void> => {
-      // Check authentication
-      if (!isAuthenticated || !user?.id) {
-        console.error('User must be authenticated to delete notes');
-        return;
-      }
+  const deleteNote = async (noteId: string): Promise<void> => {
+    // Check authentication
+    if (!isAuthenticated || !user?.id) {
+      console.error('User must be authenticated to delete notes');
+      return;
+    }
 
-      // Call mutation
-      await deleteMutation.mutateAsync({
-        query: {
-          note_id: noteId,
-        },
-      } as DeleteBibleBookNoteRemoveData);
-    },
-    [isAuthenticated, user?.id, deleteMutation]
-  );
+    // Call mutation
+    await deleteMutation.mutateAsync({
+      query: {
+        note_id: noteId,
+      },
+    } as DeleteBibleBookNoteRemoveData);
+  };
 
   /**
    * Manually refetch notes from API
    */
-  const refetchNotes = useCallback(async (): Promise<void> => {
+  const refetchNotes = async (): Promise<void> => {
     if (isAuthenticated && user?.id) {
       await refetch();
     }
-  }, [isAuthenticated, user?.id, refetch]);
+  };
 
   // Combine auth and query loading states
   // Loading if:

--- a/hooks/bible/use-scroll-depth-tracking.ts
+++ b/hooks/bible/use-scroll-depth-tracking.ts
@@ -17,7 +17,7 @@
  * ```
  */
 
-import { useCallback, useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 
 /**
@@ -63,7 +63,7 @@ export function useScrollDepthTracking(
   /**
    * Handle scroll event - update max depth if current scroll is greater
    */
-  const handleScroll = useCallback((scrollPercent: number) => {
+  const handleScroll = (scrollPercent: number) => {
     // Clamp scroll percent to 0-100
     const clampedPercent = Math.max(0, Math.min(100, scrollPercent));
 
@@ -71,7 +71,7 @@ export function useScrollDepthTracking(
     if (clampedPercent > maxScrollDepthRef.current) {
       maxScrollDepthRef.current = clampedPercent;
     }
-  }, []);
+  };
 
   // Fire event on unmount with max scroll depth
   useEffect(() => {

--- a/hooks/use-native-dictionary.ts
+++ b/hooks/use-native-dictionary.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 import * as Dictionary from '@/modules/dictionary';
 
 interface UseNativeDictionaryResult {
@@ -34,38 +34,32 @@ export function useNativeDictionary(): UseNativeDictionaryResult {
 
   const isAvailable = Dictionary.isNativeDictionaryAvailable();
 
-  const showDefinition = useCallback(
-    async (word: string): Promise<boolean> => {
-      if (!isAvailable) {
-        return false;
-      }
+  const showDefinition = async (word: string): Promise<boolean> => {
+    if (!isAvailable) {
+      return false;
+    }
 
-      setIsLoading(true);
-      setLastWord(word);
+    setIsLoading(true);
+    setLastWord(word);
 
-      try {
-        return await Dictionary.showDefinition(word);
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [isAvailable]
-  );
+    try {
+      return await Dictionary.showDefinition(word);
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
-  const hasDefinition = useCallback(
-    async (word: string): Promise<boolean> => {
-      if (!isAvailable) {
-        return false;
-      }
+  const hasDefinition = async (word: string): Promise<boolean> => {
+    if (!isAvailable) {
+      return false;
+    }
 
-      try {
-        return await Dictionary.hasDefinition(word);
-      } catch {
-        return false;
-      }
-    },
-    [isAvailable]
-  );
+    try {
+      return await Dictionary.hasDefinition(word);
+    } catch {
+      return false;
+    }
+  };
 
   return {
     showDefinition,

--- a/hooks/use-text-selection.ts
+++ b/hooks/use-text-selection.ts
@@ -31,7 +31,7 @@
  * ```
  */
 
-import { useCallback, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 /**
  * Selection state for a word or phrase
@@ -155,7 +155,7 @@ export function useTextSelection(): UseTextSelectionReturn {
   /**
    * Select a word at the given position
    */
-  const selectWord = useCallback((input: SelectWordInput) => {
+  const selectWord = (input: SelectWordInput) => {
     const { verseNumber, text, startChar, endChar, tapPosition } = input;
 
     // Clear any pending menu timer
@@ -182,12 +182,12 @@ export function useTextSelection(): UseTextSelectionReturn {
     menuTimerRef.current = setTimeout(() => {
       setIsMenuVisible(true);
     }, 300);
-  }, []);
+  };
 
   /**
    * Clear the current selection
    */
-  const clearSelection = useCallback(() => {
+  const clearSelection = () => {
     if (menuTimerRef.current) {
       clearTimeout(menuTimerRef.current);
       menuTimerRef.current = null;
@@ -195,12 +195,12 @@ export function useTextSelection(): UseTextSelectionReturn {
     setSelection(null);
     setIsMenuVisible(false);
     setMenuPosition({ x: 0, y: 0 });
-  }, []);
+  };
 
   /**
    * Show the menu immediately
    */
-  const showMenu = useCallback(() => {
+  const showMenu = () => {
     if (selection) {
       if (menuTimerRef.current) {
         clearTimeout(menuTimerRef.current);
@@ -208,14 +208,14 @@ export function useTextSelection(): UseTextSelectionReturn {
       }
       setIsMenuVisible(true);
     }
-  }, [selection]);
+  };
 
   /**
    * Hide the menu
    */
-  const hideMenu = useCallback(() => {
+  const hideMenu = () => {
     setIsMenuVisible(false);
-  }, []);
+  };
 
   return {
     selection,

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "eslint": "^9.25.0",
     "eslint-config-biome": "^2.1.3",
     "eslint-config-expo": "~10.0.0",
+    "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "husky": "^9.1.7",
     "jest": "~29.7.0",
     "jest-expo": "~54.0.14",


### PR DESCRIPTION
React Compiler (already enabled in app.json) auto-memoizes components and functions, making manual useMemo, useCallback, and React.memo unnecessary and potentially counterproductive.

Changes:
- Install eslint-plugin-react-compiler for Rules of React validation
- Fix AppErrorBoundary to pass posthog via props instead of module var
- Add 'worklet' directive to BibleNavigationModal useDerivedValue
- Remove useMemo from 39 style factory patterns
- Remove useCallback from 150 event handlers (kept 24 in gesture files)
- Remove all 6 React.memo component wrappers

Remaining memoization:
- 69 useMemo calls (non-style computations, kept intentionally)
- 24 useCallback calls (gesture handlers using runOnJS)