### PR TITLE
fix(e2e): fix E2E workflow failures from first run

### DIFF
--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -104,6 +104,7 @@ jobs:
           echo "build_url=https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/$BUILD_ID" >> $GITHUB_OUTPUT
 
       - name: Push JS update
+        continue-on-error: true
         run: |
           npm install -g eas-cli
           eas update --branch e2e-test --message "CI update for ${{ github.sha }}"
@@ -194,6 +195,7 @@ jobs:
 
       - name: Capture emulator logcat
         if: failure()
+        timeout-minutes: 1
         run: adb logcat -d > emulator-logcat.txt || true
 
       - name: Upload emulator logs

--- a/app.config.js
+++ b/app.config.js
@@ -12,7 +12,7 @@ const config = {
     icon: './assets/images/ios-icon.png',
     bundleIdentifier: 'org.versemate.app',
     supportsTablet: true,
-    associatedDomains: ['applinks:app.versemate.org', 'applinks:app.versemate.org'],
+    associatedDomains: ['applinks:app.versemate.org'],
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
       CFBundleURLTypes: [


### PR DESCRIPTION
## Summary
- Remove duplicate `associatedDomains` entry in `app.config.js` that caused `eas update` manifest validation to fail
- Add `continue-on-error: true` to "Push JS update" step so phone tests run even if the update fails (standalone APK has JS bundled)
- Add `timeout-minutes: 1` to logcat capture to prevent hanging when emulator is terminated

## Context
First run of the `maestro-e2e.yml` workflow (from #112) failed because:
1. `eas update` rejected duplicate `applinks:app.versemate.org` entries
2. Phone tests were skipped because they depended on the failed update step
3. `adb logcat -d` hung indefinitely after emulator shutdown

## Test plan
- [ ] CI checks pass
- [ ] Re-trigger Maestro E2E workflow after merge to verify fixes