### PR TITLE
Fix verse-text-1 visibility: use verse-group View testID

### DIFF
--- a/.maestro/bible-reading/verse-insight-flow.yaml
+++ b/.maestro/bible-reading/verse-insight-flow.yaml
@@ -11,9 +11,12 @@ tags:
 # Verse Insight Bottom Sheet E2E Test
 #
 # This flow tests verse insight panel functionality:
-# 1. Switch to Bible view and tap a verse
-# 2. Verify insight panel / bottom sheet appears
+# 1. Wait for Bible view with verse text to fully load
+# 2. Tap a verse to open insight panel
 # 3. Dismiss the panel and verify return to Bible view
+#
+# Note: After setup.yaml (clearState), the app defaults to Bible view.
+# Do NOT tap bible-view-toggle — that would switch AWAY to Explanations.
 
 - runFlow: ../shared/setup.yaml
 
@@ -23,18 +26,12 @@ tags:
       id: "chapter-selector-button"
     timeout: 30000
 
-# Switch to Bible view to see verse text (may already be in Bible view)
-- tapOn:
-    id: "bible-view-toggle"
-    optional: true
-
-- waitForAnimationToEnd
-
-# Wait for verse text to render
+# Wait for verse text to render in the default Bible view
+# On slow CI emulators, HighlightedText may take time after API fetch
 - extendedWaitUntil:
     visible:
       id: "verse-text-1"
-    timeout: 30000
+    timeout: 60000
 
 # ============================================
 # Test 1: Tap Verse to Open Insight
@@ -70,10 +67,6 @@ tags:
 # Verify we're back on Bible verse view
 - assertVisible:
     id: "chapter-selector-button"
-
-# Verify Bible view toggle is still visible
-- assertVisible:
-    id: "bible-view-toggle"
 
 # ============================================
 # Test Complete

--- a/.maestro/bible-reading/verse-insight-flow.yaml
+++ b/.maestro/bible-reading/verse-insight-flow.yaml
@@ -30,10 +30,10 @@ tags:
 
 - waitForAnimationToEnd
 
-# Scroll to find verse-text-1 (handles slow rendering on CI emulators)
+# Wait for verse group to render (View element, more reliable than nested Text)
 - scrollUntilVisible:
     element:
-      id: "verse-text-1"
+      id: "verse-group-1"
     direction: DOWN
     timeout: 60000
 
@@ -41,9 +41,9 @@ tags:
 # Test 1: Tap Verse to Open Insight
 # ============================================
 
-# Tap verse 1
+# Tap the verse group (View wrapper around verse text)
 - tapOn:
-    id: "verse-text-1"
+    id: "verse-group-1"
 
 # Wait for insight panel / bottom sheet to appear
 - waitForAnimationToEnd

--- a/.maestro/bible-reading/verse-insight-flow.yaml
+++ b/.maestro/bible-reading/verse-insight-flow.yaml
@@ -18,10 +18,11 @@ tags:
 - runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load (Genesis 1)
+# Extended timeout: previous test may leave app in unexpected state
 - extendedWaitUntil:
     visible:
       id: "chapter-selector-button"
-    timeout: 30000
+    timeout: 60000
 
 # Explicitly tap Bible view button to ensure we're in Bible view
 # (idempotent — stays in Bible view if already there)

--- a/.maestro/bible-reading/verse-insight-flow.yaml
+++ b/.maestro/bible-reading/verse-insight-flow.yaml
@@ -11,12 +11,9 @@ tags:
 # Verse Insight Bottom Sheet E2E Test
 #
 # This flow tests verse insight panel functionality:
-# 1. Wait for Bible view with verse text to fully load
+# 1. Ensure Bible view is active and verse text is visible
 # 2. Tap a verse to open insight panel
 # 3. Dismiss the panel and verify return to Bible view
-#
-# Note: After setup.yaml (clearState), the app defaults to Bible view.
-# Do NOT tap bible-view-toggle — that would switch AWAY to Explanations.
 
 - runFlow: ../shared/setup.yaml
 
@@ -26,11 +23,18 @@ tags:
       id: "chapter-selector-button"
     timeout: 30000
 
-# Wait for verse text to render in the default Bible view
-# On slow CI emulators, HighlightedText may take time after API fetch
-- extendedWaitUntil:
-    visible:
+# Explicitly tap Bible view button to ensure we're in Bible view
+# (idempotent — stays in Bible view if already there)
+- tapOn:
+    id: "bible-view-toggle"
+
+- waitForAnimationToEnd
+
+# Scroll to find verse-text-1 (handles slow rendering on CI emulators)
+- scrollUntilVisible:
+    element:
       id: "verse-text-1"
+    direction: DOWN
     timeout: 60000
 
 # ============================================

--- a/.maestro/dictionary/dictionary-lookup-flow.yaml
+++ b/.maestro/dictionary/dictionary-lookup-flow.yaml
@@ -18,9 +18,6 @@ tags:
 # 4. Dismiss the tooltip
 #
 # Covers: GH-193 (dictionary fuzzy matching)
-#
-# Note: Uses setup.yaml (clearState) which defaults to Bible view.
-# Do NOT tap bible-view-toggle — that would switch AWAY to Explanations.
 
 - runFlow: ../shared/setup.yaml
 
@@ -32,11 +29,17 @@ tags:
 - assertVisible:
     id: "chapter-selector-button"
 
-# Wait for verse text to render in the default Bible view
-# Extended timeout for slow CI emulators (API fetch + HighlightedText render)
-- extendedWaitUntil:
-    visible:
+# Explicitly tap Bible view to ensure we're in Bible view
+- tapOn:
+    id: "bible-view-toggle"
+
+- waitForAnimationToEnd
+
+# Scroll to find verse-text-1 (handles slow rendering on CI emulators)
+- scrollUntilVisible:
+    element:
       id: "verse-text-1"
+    direction: DOWN
     timeout: 60000
 
 # ============================================

--- a/.maestro/dictionary/dictionary-lookup-flow.yaml
+++ b/.maestro/dictionary/dictionary-lookup-flow.yaml
@@ -12,14 +12,17 @@ tags:
 # Dictionary Lookup E2E Test Flow
 #
 # This flow tests the dictionary/definition feature:
-# 1. Wait for Genesis 1 content to fully load
+# 1. Wait for Genesis 1 content to fully load in Bible view
 # 2. Long-press on a word in the verse text to trigger definition lookup
 # 3. Verify the word definition tooltip appears
 # 4. Dismiss the tooltip
 #
 # Covers: GH-193 (dictionary fuzzy matching)
+#
+# Note: Uses setup.yaml (clearState) which defaults to Bible view.
+# Do NOT tap bible-view-toggle — that would switch AWAY to Explanations.
 
-- runFlow: ../shared/setup-warm.yaml
+- runFlow: ../shared/setup.yaml
 
 # ============================================
 # Test 1: Wait for Bible content to load
@@ -29,16 +32,12 @@ tags:
 - assertVisible:
     id: "chapter-selector-button"
 
-# Switch to Bible view to ensure verse text is showing
-- tapOn:
-    id: "bible-view-toggle"
-    optional: true
-
-# Wait for verse text to render (HighlightedText component)
+# Wait for verse text to render in the default Bible view
+# Extended timeout for slow CI emulators (API fetch + HighlightedText render)
 - extendedWaitUntil:
     visible:
       id: "verse-text-1"
-    timeout: 30000
+    timeout: 60000
 
 # ============================================
 # Test 2: Long-press on verse text to trigger dictionary

--- a/.maestro/dictionary/dictionary-lookup-flow.yaml
+++ b/.maestro/dictionary/dictionary-lookup-flow.yaml
@@ -35,10 +35,10 @@ tags:
 
 - waitForAnimationToEnd
 
-# Scroll to find verse-text-1 (handles slow rendering on CI emulators)
+# Wait for verse group to render (View element, more reliable than nested Text)
 - scrollUntilVisible:
     element:
-      id: "verse-text-1"
+      id: "verse-group-1"
     direction: DOWN
     timeout: 60000
 
@@ -46,9 +46,9 @@ tags:
 # Test 2: Long-press on verse text to trigger dictionary
 # ============================================
 
-# Long-press on verse 1 text content (triggers word selection via HighlightedText onLongPress)
+# Long-press on verse group (View wrapper triggers word selection via HighlightedText onLongPress)
 - longPressOn:
-    id: "verse-text-1"
+    id: "verse-group-1"
 
 # ============================================
 # Test 3: Verify dictionary tooltip appears

--- a/.maestro/split-view/dictionary-tablet-flow.yaml
+++ b/.maestro/split-view/dictionary-tablet-flow.yaml
@@ -31,14 +31,18 @@ tags:
 - assertVisible:
     id: "bible-content-panel"
 
-- assertVisible:
-    id: "bible-explanations-panel"
+# Wait for explanations panel (may take a moment on slow emulators)
+- extendedWaitUntil:
+    visible:
+      id: "bible-explanations-panel"
+    timeout: 30000
 
-# Wait for verse text to render (HighlightedText component)
+# Wait for verse text to render in the Bible content panel
+# Extended timeout: clearState in tablet setup forces fresh content load
 - extendedWaitUntil:
     visible:
       id: "verse-text-1"
-    timeout: 30000
+    timeout: 60000
 
 # ============================================
 # Test 2: Long-press on verse text to trigger dictionary

--- a/.maestro/split-view/dictionary-tablet-flow.yaml
+++ b/.maestro/split-view/dictionary-tablet-flow.yaml
@@ -37,11 +37,10 @@ tags:
       id: "bible-explanations-panel"
     timeout: 30000
 
-# Scroll to find verse-text-1 in the Bible content panel
-# (handles slow rendering and virtualized lists on CI emulators)
+# Wait for verse group to render (View element, more reliable than nested Text)
 - scrollUntilVisible:
     element:
-      id: "verse-text-1"
+      id: "verse-group-1"
     direction: DOWN
     timeout: 60000
 
@@ -49,9 +48,9 @@ tags:
 # Test 2: Long-press on verse text to trigger dictionary
 # ============================================
 
-# Long-press on verse 1 text content (triggers word selection via HighlightedText onLongPress)
+# Long-press on verse group (View wrapper triggers word selection via HighlightedText onLongPress)
 - longPressOn:
-    id: "verse-text-1"
+    id: "verse-group-1"
 
 # ============================================
 # Test 3: Verify tooltip appears and is visible

--- a/.maestro/split-view/dictionary-tablet-flow.yaml
+++ b/.maestro/split-view/dictionary-tablet-flow.yaml
@@ -37,11 +37,12 @@ tags:
       id: "bible-explanations-panel"
     timeout: 30000
 
-# Wait for verse text to render in the Bible content panel
-# Extended timeout: clearState in tablet setup forces fresh content load
-- extendedWaitUntil:
-    visible:
+# Scroll to find verse-text-1 in the Bible content panel
+# (handles slow rendering and virtualized lists on CI emulators)
+- scrollUntilVisible:
+    element:
       id: "verse-text-1"
+    direction: DOWN
     timeout: 60000
 
 # ============================================

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -532,6 +532,7 @@ export function ChapterReader({
                   return (
                     <View
                       key={groupKey}
+                      testID={`verse-group-${group[0].verseNumber}`}
                       onLayout={(e) =>
                         handleVerseLayout(
                           group[0].verseNumber,


### PR DESCRIPTION
## Summary
- Add `testID` to verse group `View` wrapper in ChapterReader (more reliable than nested `Text` testID on Android)
- Update dictionary, verse-insight, and dictionary-tablet tests to use `verse-group-1`
- Increase verse-insight initial timeout to 60s

## Root Cause
On Android, Maestro cannot reliably find `testID` on deeply nested `Text` elements inside `ScrollView`. The `verse-text-{N}` testID is on an inner `Text` inside `HighlightedText` inside another `Text`. Using a `View` wrapper testID (`verse-group-{N}`) is much more reliable.

## Branch CI Results
- Dictionary Lookup: PASSED (was failing)
- Dictionary Tablet: PASSED (was failing)  
- All other phone tests: PASSED
- Login test: expected failure (secrets not available on branch)