### PR TITLE
Fix null reference crash in Help screen (#79)

### DIFF
--- a/app/help.tsx
+++ b/app/help.tsx
@@ -84,9 +84,7 @@ export default function HelpScreen() {
     setIsLoading(true);
     try {
       const { data } = await getSupportConversations();
-      if (data) {
-        setConversations(data.conversations);
-      }
+      setConversations(data?.conversations ?? []);
     } catch (error) {
       console.error('Failed to load conversations:', error);
     } finally {
@@ -97,9 +95,7 @@ export default function HelpScreen() {
   const loadMessages = useCallback(async (id: string) => {
     try {
       const { data } = await getSupportMessages(id);
-      if (data) {
-        setMessages(data.messages);
-      }
+      setMessages(data?.messages ?? []);
     } catch (error) {
       console.error('Failed to load messages:', error);
     }


### PR DESCRIPTION
## Summary
- Fixes the `Cannot read property 'length' of undefined` crash on the Help screen reported in #79
- The bug occurred when `getSupportConversations()` or `getSupportMessages()` returned a response where `data.conversations` / `data.messages` was undefined — the state setter stored `undefined`, and subsequent renders crashed on `.length` access
- Uses nullish coalescing (`data?.conversations ?? []`) to ensure state is always a valid array

## Changes
- `app/help.tsx`: Added null-safe fallbacks in `loadConversations` and `loadMessages`

## Test plan
- [ ] Open the Help screen while authenticated — conversations load normally
- [ ] Force an API error / empty response — screen shows empty state instead of crashing
- [ ] Send a message and verify message list renders correctly

Closes #79