### PR TITLE
fix(e2e): add Pixel 6 profile to phone emulator

### DIFF
--- a/.github/workflows/maestro-e2e.yml
+++ b/.github/workflows/maestro-e2e.yml
@@ -117,6 +117,7 @@ jobs:
           api-level: 34
           target: google_apis
           arch: x86_64
+          profile: pixel_6
           force-avd-creation: true
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           disable-animations: true
@@ -183,7 +184,7 @@ jobs:
           |----------|-------|
           | **Test Target** | $TEST_TARGET |
           | **Android API Level** | 34 |
-          | **Phone Emulator** | Default (x86_64, google_apis) |
+          | **Phone Emulator** | Pixel 6 (x86_64, google_apis) |
           | **Tablet Emulator** | Nexus 10 (2560x1600) |
           | **APK Source** | $APK_SOURCE |
           | **Fingerprint Hash** | \`$FINGERPRINT_HASH\` |


### PR DESCRIPTION
## Summary
- The phone emulator step in `maestro-e2e.yml` was using the default AVD (320x640 at 160dpi) — way too small for the app
- All 4 navigation tests failed because UI elements couldn't render at that resolution
- Adds `profile: pixel_6` to match a realistic phone screen (1080x2400)
- The tablet emulator already had `profile: Nexus 10` which is why split-view tests passed

## Context
E2E run [22003509164](https://github.com/verse-mate/verse-mate-mobile/actions/runs/22003509164) phone test failures:
```
[Failed] Navigation Modal Flow (37s) - id: bible-navigation-modal is visible
[Failed] Chapter Navigation Flow (27s) - "Genesis 1" is visible
[Failed] Hamburger Menu Flow (15s) - id: hamburger-menu is visible
[Failed] Content Tab Switching Flow (28s) - id: chapter-content-tabs is visible
```

Emulator log confirmed: `androidboot.qemu.skin=320x640` / `display: 320x640, dpi: 160x160`

## Test plan
- [ ] Merge and trigger `maestro-e2e.yml` to verify navigation tests pass with Pixel 6 profile