### PR TITLE
fix(e2e): robust onboarding handling with shared setup flow

### DIFF
--- a/.maestro/auth/auth-flow.yaml
+++ b/.maestro/auth/auth-flow.yaml
@@ -19,34 +19,7 @@ tags:
 # Note: This test verifies UI navigation only.
 # Actual signup/login would require test credentials and API connectivity.
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/bible-reading/bible-reading-flow.yaml
+++ b/.maestro/bible-reading/bible-reading-flow.yaml
@@ -19,32 +19,7 @@ tags:
 # 3. Verify Bible verses are visible (no tabs in Bible view)
 # 4. Verify view switcher icons work
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: tap on localhost to connect to dev server if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-# Dismiss developer menu if shown
-- tapOn:
-    text: "Continue"
-    optional: true
-
-# Dismiss dev tools panel by tapping outside or X button
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load (either Bible chapter or Topic screen)
 - extendedWaitUntil:

--- a/.maestro/bible-reading/view-switcher-flow.yaml
+++ b/.maestro/bible-reading/view-switcher-flow.yaml
@@ -19,30 +19,7 @@ tags:
 # 3. Tab persistence across view switches
 # 4. Tab persistence across chapter changes
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/bookmarks/bookmark-flow.yaml
+++ b/.maestro/bookmarks/bookmark-flow.yaml
@@ -21,34 +21,7 @@ tags:
 # For authenticated bookmark testing, use auth-flow.yaml to login first,
 # then run bookmark-authenticated-flow.yaml (future test).
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/highlights/highlights-flow.yaml
+++ b/.maestro/highlights/highlights-flow.yaml
@@ -17,34 +17,7 @@ tags:
 #
 # Note: Full highlights create/edit/delete testing requires authentication.
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/navigation/chapter-navigation-flow.yaml
+++ b/.maestro/navigation/chapter-navigation-flow.yaml
@@ -17,30 +17,7 @@ tags:
 #
 # Note: FABs auto-hide after scrolling, so we tap the screen to show them
 
-- launchApp:
-    appId: org.versemate.app
-    clearState: true
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to load
 - extendedWaitUntil:

--- a/.maestro/navigation/hamburger-menu-flow.yaml
+++ b/.maestro/navigation/hamburger-menu-flow.yaml
@@ -19,34 +19,7 @@ tags:
 #
 # Note: This test uses testID selectors for reliable interaction
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/navigation/navigation-modal-flow.yaml
+++ b/.maestro/navigation/navigation-modal-flow.yaml
@@ -25,30 +25,7 @@ tags:
 # 5. Select chapter 5 from grid
 # 6. Verify Matthew 5 loads
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to load
 - waitForAnimationToEnd

--- a/.maestro/navigation/tab-switching-flow.yaml
+++ b/.maestro/navigation/tab-switching-flow.yaml
@@ -24,30 +24,7 @@ tags:
 # 5. Switch to Detailed tab
 # 6. Navigate to next chapter -> verify tab persists
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to load
 - waitForAnimationToEnd

--- a/.maestro/notes/notes-flow.yaml
+++ b/.maestro/notes/notes-flow.yaml
@@ -17,34 +17,7 @@ tags:
 #
 # Note: Full notes create/edit/delete testing requires authentication.
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/regression/content-rendering-assertions.yaml
+++ b/.maestro/regression/content-rendering-assertions.yaml
@@ -23,30 +23,7 @@ tags:
 # 2. Navigate to a topic - verify no placeholders
 # 3. Return to Bible - verify no placeholders after round-trip
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Test 1: Bible Screen - No Placeholder Text

--- a/.maestro/regression/skeleton-flash-test.yaml
+++ b/.maestro/regression/skeleton-flash-test.yaml
@@ -29,30 +29,7 @@ tags:
 # - Should NOT show skeleton loader between transitions
 # - Header should update at same time as content updates
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for chapter to load - verify chapter selector is visible
 - assertVisible:

--- a/.maestro/settings/settings-flow.yaml
+++ b/.maestro/settings/settings-flow.yaml
@@ -18,34 +18,7 @@ tags:
 # Note: Theme switching and profile editing are optional as they
 # depend on authentication state and specific UI implementation.
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -1,0 +1,22 @@
+# Shared app setup: launch with clean state, skip onboarding, wait for Bible screen.
+# Usage from any test subfolder: - runFlow: ../shared/setup.yaml
+
+- launchApp:
+    clearState: true
+    appId: org.versemate.app
+
+# Wait for onboarding screen to fully load
+- extendedWaitUntil:
+    visible:
+      text: "Skip"
+    timeout: 30000
+
+# Skip onboarding
+- tapOn:
+    text: "Skip"
+
+# Wait for main Bible screen to load after redirect
+- extendedWaitUntil:
+    visible:
+      id: "chapter-selector-button"
+    timeout: 30000

--- a/.maestro/split-view/landscape-split-view-basic.yaml
+++ b/.maestro/split-view/landscape-split-view-basic.yaml
@@ -27,30 +27,7 @@ tags:
 # This test would have caught the iPad bug where BibleContentPanel
 # showed "SimpleChapterPager placeholder - V3 implementation pending"
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Test 1: Verify Split View Layout Renders

--- a/.maestro/split-view/split-view-bible-sync.yaml
+++ b/.maestro/split-view/split-view-bible-sync.yaml
@@ -34,30 +34,7 @@ tags:
 # 5. Verify both panels update correctly
 # 6. Navigate to a different book entirely
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Test 1: Verify Split View Renders

--- a/.maestro/swipe/book-crossing-swipe-test.yaml
+++ b/.maestro/swipe/book-crossing-swipe-test.yaml
@@ -21,34 +21,7 @@ tags:
 #
 # This tests the OT/NT boundary crossing - the most important cross-book case
 
-- launchApp:
-    appId: org.versemate.app
-    clearState: true
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Wait for any overlays to clear
-- waitForAnimationToEnd
-
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Setup: Navigate to Malachi 4 (last OT chapter)

--- a/.maestro/swipe/swipe-boundary-test.yaml
+++ b/.maestro/swipe/swipe-boundary-test.yaml
@@ -26,34 +26,7 @@ tags:
 # 5. Swipe left - verify we stay on Revelation 22 (boundary blocks)
 # 6. Swipe right - verify can navigate to Revelation 21
 
-- launchApp:
-    appId: org.versemate.app
-    clearState: true
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Wait for any overlays to clear
-- waitForAnimationToEnd
-
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Test 1: Genesis 1 Start Boundary

--- a/.maestro/swipe/swipe-header-sync-test.yaml
+++ b/.maestro/swipe/swipe-header-sync-test.yaml
@@ -26,35 +26,7 @@ tags:
 # - Each swipe advances exactly one chapter
 # - Header text updates correctly after each swipe
 
-- launchApp:
-    appId: org.versemate.app
-    clearState: true
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Wait for any overlays to clear
-- waitForAnimationToEnd
-
-
-# Handle onboarding screen if shown (when clearState was used previously)
-- tapOn:
-    text: "Skip"
-    optional: true
-
-# Wait after skipping onboarding
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Setup: Ensure we start at Genesis 1

--- a/.maestro/swipe/swipe-navigation-basic.yaml
+++ b/.maestro/swipe/swipe-navigation-basic.yaml
@@ -21,30 +21,7 @@ tags:
 # 2. Swipe left -> Genesis 2
 # 3. Swipe right -> Genesis 1
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to load - verify chapter selector is visible
 - assertVisible:

--- a/.maestro/swipe/swipe-navigation-boundaries.yaml
+++ b/.maestro/swipe/swipe-navigation-boundaries.yaml
@@ -18,30 +18,7 @@ tags:
 # Note: Testing Revelation 22 boundary is complex and better tested manually
 # due to the navigation modal behavior.
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load
 - extendedWaitUntil:

--- a/.maestro/topics/topics-reading-flow.yaml
+++ b/.maestro/topics/topics-reading-flow.yaml
@@ -16,34 +16,7 @@ tags:
 # 3. Select a topic from the list
 # 4. Return to Bible chapter
 
-# ============================================
-# Test Setup: Launch App
-# ============================================
-
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load (either chapter or topic screen)
 - extendedWaitUntil:

--- a/.maestro/topics/topics-swipe-navigation.yaml
+++ b/.maestro/topics/topics-swipe-navigation.yaml
@@ -25,30 +25,7 @@ tags:
 # 4. Swipe right again to go to previous topic (circular) - verify header changed
 # 5. Verify FAB buttons work for navigation
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Setup: Navigate to a Known Topic

--- a/.maestro/topics/topics-view-switching.yaml
+++ b/.maestro/topics/topics-view-switching.yaml
@@ -22,30 +22,7 @@ tags:
 # 5. Switch back to Bible view - verify Bible content reappears
 # 6. Swipe to next topic - verify view mode persists
 
-- launchApp:
-    clearState: true
-    appId: org.versemate.app
-
-# For development builds: dismiss dev menu if shown
-- tapOn:
-    text: "http://localhost:8081"
-    optional: true
-
-- tapOn:
-    text: "Continue"
-    optional: true
-
-- tapOn:
-    point: "50%,15%"
-    optional: true
-
-# Handle onboarding screen if shown
-- tapOn:
-    text: "Skip"
-    optional: true
-
-- waitForAnimationToEnd
-
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Setup: Navigate to a Known Topic


### PR DESCRIPTION
## Summary
- Create `.maestro/shared/setup.yaml` — shared app launch flow that properly waits for and dismisses onboarding
- Replace fragile inline setup blocks in all 23 Maestro test files with `- runFlow: ../shared/setup.yaml`
- Net result: **+45 lines, -595 lines** (massive deduplication)

## Root Cause
All phone tests failed on CI because:
1. `clearState: true` wipes AsyncStorage, including `HAS_SEEN_ONBOARDING`
2. The onboarding screen blocks access to the main app
3. The old `tapOn: text: "Skip"` with `optional: true` didn't reliably dismiss it — the button wasn't visible yet when the tap was attempted
4. Tests then immediately asserted main screen elements that didn't exist

Split-view tests passed because they used `extendedWaitUntil` with a 45s timeout instead of immediate assertions.

## Fix
The shared setup flow:
1. Waits for "Skip" button to appear (`extendedWaitUntil`, 30s timeout)
2. Taps Skip (not optional — fails fast if onboarding doesn't load)
3. Waits for main Bible screen (`chapter-selector-button`) to load (30s timeout)

Also removes dev menu dismissal taps that were irrelevant for standalone `e2e-test` builds.

## Test plan
- [ ] CI checks pass
- [ ] Trigger Maestro E2E workflow after merge — navigation tests should now pass