### PR TITLE
fix: prevent verse text truncation in portrait paragraph mode

### DIFF
--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -640,7 +640,7 @@ export function ChapterReader({
                                 onAutoHighlightPress={handleAutoHighlightPress}
                                 onVerseTap={handleVerseTap}
                                 onWordSelect={handleWordSelect}
-                                style={styles.verseText}
+                                style={styles.verseTextInline}
                                 isVisible={isVerseVisible(group[0].verseNumber)}
                               />
                             </Text>
@@ -836,6 +836,12 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
     },
     verseText: {
       flex: 1,
+      fontSize: fontSizes.bodyLarge,
+      fontWeight: fontWeights.regular,
+      lineHeight: fontSizes.bodyLarge * 2.0,
+      color: colors.textPrimary,
+    },
+    verseTextInline: {
       fontSize: fontSizes.bodyLarge,
       fontWeight: fontWeights.regular,
       lineHeight: fontSizes.bodyLarge * 2.0,


### PR DESCRIPTION
## Summary
- Fixes text being cut off at the end of verses in portrait mode (e.g., verse 21 in Luke 17 showing "For behol" instead of the full text)
- Root cause: `flex: 1` on `HighlightedText` (a nested inline `<Text>`) inside the paragraph `<Text>` wrapper causes React Native to incorrectly measure text width, truncating instead of wrapping
- Added `verseTextInline` style (without `flex: 1`) for paragraph mode; verse-row mode keeps `flex: 1` as intended

## Test plan
- [ ] Open Luke 17 in portrait mode — verify verse 21 text wraps fully ("For behold, the kingdom of God is in your midst.")
- [ ] Check other long verses in portrait mode for proper wrapping
- [ ] Verify landscape/split-view rendering is unchanged
- [ ] Verify verse-row mode (non-paragraph) still renders correctly