### PR TITLE
Fix chapter picker search box alignment

### DIFF
--- a/components/bible/BibleNavigationModal.tsx
+++ b/components/bible/BibleNavigationModal.tsx
@@ -778,7 +778,7 @@ function BibleNavigationModalComponent({
     return (
       <View style={styles.filterContainer}>
         <View style={styles.filterInputWrapper}>
-          <Ionicons name="search" size={24} color={colors.textTertiary} />
+          <Ionicons name="search" size={18} color={colors.textTertiary} />
           <TextInput
             style={styles.filterInput}
             placeholder={placeholder}
@@ -1243,20 +1243,16 @@ const createStyles = (
       borderRadius: 100,
       height: 36,
       paddingHorizontal: spacing.lg,
-      paddingVertical: 4,
       flexDirection: 'row',
       alignItems: 'center',
-      gap: 4,
+      gap: spacing.sm,
     },
     filterInput: {
       flex: 1,
       fontSize: 14,
       color: colors.textPrimary,
       padding: 0,
-    },
-    searchIcon: {
-      width: 24,
-      height: 24,
+      includeFontPadding: false,
     },
     filterClearButton: {
       position: 'absolute',


### PR DESCRIPTION
## Summary
- Reduce search icon size from 24px to 18px for proper proportion with 14px text
- Increase gap between icon and text from 4px to 8px (`spacing.sm` token)
- Remove `paddingVertical` that was competing with `alignItems: 'center'` for vertical centering
- Add `includeFontPadding: false` on TextInput for consistent Android centering
- Remove unused `searchIcon` style definition

## Test plan
- [ ] Open chapter picker and verify search icon is smaller and vertically centered
- [ ] Verify placeholder text "Filter books..." is vertically centered
- [ ] Verify proper spacing between search icon and placeholder text
- [ ] Verify appearance in both light and dark mode
- [ ] Verify "Filter topics..." tab also looks correct
- [ ] Test on both iOS and Android

Closes #84