### PR TITLE
fix: reset FAB visibility timer on chapter navigation (#128)

### DIFF
--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -175,6 +175,7 @@ export default function ChapterScreen() {
     visible: fabVisible,
     handleScroll,
     handleTap,
+    showButtons,
   } = useFABVisibility({
     initialVisible: true,
   });
@@ -313,12 +314,15 @@ export default function ChapterScreen() {
   const handlePrevious = useCallback(() => {
     if (!canGoPrevious || !prevChapter) return;
 
+    // Reset FAB visibility timer so arrows stay visible during rapid navigation
+    showButtons();
+
     // Haptic feedback for button press
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     // Update state via hook (V3: single source of truth)
     navigateToChapter(prevChapter.bookId, prevChapter.chapterNumber);
-  }, [canGoPrevious, prevChapter, navigateToChapter]);
+  }, [canGoPrevious, prevChapter, navigateToChapter, showButtons]);
 
   /**
    * Navigate to next chapter
@@ -328,12 +332,15 @@ export default function ChapterScreen() {
   const handleNext = useCallback(() => {
     if (!canGoNext || !nextChapter) return;
 
+    // Reset FAB visibility timer so arrows stay visible during rapid navigation
+    showButtons();
+
     // Haptic feedback for button press
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
 
     // Update state via hook (V3: single source of truth)
     navigateToChapter(nextChapter.bookId, nextChapter.chapterNumber);
-  }, [canGoNext, nextChapter, navigateToChapter]);
+  }, [canGoNext, nextChapter, navigateToChapter, showButtons]);
 
   /**
    * Render chapter page content for SimpleChapterPager


### PR DESCRIPTION
## Summary
- Navigation arrows (FABs) disappeared on a fixed 3-second timer that was never reset by button presses, causing accidental verse taps during rapid chapter navigation
- Now calls `showButtons()` in `handlePrevious`/`handleNext` to reset the idle countdown on each interaction

## Changes
- `app/bible/[bookId]/[chapterNumber].tsx` — destructure `showButtons` from `useFABVisibility` and call it at the start of both navigation handlers

## Test plan
- [ ] Open any chapter, tap navigation arrows rapidly (10+ times) — arrows should stay visible throughout
- [ ] Stop tapping — arrows should fade after 3 seconds of inactivity
- [ ] Test in split-view/landscape mode (same handlers are reused)
- [ ] Verify normal scroll-based show/hide behavior is unchanged

Closes #128