### PR TITLE
fix(e2e): add config section to shared setup flow

### DIFF
--- a/.maestro/shared/setup.yaml
+++ b/.maestro/shared/setup.yaml
@@ -1,3 +1,5 @@
+appId: org.versemate.app
+---
 # Shared app setup: launch with clean state, skip onboarding, wait for Bible screen.
 # Usage from any test subfolder: - runFlow: ../shared/setup.yaml
 


### PR DESCRIPTION
## Summary
- Maestro requires all flow files (including subflows via `runFlow`) to have an `appId` config section with `---` separator
- The shared `setup.yaml` was missing this header, causing `Config Section Required` errors in CI
- Adds `appId: org.versemate.app` + `---` to `.maestro/shared/setup.yaml`

## Context
E2E run [22002534881](https://github.com/verse-mate/verse-mate-mobile/actions/runs/22002534881) failed with:
```
Config Section Required
.maestro/navigation/../shared/setup.yaml:4
Flow files must start with a config section.
```

## Test plan
- [ ] Merge and trigger `maestro-e2e.yml` workflow to verify navigation tests pass