### PR TITLE
fix: Andy's feedback roundup - UI/UX fixes

### DIFF
--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -138,7 +138,7 @@ export default function OnboardingScreen() {
   };
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { paddingTop: insets.top }]}>
       <StatusBar style="light" />
       <PagerView
         style={styles.pagerView}

--- a/components/bible/BibleContentPanel.tsx
+++ b/components/bible/BibleContentPanel.tsx
@@ -158,6 +158,7 @@ export function BibleContentPanel({
           isPreloading={!isCurrent}
           targetVerse={isCurrent ? targetVerse : undefined}
           targetEndVerse={isCurrent ? targetEndVerse : undefined}
+          hideChapterTitle
         />
       );
     },

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -119,6 +119,15 @@ export function BibleExplanationsPanel({
   const touchStartTime = useRef(0);
   const touchStartY = useRef(0);
 
+  // Ref for scroll reset on tab/chapter change
+  const scrollViewRef = useRef<ScrollView>(null);
+
+  // Reset scroll position when tab or chapter changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: deps are intentional triggers for scroll reset
+  useEffect(() => {
+    scrollViewRef.current?.scrollTo({ y: 0, animated: false });
+  }, [activeTab, bookId, chapterNumber]);
+
   // Animate indicator when active tab changes
   useEffect(() => {
     const targetIndex = getTabIndex(activeTab);
@@ -330,6 +339,7 @@ export function BibleExplanationsPanel({
 
       {/* Content Area */}
       <ScrollView
+        ref={scrollViewRef}
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
         showsVerticalScrollIndicator={true}
@@ -533,7 +543,7 @@ function createStyles(
     },
     heading2: {
       fontSize: fontSizes.heading2,
-      fontWeight: fontWeights.semibold,
+      fontWeight: fontWeights.bold,
       lineHeight: fontSizes.heading2 * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xl,

--- a/components/bible/BibleNavigationModal.tsx
+++ b/components/bible/BibleNavigationModal.tsx
@@ -800,6 +800,8 @@ function BibleNavigationModalComponent({
             value={currentFilterText}
             onChangeText={onChangeText}
             returnKeyType="search"
+            autoCorrect={false}
+            autoCapitalize="words"
             accessibilityLabel={placeholder}
             testID={isTopicsMode ? 'topics-search-input' : 'books-search-input'}
           />

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -220,6 +220,8 @@ export interface ChapterPageProps {
   onScroll?: (velocity: number, isAtBottom: boolean) => void;
   /** Callback when user taps the screen */
   onTap?: () => void;
+  /** Hide the chapter title text (used in split view where parent has a header) */
+  hideChapterTitle?: boolean;
 }
 
 /**
@@ -256,6 +258,7 @@ export function ChapterPage({
   targetEndVerse,
   onScroll,
   onTap,
+  hideChapterTitle = false,
 }: ChapterPageProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors); // Use local createStyles for ChapterPage
@@ -775,6 +778,7 @@ export function ChapterPage({
                 chapter={displayChapter}
                 activeTab={activeTab}
                 explanationsOnly={false}
+                hideChapterTitle={hideChapterTitle}
                 onContentLayout={handleContentLayout}
                 onOpenNotes={handleOpenNotes}
                 filteredHighlights={chapterHighlights}

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -157,6 +157,8 @@ interface ChapterReaderProps {
   explanation?: ExplanationContent;
   /** Show only explanations, hide Bible verses (for Explanations view) */
   explanationsOnly?: boolean;
+  /** Hide the chapter title text (used when parent already shows a header) */
+  hideChapterTitle?: boolean;
   /** Callback to report Y-position of verse sections for scrolling */
   onContentLayout?: (sectionPositions: Record<number, number>) => void;
   /** Callback to open notes modal */
@@ -253,6 +255,7 @@ export function ChapterReader({
   activeTab,
   explanation,
   explanationsOnly = false,
+  hideChapterTitle = false,
   onContentLayout,
   onOpenNotes,
   filteredHighlights,
@@ -469,9 +472,11 @@ export function ChapterReader({
       {/* Chapter Title Row with Bookmark, Notes, and Share buttons - Only show in Bible view */}
       {!explanationsOnly && (
         <View style={styles.titleRow} collapsable={false}>
-          <Text style={styles.chapterTitle} accessibilityRole="header">
-            {chapter.title}
-          </Text>
+          {!hideChapterTitle && (
+            <Text style={styles.chapterTitle} accessibilityRole="header">
+              {chapter.title}
+            </Text>
+          )}
           <View style={styles.iconButtons}>
             <BookmarkToggle
               bookId={chapter.bookId}

--- a/components/bible/HamburgerMenu.tsx
+++ b/components/bible/HamburgerMenu.tsx
@@ -32,6 +32,7 @@ import {
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   Share,
   StyleSheet,
   Text,
@@ -321,79 +322,91 @@ export function HamburgerMenu({ visible, onClose }: HamburgerMenuProps) {
                   </Pressable>
                 </View>
 
-                {/* User Profile Section (Button) */}
-                <Pressable
-                  onPress={handleProfilePress}
-                  style={({ pressed }) => [styles.userSection, pressed && styles.menuItemPressed]}
+                <ScrollView
+                  style={styles.menuScrollContent}
+                  contentContainerStyle={styles.menuScrollContainer}
+                  showsVerticalScrollIndicator={false}
+                  bounces={false}
                 >
-                  <View style={styles.avatarContainer}>
-                    <Avatar url={user?.imageSrc} size={40} />
-                  </View>
-                  <View style={styles.userInfo}>
-                    <Text style={styles.userName}>
-                      {isAuthenticated && user
-                        ? `${user.firstName} ${user.lastName}`
-                        : 'Guest User'}
-                    </Text>
-                    <Text style={styles.userEmail}>
-                      {isAuthenticated && user ? user.email : 'Sign in to sync your data'}
-                    </Text>
-                  </View>
-                </Pressable>
+                  {/* User Profile Section (Button) */}
+                  <Pressable
+                    onPress={handleProfilePress}
+                    style={({ pressed }) => [styles.userSection, pressed && styles.menuItemPressed]}
+                  >
+                    <View style={styles.avatarContainer}>
+                      <Avatar url={user?.imageSrc} size={40} />
+                    </View>
+                    <View style={styles.userInfo}>
+                      <Text style={styles.userName}>
+                        {isAuthenticated && user
+                          ? `${user.firstName} ${user.lastName}`
+                          : 'Guest User'}
+                      </Text>
+                      <Text style={styles.userEmail}>
+                        {isAuthenticated && user ? user.email : 'Sign in to sync your data'}
+                      </Text>
+                    </View>
+                  </Pressable>
 
-                {/* Menu Items */}
-                <View style={styles.menuItems}>
-                  {regularMenuItems.map((item) => (
+                  {/* Menu Items */}
+                  <View style={styles.menuItems}>
+                    {regularMenuItems.map((item) => (
+                      <Pressable
+                        key={item.id}
+                        style={({ pressed }) => [
+                          styles.menuItem,
+                          pressed && styles.menuItemPressed,
+                        ]}
+                        onPress={() => handleItemPress(item)}
+                        accessibilityLabel={item.label}
+                        accessibilityRole="button"
+                        testID={`menu-item-${item.id}`}
+                      >
+                        <View style={styles.menuIconContainer}>
+                          <item.icon width={24} height={24} color={colors.textPrimary} />
+                          {item.id === 'help' && hasUnreadHelp && (
+                            <View style={styles.unreadBadge} />
+                          )}
+                        </View>
+                        <Text style={styles.menuItemText}>{item.label}</Text>
+                      </Pressable>
+                    ))}
+                  </View>
+
+                  {/* Authentication Action (Login/Logout) */}
+                  <View style={styles.footer}>
                     <Pressable
-                      key={item.id}
                       style={({ pressed }) => [styles.menuItem, pressed && styles.menuItemPressed]}
-                      onPress={() => handleItemPress(item)}
-                      accessibilityLabel={item.label}
-                      accessibilityRole="button"
-                      testID={`menu-item-${item.id}`}
+                      onPress={async () => {
+                        if (isAuthenticated) {
+                          await logout();
+                          showSuccess('Logged Out', 'You have been logged out successfully.');
+                          onClose();
+                        } else {
+                          onClose();
+                          router.push('/auth/login');
+                        }
+                      }}
+                      testID={isAuthenticated ? 'menu-item-logout' : 'menu-item-login'}
                     >
                       <View style={styles.menuIconContainer}>
-                        <item.icon width={24} height={24} color={colors.textPrimary} />
-                        {item.id === 'help' && hasUnreadHelp && <View style={styles.unreadBadge} />}
+                        <IconProfile
+                          width={24}
+                          height={24}
+                          color={isAuthenticated ? colors.error : colors.gold}
+                        />
                       </View>
-                      <Text style={styles.menuItemText}>{item.label}</Text>
+                      <Text
+                        style={[
+                          styles.menuItemText,
+                          { color: isAuthenticated ? colors.error : colors.gold },
+                        ]}
+                      >
+                        {isAuthenticated ? 'Log Out' : 'Log In'}
+                      </Text>
                     </Pressable>
-                  ))}
-                </View>
-
-                {/* Authentication Action (Login/Logout) */}
-                <View style={styles.footer}>
-                  <Pressable
-                    style={({ pressed }) => [styles.menuItem, pressed && styles.menuItemPressed]}
-                    onPress={async () => {
-                      if (isAuthenticated) {
-                        await logout();
-                        showSuccess('Logged Out', 'You have been logged out successfully.');
-                        onClose();
-                      } else {
-                        onClose();
-                        router.push('/auth/login');
-                      }
-                    }}
-                    testID={isAuthenticated ? 'menu-item-logout' : 'menu-item-login'}
-                  >
-                    <View style={styles.menuIconContainer}>
-                      <IconProfile
-                        width={24}
-                        height={24}
-                        color={isAuthenticated ? colors.error : colors.gold}
-                      />
-                    </View>
-                    <Text
-                      style={[
-                        styles.menuItemText,
-                        { color: isAuthenticated ? colors.error : colors.gold },
-                      ]}
-                    >
-                      {isAuthenticated ? 'Log Out' : 'Log In'}
-                    </Text>
-                  </Pressable>
-                </View>
+                  </View>
+                </ScrollView>
               </Animated.View>
             </Animated.View>
           </GestureDetector>
@@ -444,6 +457,12 @@ const createStyles = (
       elevation: 5,
       paddingHorizontal: 16, // Figma uses padding
       borderTopLeftRadius: 24,
+    },
+    menuScrollContent: {
+      flex: 1,
+    },
+    menuScrollContainer: {
+      flexGrow: 1,
     },
     headerControls: {
       flexDirection: 'row',

--- a/components/bible/VerseMateTooltip.tsx
+++ b/components/bible/VerseMateTooltip.tsx
@@ -483,7 +483,7 @@ export function VerseMateTooltip({
 
   // Animated style for expansion (Reanimated — runs on UI thread)
   const insightAnimatedStyle = useAnimatedStyle(() => ({
-    maxHeight: interpolate(expansionAnim.value, [0, 1], [0, 400]),
+    maxHeight: interpolate(expansionAnim.value, [0, 1], [0, screenHeight * 0.6]),
     opacity: interpolate(expansionAnim.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 

--- a/components/bible/WordDefinitionTooltip.tsx
+++ b/components/bible/WordDefinitionTooltip.tsx
@@ -606,7 +606,7 @@ const createStyles = (
     overlay: {
       flex: 1,
       justifyContent: 'flex-end',
-      alignItems: tooltipWidth ? 'flex-end' : 'stretch',
+      alignItems: tooltipWidth ? 'center' : 'stretch',
     },
     backdrop: {
       ...StyleSheet.absoluteFillObject,


### PR DESCRIPTION
## Summary
Addresses multiple UI/UX issues from Andy's feedback (closes #129).

**Fixed:**
- Disable autocorrect on Bible book search input (Isa → USA)
- Reset commentary scroll to top on tab/chapter change
- Bold heading2 in detailed insights for better scannability
- Fix duplicate chapter title in landscape split view (`hideChapterTitle` prop)
- Make hamburger menu scrollable for landscape overflow
- Add top safe area padding to onboarding screen
- Increase insight tooltip maxHeight from 400px to 60% screen height
- Center dictionary popup on iPad instead of right-aligning

**Investigated & confirmed working as designed:**
- Warning icon next to profile (shows on save error, auto-clears)
- Floating menu after login (not reproducible)

**Deferred to separate ticket:**
- Dictionary in Topics view (requires TopicText architecture change)

## Files changed
- `BibleNavigationModal.tsx` — autoCorrect/autoCapitalize on search input
- `BibleExplanationsPanel.tsx` — scroll reset + bold heading2
- `BibleContentPanel.tsx` / `ChapterPage.tsx` / `ChapterReader.tsx` — hideChapterTitle for split view
- `HamburgerMenu.tsx` — ScrollView wrapper for landscape
- `onboarding.tsx` — top safe area padding
- `VerseMateTooltip.tsx` — dynamic maxHeight
- `WordDefinitionTooltip.tsx` — centered overlay on iPad

## Test plan
- [ ] Verify autocorrect is disabled when searching books (type "Isa")
- [ ] Switch commentary tabs and confirm scroll resets to top
- [ ] Navigate chapters and confirm commentary scroll resets
- [ ] Rotate to landscape — no duplicate chapter title in split view
- [ ] Open hamburger menu in landscape — items are scrollable
- [ ] Check onboarding screen — text doesn't overlap status bar
- [ ] Open verse insight on a long passage — tooltip uses more vertical space
- [ ] Long-press a word on iPad — dictionary popup is centered

Closes #129