### PR TITLE
Add text size selector for adjustable reading font sizes

### DIFF
--- a/.maestro/settings/text-size-flow.yaml
+++ b/.maestro/settings/text-size-flow.yaml
@@ -1,0 +1,90 @@
+---
+appId: org.versemate.app
+name: Text Size Settings Flow
+description: Tests text size adjustment in settings screen
+tags:
+  - settings
+  - user-flow
+
+---
+
+# Text Size E2E Test Flow
+#
+# This flow tests text size selector functionality:
+# 1. Navigate to settings via hamburger menu
+# 2. Verify "Text Size" section visible
+# 3. Increase text size and verify label
+# 4. Decrease text size and verify label
+
+- runFlow: ../shared/setup.yaml
+
+# Wait for app to fully load
+- extendedWaitUntil:
+    visible:
+      id: "chapter-selector-button"
+    timeout: 30000
+
+# ============================================
+# Navigate to Settings
+# ============================================
+
+- tapOn:
+    id: "hamburger-menu-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "hamburger-menu"
+    timeout: 5000
+
+- tapOn:
+    id: "menu-item-settings"
+
+- waitForAnimationToEnd
+
+# ============================================
+# Verify Text Size section
+# ============================================
+
+- assertVisible:
+    text: "Text Size"
+
+# Verify stepper is visible with default "Medium"
+- assertVisible:
+    id: "text-size-stepper"
+
+- assertVisible:
+    id: "text-size-label"
+
+# ============================================
+# Test: Increase text size
+# ============================================
+
+- tapOn:
+    id: "text-size-increase"
+
+# Verify label changed to "Large"
+- assertVisible:
+    text: "Large"
+
+# ============================================
+# Test: Decrease text size back
+# ============================================
+
+- tapOn:
+    id: "text-size-decrease"
+
+# Verify label changed back to "Medium"
+- assertVisible:
+    text: "Medium"
+
+# ============================================
+# Navigate back
+# ============================================
+
+- tapOn:
+    id: "settings-back-button"
+
+- waitForAnimationToEnd
+
+- assertVisible:
+    id: "chapter-selector-button"

--- a/__tests__/components/settings/TextSizeStepper.test.tsx
+++ b/__tests__/components/settings/TextSizeStepper.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as Haptics from 'expo-haptics';
+
+import { TextSizeStepper } from '@/components/settings/TextSizeStepper';
+
+jest.unmock('@/contexts/TextSizeContext');
+
+// Mock Haptics
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'LIGHT' },
+}));
+
+// Track mock state
+let mockPreset = 'medium';
+const mockSetPreset = jest.fn().mockImplementation(async (newPreset: string) => {
+  mockPreset = newPreset;
+});
+
+jest.mock('@/contexts/TextSizeContext', () => ({
+  useTextSize: () => ({
+    preset: mockPreset,
+    scaleFactor: { small: 0.85, medium: 1.0, large: 1.15, extraLarge: 1.3 }[mockPreset],
+    setPreset: mockSetPreset,
+    scaledFontSize: (base: number) =>
+      Math.round(
+        base *
+          ({ small: 0.85, medium: 1.0, large: 1.15, extraLarge: 1.3 } as Record<string, number>)[
+            mockPreset
+          ]
+      ),
+    isLoading: false,
+  }),
+  PRESET_LABELS: { small: 'Small', medium: 'Medium', large: 'Large', extraLarge: 'Extra Large' },
+  PRESET_ORDER: ['small', 'medium', 'large', 'extraLarge'],
+}));
+
+describe('TextSizeStepper', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPreset = 'medium';
+  });
+
+  it('renders current preset label', () => {
+    render(<TextSizeStepper />);
+
+    expect(screen.getByTestId('text-size-label')).toHaveTextContent('Medium');
+  });
+
+  it('renders decrease and increase buttons', () => {
+    render(<TextSizeStepper />);
+
+    expect(screen.getByTestId('text-size-decrease')).toBeTruthy();
+    expect(screen.getByTestId('text-size-increase')).toBeTruthy();
+  });
+
+  it('calls setPreset with next preset on increase', async () => {
+    render(<TextSizeStepper />);
+
+    fireEvent.press(screen.getByTestId('text-size-increase'));
+
+    await waitFor(() => {
+      expect(mockSetPreset).toHaveBeenCalledWith('large');
+    });
+  });
+
+  it('calls setPreset with previous preset on decrease', async () => {
+    render(<TextSizeStepper />);
+
+    fireEvent.press(screen.getByTestId('text-size-decrease'));
+
+    await waitFor(() => {
+      expect(mockSetPreset).toHaveBeenCalledWith('small');
+    });
+  });
+
+  it('triggers haptic feedback on press', async () => {
+    render(<TextSizeStepper />);
+
+    fireEvent.press(screen.getByTestId('text-size-increase'));
+
+    await waitFor(() => {
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+    });
+  });
+
+  it('disables decrease button at minimum (small)', () => {
+    mockPreset = 'small';
+    render(<TextSizeStepper />);
+
+    const decreaseBtn = screen.getByTestId('text-size-decrease');
+    expect(decreaseBtn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('disables increase button at maximum (extraLarge)', () => {
+    mockPreset = 'extraLarge';
+    render(<TextSizeStepper />);
+
+    const increaseBtn = screen.getByTestId('text-size-increase');
+    expect(increaseBtn.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('shows preview text in non-compact mode', () => {
+    render(<TextSizeStepper />);
+
+    expect(screen.getByText(/The Lord is my shepherd/)).toBeTruthy();
+  });
+
+  it('hides preview text in compact mode', () => {
+    render(<TextSizeStepper compact />);
+
+    expect(screen.queryByText(/The Lord is my shepherd/)).toBeNull();
+  });
+});

--- a/__tests__/contexts/TextSizeContext.test.tsx
+++ b/__tests__/contexts/TextSizeContext.test.tsx
@@ -1,0 +1,188 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { act } from 'react-test-renderer';
+
+import {
+  PRESET_ORDER,
+  SCALE_FACTORS,
+  type TextSizePreset,
+  TextSizeProvider,
+  useTextSize,
+} from '@/contexts/TextSizeContext';
+
+jest.unmock('@/contexts/TextSizeContext');
+
+jest.mock('@react-native-async-storage/async-storage');
+
+const mockAsyncStorage = AsyncStorage as jest.Mocked<typeof AsyncStorage>;
+
+// Mock PostHog
+const mockCapture = jest.fn();
+jest.mock('@/lib/analytics/posthog-provider', () => ({
+  getPostHogInstance: () => ({ capture: mockCapture }),
+}));
+
+const createWrapper = () => {
+  const Wrapper = ({ children }: { children: React.ReactNode }) => (
+    <TextSizeProvider>{children}</TextSizeProvider>
+  );
+  return Wrapper;
+};
+
+describe('TextSizeContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+    mockAsyncStorage.setItem.mockResolvedValue(undefined);
+  });
+
+  it('defaults to medium preset with 1.0x scale factor', async () => {
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.preset).toBe('medium');
+    expect(result.current.scaleFactor).toBe(1.0);
+  });
+
+  it('loads saved preset from AsyncStorage', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('large');
+
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.preset).toBe('large');
+    expect(result.current.scaleFactor).toBe(1.15);
+  });
+
+  it('falls back to medium for invalid stored values', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue('invalid_value');
+
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.preset).toBe('medium');
+  });
+
+  it('setPreset updates state and AsyncStorage', async () => {
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setPreset('extraLarge');
+    });
+
+    expect(result.current.preset).toBe('extraLarge');
+    expect(result.current.scaleFactor).toBe(1.3);
+    expect(mockAsyncStorage.setItem).toHaveBeenCalledWith('text-size-preference', 'extraLarge');
+  });
+
+  it('scaledFontSize returns correct values for each preset', async () => {
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Default medium (1.0x)
+    expect(result.current.scaledFontSize(18)).toBe(18);
+    expect(result.current.scaledFontSize(24)).toBe(24);
+
+    // Switch to small (0.85x)
+    await act(async () => {
+      await result.current.setPreset('small');
+    });
+    expect(result.current.scaledFontSize(18)).toBe(Math.round(18 * 0.85));
+    expect(result.current.scaledFontSize(24)).toBe(Math.round(24 * 0.85));
+
+    // Switch to extraLarge (1.3x)
+    await act(async () => {
+      await result.current.setPreset('extraLarge');
+    });
+    expect(result.current.scaledFontSize(18)).toBe(Math.round(18 * 1.3));
+  });
+
+  it('tracks PostHog analytics on preset change', async () => {
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setPreset('large');
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith('$set', {
+      $set: { text_size_preference: 'large' },
+    });
+  });
+
+  it('handles AsyncStorage failures gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAsyncStorage.setItem.mockRejectedValue(new Error('Storage error'));
+
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should still update state optimistically
+    await act(async () => {
+      await result.current.setPreset('large');
+    });
+
+    expect(result.current.preset).toBe('large');
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it('handles AsyncStorage load failure gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockAsyncStorage.getItem.mockRejectedValue(new Error('Load error'));
+
+    const { result } = renderHook(() => useTextSize(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should fall back to default
+    expect(result.current.preset).toBe('medium');
+    consoleSpy.mockRestore();
+  });
+
+  it('throws when useTextSize is used outside provider', () => {
+    // Suppress console.error for expected error
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useTextSize());
+    }).toThrow('useTextSize must be used within a TextSizeProvider');
+
+    consoleSpy.mockRestore();
+  });
+
+  it('PRESET_ORDER contains all presets in correct order', () => {
+    expect(PRESET_ORDER).toEqual(['small', 'medium', 'large', 'extraLarge']);
+  });
+
+  it('SCALE_FACTORS has correct values for all presets', () => {
+    expect(SCALE_FACTORS.small).toBe(0.85);
+    expect(SCALE_FACTORS.medium).toBe(1.0);
+    expect(SCALE_FACTORS.large).toBe(1.15);
+    expect(SCALE_FACTORS.extraLarge).toBe(1.3);
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -28,6 +28,7 @@ import { AppErrorBoundary } from '@/components/AppErrorBoundary';
 import { AuthProvider } from '@/contexts/AuthContext';
 import { DeviceInfoProvider } from '@/contexts/DeviceInfoContext';
 import { OfflineProvider } from '@/contexts/OfflineContext';
+import { TextSizeProvider } from '@/contexts/TextSizeContext';
 import { ThemeProvider as CustomThemeProvider, useTheme } from '@/contexts/ThemeContext';
 import { ToastProvider } from '@/contexts/ToastContext';
 import { preloadAllTopicsCache } from '@/hooks/topics/use-cached-topics';
@@ -419,13 +420,15 @@ export default function RootLayout() {
         <QueryClientProvider client={queryClient}>
           <AuthProvider>
             <CustomThemeProvider>
-              <DeviceInfoProvider>
-                <OfflineProvider>
-                  <ToastProvider>
-                    <RootLayoutInner />
-                  </ToastProvider>
-                </OfflineProvider>
-              </DeviceInfoProvider>
+              <TextSizeProvider>
+                <DeviceInfoProvider>
+                  <OfflineProvider>
+                    <ToastProvider>
+                      <RootLayoutInner />
+                    </ToastProvider>
+                  </OfflineProvider>
+                </DeviceInfoProvider>
+              </TextSizeProvider>
             </CustomThemeProvider>
           </AuthProvider>
         </QueryClientProvider>

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -40,6 +40,7 @@ import { OfflineIndicator } from '@/components/bible/OfflineIndicator';
 import { ProgressBar } from '@/components/bible/ProgressBar';
 import { SimpleChapterPager } from '@/components/bible/SimpleChapterPager';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
+import { TextSizePopover } from '@/components/bible/TextSizePopover';
 import { SplitView } from '@/components/ui/SplitView';
 import { getHeaderSpecs, spacing } from '@/constants/bible-design-tokens';
 import { useAuth } from '@/contexts/AuthContext';
@@ -166,6 +167,9 @@ export default function ChapterScreen() {
 
   // Navigation modal state
   const [isNavigationModalOpen, setIsNavigationModalOpen] = useState(false);
+
+  // Text size popover state
+  const [isTextSizeOpen, setIsTextSizeOpen] = useState(false);
 
   // Hamburger menu state
   const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -479,6 +483,9 @@ export default function ChapterScreen() {
               onMenuPress={() => {
                 setIsMenuOpen(true);
               }}
+              onTextSizePress={() => {
+                setIsTextSizeOpen(true);
+              }}
             />
 
             {/* Content Tabs - Only visible in Explanations view */}
@@ -510,6 +517,9 @@ export default function ChapterScreen() {
 
             {/* Hamburger Menu */}
             <HamburgerMenu visible={isMenuOpen} onClose={() => setIsMenuOpen(false)} />
+
+            {/* Text Size Popover */}
+            <TextSizePopover visible={isTextSizeOpen} onClose={() => setIsTextSizeOpen(false)} />
           </>
         )}
 
@@ -561,6 +571,7 @@ interface ChapterHeaderProps {
   onNavigationPress: () => void;
   onViewChange: (view: ViewMode) => void;
   onMenuPress: () => void;
+  onTextSizePress?: () => void;
   navigationModalVisible?: boolean;
 }
 
@@ -571,6 +582,7 @@ function ChapterHeader({
   onNavigationPress,
   onViewChange,
   onMenuPress,
+  onTextSizePress,
   navigationModalVisible,
 }: ChapterHeaderProps) {
   // Get theme directly inside ChapterHeader (no props drilling)
@@ -681,6 +693,19 @@ function ChapterHeader({
 
         {/* Offline Indicator */}
         <OfflineIndicator />
+
+        {/* Text Size Button */}
+        {onTextSizePress && (
+          <Pressable
+            onPress={onTextSizePress}
+            style={styles.iconButton}
+            accessibilityLabel="Adjust text size"
+            accessibilityRole="button"
+            testID="text-size-button"
+          >
+            <Ionicons name="text" size={headerSpecs.iconSize} color={headerSpecs.iconColor} />
+          </Pressable>
+        )}
 
         {/* Hamburger Menu Icon */}
         <Pressable

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -34,6 +34,7 @@ import { DeleteAccountFinalModal } from '@/components/account/DeleteAccountFinal
 import { DeleteAccountPasswordModal } from '@/components/account/DeleteAccountPasswordModal';
 import { DeleteAccountWarningModal } from '@/components/account/DeleteAccountWarningModal';
 import { Button } from '@/components/Button';
+import { TextSizeSelector } from '@/components/settings/TextSizeSelector';
 import { ThemeSelector } from '@/components/settings/ThemeSelector';
 import { Avatar } from '@/components/ui/Avatar';
 import { TextInput } from '@/components/ui/TextInput';
@@ -811,6 +812,9 @@ export default function SettingsScreen() {
 
         {/* Theme Selector Section */}
         <ThemeSelector />
+
+        {/* Text Size Selector Section */}
+        <TextSizeSelector />
 
         {/* Downloads & Offline — hidden on web (online-only) */}
         {Platform.OS !== 'web' && (

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -29,6 +29,7 @@ import {
   spacing,
 } from '@/constants/bible-design-tokens';
 import { useAuth } from '@/contexts/AuthContext';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import { useBibleByLine, useBibleDetailed, useBibleSummary } from '@/src/api';
@@ -94,11 +95,12 @@ export function BibleExplanationsPanel({
 }: BibleExplanationsPanelProps) {
   const { mode, colors } = useTheme();
   const { user } = useAuth();
+  const { scaledFontSize } = useTextSize();
   const insets = useSafeAreaInsets();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
   const { styles, markdownStyles } = useMemo(
-    () => createStyles(specs, colors, insets),
-    [specs, colors, insets]
+    () => createStyles(specs, colors, insets, scaledFontSize),
+    [specs, colors, insets, scaledFontSize]
   );
 
   // Get current language from user preferences (default to 'en-US')
@@ -388,7 +390,8 @@ export function BibleExplanationsPanel({
 function createStyles(
   specs: ReturnType<typeof getSplitViewSpecs>,
   colors: ReturnType<typeof getColors>,
-  insets: ReturnType<typeof useSafeAreaInsets>
+  insets: ReturnType<typeof useSafeAreaInsets>,
+  scaledFontSize: (base: number) => number = (b) => b
 ) {
   const styles = StyleSheet.create({
     container: {
@@ -497,9 +500,9 @@ function createStyles(
     },
     contentTitle: {
       flex: 1,
-      fontSize: fontSizes.heading1,
+      fontSize: scaledFontSize(fontSizes.heading1),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading1) * lineHeights.heading,
       color: colors.textPrimary,
       marginRight: spacing.md,
     },
@@ -512,29 +515,29 @@ function createStyles(
 
   const markdownStyles = StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * lineHeights.body,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: scaledFontSize(fontSizes.heading1),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading1) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledFontSize(fontSizes.heading2),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading2) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xl,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * lineHeights.body,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },
@@ -547,8 +550,8 @@ function createStyles(
       marginBottom: spacing.lg,
     },
     blockquote_text: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * lineHeights.body,
       color: colors.textPrimary,
     },
   });

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -47,6 +47,7 @@ import {
 import type { HighlightColor } from '@/constants/highlight-colors';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useBibleInteraction } from '@/contexts/BibleInteractionContext';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { isElementVisible, useTextVisibility } from '@/contexts/TextVisibilityContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useToast } from '@/contexts/ToastContext';
@@ -262,9 +263,16 @@ export function ChapterReader({
   filteredAutoHighlights,
 }: ChapterReaderProps) {
   const { colors, mode } = useTheme();
+  const { scaledFontSize } = useTextSize();
   const specs = getHeaderSpecs(mode);
-  const styles = createStyles(colors, explanationsOnly);
-  const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
+  const styles = useMemo(
+    () => createStyles(colors, explanationsOnly, scaledFontSize),
+    [colors, explanationsOnly, scaledFontSize]
+  );
+  const markdownStyles = useMemo(
+    () => createMarkdownStyles(colors, scaledFontSize),
+    [colors, scaledFontSize]
+  );
   const { showToast } = useToast();
 
   // Use Bible Interaction Context for highlights and interactions
@@ -776,8 +784,18 @@ export function ChapterReader({
   );
 }
 
-const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: boolean) =>
-  StyleSheet.create({
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  explanationsOnly?: boolean,
+  scaledFontSize: (base: number) => number = (b) => b
+) => {
+  const scaledBodyLarge = scaledFontSize(fontSizes.bodyLarge);
+  const scaledDisplayMedium = scaledFontSize(fontSizes.displayMedium);
+  const scaledHeading1 = scaledFontSize(fontSizes.heading1);
+  const scaledHeading2 = scaledFontSize(fontSizes.heading2);
+  const scaledCaption = scaledFontSize(fontSizes.caption);
+
+  return StyleSheet.create({
     container: {
       flex: 1,
     },
@@ -789,9 +807,9 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
     },
     chapterTitle: {
       flex: 1,
-      fontSize: fontSizes.displayMedium,
+      fontSize: scaledDisplayMedium,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.displayMedium * lineHeights.display,
+      lineHeight: scaledDisplayMedium * lineHeights.display,
       color: colors.textPrimary,
       marginRight: spacing.md,
     },
@@ -801,16 +819,16 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
       gap: spacing.xs,
     },
     sectionSubtitle: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledHeading2,
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: scaledHeading2 * lineHeights.heading,
       color: colors.textPrimary,
       marginBottom: spacing.sm,
     },
     verseRange: {
-      fontSize: fontSizes.caption,
+      fontSize: scaledCaption,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.caption * lineHeights.ui,
+      lineHeight: scaledCaption * lineHeights.ui,
       color: colors.textTertiary,
       marginBottom: spacing.md,
     },
@@ -823,34 +841,34 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
       marginBottom: spacing.md,
     },
     verseNumber: {
-      fontSize: fontSizes.caption,
+      fontSize: scaledCaption,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      lineHeight: scaledBodyLarge * lineHeights.body,
       color: colors.textTertiary,
       marginRight: spacing.xs,
       marginTop: -4,
     },
     verseNumberSuperscript: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: scaledBodyLarge,
       fontWeight: fontWeights.bold,
       color: colors.textTertiary,
     },
     verseText: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: scaledBodyLarge,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
     },
     verseTextInline: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: scaledBodyLarge,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
     },
     verseTextParagraph: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: scaledBodyLarge,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },
@@ -866,13 +884,12 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
       justifyContent: 'space-between',
       marginBottom: spacing.lg,
     },
-    // Removed explanationTitleContainer as we are reverting to direct Text usage like titleRow
     explanationTitle: {
       flex: 1,
-      fontSize: fontSizes.heading1,
+      fontSize: scaledHeading1,
       fontWeight: fontWeights.bold,
       color: colors.textPrimary,
-      lineHeight: fontSizes.heading1 * lineHeights.heading, // Fixed: Multiply fontSize by lineHeight
+      lineHeight: scaledHeading1 * lineHeights.heading,
       marginRight: spacing.md,
     },
     explanationTitleActions: {
@@ -881,41 +898,51 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
       gap: spacing.xs,
     },
   });
+};
 
-const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
-  StyleSheet.create({
+const createMarkdownStyles = (
+  colors: ReturnType<typeof getColors>,
+  scaledFontSize: (base: number) => number = (b) => b
+) => {
+  const scaledBodyLarge = scaledFontSize(fontSizes.bodyLarge);
+  const scaledBodySmall = scaledFontSize(fontSizes.bodySmall);
+  const scaledHeading1 = scaledFontSize(fontSizes.heading1);
+  const scaledHeading2 = scaledFontSize(fontSizes.heading2);
+  const scaledHeading3 = scaledFontSize(fontSizes.heading3);
+
+  return StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledBodyLarge,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: scaledHeading1,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: scaledHeading1 * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledHeading2,
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: scaledHeading2 * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     heading3: {
-      fontSize: fontSizes.heading3,
+      fontSize: scaledHeading3,
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading3 * lineHeights.heading,
+      lineHeight: scaledHeading3 * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledBodyLarge,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.lg,
     },
@@ -928,8 +955,8 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
       color: colors.textPrimary,
     },
     list_item: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledBodyLarge,
+      lineHeight: scaledBodyLarge * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.sm,
     },
@@ -941,7 +968,7 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
     },
     code_inline: {
       fontFamily: 'monospace',
-      fontSize: fontSizes.bodySmall,
+      fontSize: scaledBodySmall,
       backgroundColor: colors.backgroundElevated,
       paddingHorizontal: spacing.xs,
       paddingVertical: 2,
@@ -950,7 +977,7 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
     },
     fence: {
       fontFamily: 'monospace',
-      fontSize: fontSizes.bodySmall,
+      fontSize: scaledBodySmall,
       backgroundColor: colors.backgroundElevated,
       padding: spacing.md,
       borderRadius: 4,
@@ -975,3 +1002,4 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
       marginVertical: spacing.xl,
     },
   });
+};

--- a/components/bible/NoteCard.tsx
+++ b/components/bible/NoteCard.tsx
@@ -33,6 +33,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { fontSizes, fontWeights, type getColors, spacing } from '@/constants/bible-design-tokens';
 import { NOTES_CONFIG } from '@/constants/notes';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Note } from '@/types/notes';
 
@@ -76,7 +77,8 @@ export function NoteCard({
   isExpanded = false,
 }: NoteCardProps) {
   const { colors } = useTheme();
-  const styles = createStyles(colors);
+  const { scaledFontSize } = useTextSize();
+  const styles = createStyles(colors, scaledFontSize);
 
   const isTruncated = note.content.length > truncateLength;
 
@@ -142,7 +144,10 @@ export function NoteCard({
   );
 }
 
-const createStyles = (colors: ReturnType<typeof getColors>) =>
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  scaledFontSize: (b: number) => number = (b) => b
+) =>
   StyleSheet.create({
     card: {
       flexDirection: 'row',
@@ -163,10 +168,10 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
       marginRight: spacing.md,
     },
     text: {
-      fontSize: fontSizes.body,
+      fontSize: scaledFontSize(fontSizes.body),
       fontWeight: fontWeights.regular,
       color: colors.textPrimary,
-      lineHeight: fontSizes.body * 1.5,
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
     },
     actions: {
       flexDirection: 'row',

--- a/components/bible/NotesModal.tsx
+++ b/components/bible/NotesModal.tsx
@@ -48,6 +48,7 @@ import {
   type ThemeMode,
 } from '@/constants/bible-design-tokens';
 import { NOTES_CONFIG } from '@/constants/notes';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useToast } from '@/contexts/ToastContext';
 import { useNotes } from '@/hooks/bible/use-notes';
@@ -77,7 +78,8 @@ export interface NotesModalProps {
  */
 export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }: NotesModalProps) {
   const { colors, mode } = useTheme();
-  const styles = createStyles(colors, mode);
+  const { scaledFontSize } = useTextSize();
+  const styles = createStyles(colors, mode, scaledFontSize);
   const { addNote, isAddingNote, deleteNote } = useNotes();
   const { showToast } = useToast();
   const {
@@ -445,7 +447,11 @@ export function NotesModal({ visible, bookId, chapterNumber, bookName, onClose }
   );
 }
 
-const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => {
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  mode: ThemeMode,
+  scaledFontSize: (b: number) => number = (b) => b
+) => {
   const modalSpecs = getModalSpecs(mode);
 
   return StyleSheet.create({
@@ -579,9 +585,9 @@ const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => 
     },
     noteContent: {
       flex: 1,
-      fontSize: fontSizes.body,
+      fontSize: scaledFontSize(fontSizes.body),
       color: colors.textPrimary,
-      lineHeight: fontSizes.body * 1.5,
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
     },
     noteMenuButton: {
       padding: spacing.xs,

--- a/components/bible/TextSizePopover.tsx
+++ b/components/bible/TextSizePopover.tsx
@@ -1,0 +1,134 @@
+/**
+ * Text Size Popover Component
+ *
+ * Compact inline strip triggered from ChapterHeader's "Aa" button.
+ * Shows a tight [- Label +] control anchored below the header.
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { type getColors, spacing } from '@/constants/bible-design-tokens';
+import { PRESET_LABELS, PRESET_ORDER, useTextSize } from '@/contexts/TextSizeContext';
+import { useTheme } from '@/contexts/ThemeContext';
+
+interface TextSizePopoverProps {
+  visible: boolean;
+  onClose: () => void;
+}
+
+export function TextSizePopover({ visible, onClose }: TextSizePopoverProps) {
+  const { colors } = useTheme();
+  const { preset, setPreset } = useTextSize();
+  const insets = useSafeAreaInsets();
+  const styles = createStyles(colors, insets.top);
+
+  const currentIndex = PRESET_ORDER.indexOf(preset);
+  const isAtMin = currentIndex <= 0;
+  const isAtMax = currentIndex >= PRESET_ORDER.length - 1;
+
+  const handleDecrease = async () => {
+    if (isAtMin) return;
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await setPreset(PRESET_ORDER[currentIndex - 1]);
+  };
+
+  const handleIncrease = async () => {
+    if (isAtMax) return;
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await setPreset(PRESET_ORDER[currentIndex + 1]);
+  };
+
+  return (
+    <Modal visible={visible} transparent animationType="fade" onRequestClose={onClose}>
+      <Pressable style={styles.backdrop} onPress={onClose}>
+        <View style={styles.pill} onStartShouldSetResponder={() => true} testID="text-size-stepper">
+          <Pressable
+            onPress={handleDecrease}
+            disabled={isAtMin}
+            style={[styles.btn, isAtMin && styles.btnDisabled]}
+            accessibilityLabel="Decrease text size"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: isAtMin }}
+            testID="text-size-decrease"
+          >
+            <Ionicons
+              name="remove"
+              size={22}
+              color={isAtMin ? colors.textDisabled : colors.textPrimary}
+            />
+          </Pressable>
+
+          <View style={[styles.divider, { backgroundColor: colors.borderSecondary }]} />
+
+          <Text style={styles.label} testID="text-size-label">
+            {PRESET_LABELS[preset]}
+          </Text>
+
+          <View style={[styles.divider, { backgroundColor: colors.borderSecondary }]} />
+
+          <Pressable
+            onPress={handleIncrease}
+            disabled={isAtMax}
+            style={[styles.btn, isAtMax && styles.btnDisabled]}
+            accessibilityLabel="Increase text size"
+            accessibilityRole="button"
+            accessibilityState={{ disabled: isAtMax }}
+            testID="text-size-increase"
+          >
+            <Ionicons
+              name="add"
+              size={22}
+              color={isAtMax ? colors.textDisabled : colors.textPrimary}
+            />
+          </Pressable>
+        </View>
+      </Pressable>
+    </Modal>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>, topInset: number) =>
+  StyleSheet.create({
+    backdrop: {
+      flex: 1,
+    },
+    pill: {
+      position: 'absolute',
+      top: topInset + 56 + spacing.xs,
+      right: spacing.lg,
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: colors.backgroundElevated,
+      borderRadius: 10,
+      borderWidth: 1,
+      borderColor: colors.borderSecondary,
+      shadowColor: '#000',
+      shadowOffset: { width: 0, height: 2 },
+      shadowOpacity: 0.12,
+      shadowRadius: 8,
+      elevation: 6,
+    },
+    btn: {
+      width: 44,
+      height: 44,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    btnDisabled: {
+      opacity: 0.35,
+    },
+    divider: {
+      width: 1,
+      height: 24,
+    },
+    label: {
+      paddingHorizontal: 14,
+      fontSize: 15,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      textAlign: 'center',
+      minWidth: 84,
+    },
+  });

--- a/components/bible/VerseMateTooltip.tsx
+++ b/components/bible/VerseMateTooltip.tsx
@@ -49,6 +49,7 @@ import SignInModal from '@/components/bible/SignInModal';
 import SignUpModal from '@/components/bible/SignUpModal';
 import { fontSizes, fontWeights, type getColors, spacing } from '@/constants/bible-design-tokens';
 import { getHighlightColor } from '@/constants/highlight-colors';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { useDeviceInfo } from '@/hooks/use-device-info';
@@ -120,6 +121,7 @@ export function VerseMateTooltip({
   useModal = true,
 }: VerseMateTooltipProps) {
   const { colors, mode } = useTheme();
+  const { scaledFontSize } = useTextSize();
   const { bibleVersion } = useBibleVersion();
   const insets = useSafeAreaInsets();
   const { isTablet, isLandscape, useSplitView, splitRatio, splitViewMode } = useDeviceInfo();
@@ -139,8 +141,17 @@ export function VerseMateTooltip({
         : undefined;
 
   const { styles, markdownStyles } = useMemo(
-    () => createStyles(colors, insets.bottom, isTablet, isLandscape, useSplitView, tooltipWidth),
-    [colors, insets.bottom, isTablet, isLandscape, useSplitView, tooltipWidth]
+    () =>
+      createStyles(
+        colors,
+        insets.bottom,
+        isTablet,
+        isLandscape,
+        useSplitView,
+        tooltipWidth,
+        scaledFontSize
+      ),
+    [colors, insets.bottom, isTablet, isLandscape, useSplitView, tooltipWidth, scaledFontSize]
   );
 
   // ... (rest of the component state and hooks)
@@ -775,7 +786,8 @@ const createStyles = (
   _isTablet: boolean,
   isLandscape: boolean,
   useSplitView: boolean,
-  tooltipWidth?: number
+  tooltipWidth?: number,
+  scaledFontSize: (b: number) => number = (b) => b
 ) => {
   const styles = StyleSheet.create({
     overlay: {
@@ -837,12 +849,12 @@ const createStyles = (
       flex: 1,
     },
     verseText: {
-      fontSize: fontSizes.body,
+      fontSize: scaledFontSize(fontSizes.body),
       fontStyle: 'italic',
       color: colors.textSecondary,
       marginTop: spacing.xs,
       marginBottom: spacing.sm,
-      lineHeight: fontSizes.body * 1.5,
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
     },
     colorBadge: {
       flexDirection: 'row',
@@ -1024,27 +1036,27 @@ const createStyles = (
    */
   const markdownStyles = StyleSheet.create({
     body: {
-      fontSize: fontSizes.body,
-      lineHeight: fontSizes.body * 1.5,
+      fontSize: scaledFontSize(fontSizes.body),
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading3,
+      fontSize: scaledFontSize(fontSizes.heading3),
       fontWeight: fontWeights.bold,
       color: colors.textPrimary,
       marginBottom: spacing.xs,
       marginTop: spacing.sm,
     },
     heading2: {
-      fontSize: fontSizes.heading3,
+      fontSize: scaledFontSize(fontSizes.heading3),
       fontWeight: fontWeights.semibold,
       color: colors.textPrimary,
       marginBottom: spacing.xs,
       marginTop: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.body,
-      lineHeight: fontSizes.body * 1.5,
+      fontSize: scaledFontSize(fontSizes.body),
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
       color: colors.textPrimary,
       marginBottom: spacing.sm,
     },

--- a/components/bible/WordDefinitionTooltip.tsx
+++ b/components/bible/WordDefinitionTooltip.tsx
@@ -36,6 +36,7 @@ import {
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { fontSizes, fontWeights, type getColors, spacing } from '@/constants/bible-design-tokens';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { useDeviceInfo } from '@/hooks/use-device-info';
@@ -89,6 +90,7 @@ export function WordDefinitionTooltip({
   useModal = true,
 }: WordDefinitionTooltipProps) {
   const { colors } = useTheme();
+  const { scaledFontSize } = useTextSize();
   const { bibleVersion } = useBibleVersion();
   const insets = useSafeAreaInsets();
   const { isTablet, useSplitView, splitRatio, splitViewMode } = useDeviceInfo();
@@ -104,8 +106,8 @@ export function WordDefinitionTooltip({
         : undefined;
 
   const styles = useMemo(
-    () => createStyles(colors, insets.bottom, tooltipWidth),
-    [colors, insets.bottom, tooltipWidth]
+    () => createStyles(colors, insets.bottom, tooltipWidth, scaledFontSize),
+    [colors, insets.bottom, tooltipWidth, scaledFontSize]
   );
 
   // Internal visibility state to keep Modal mounted during exit animation
@@ -634,7 +636,8 @@ export function WordDefinitionTooltip({
 const createStyles = (
   colors: ReturnType<typeof getColors>,
   bottomInset: number,
-  tooltipWidth?: number
+  tooltipWidth?: number,
+  scaledFontSize: (b: number) => number = (b) => b
 ) => {
   return StyleSheet.create({
     overlay: {
@@ -683,7 +686,7 @@ const createStyles = (
       marginTop: spacing.sm,
     },
     wordTitle: {
-      fontSize: fontSizes.heading1,
+      fontSize: scaledFontSize(fontSizes.heading1),
       fontWeight: fontWeights.bold,
       color: colors.textPrimary,
       marginBottom: spacing.md,
@@ -724,9 +727,9 @@ const createStyles = (
       marginBottom: spacing.xs,
     },
     refsText: {
-      fontSize: fontSizes.bodySmall,
+      fontSize: scaledFontSize(fontSizes.bodySmall),
       color: colors.textSecondary,
-      lineHeight: fontSizes.bodySmall * 1.5,
+      lineHeight: scaledFontSize(fontSizes.bodySmall) * 1.5,
     },
     seeAlsoContainer: {
       marginTop: spacing.md,
@@ -755,7 +758,7 @@ const createStyles = (
       color: colors.textSecondary,
     },
     lemmaText: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledFontSize(fontSizes.heading2),
       fontWeight: fontWeights.medium,
       color: colors.textPrimary,
       marginBottom: spacing.md,
@@ -776,9 +779,9 @@ const createStyles = (
       marginBottom: spacing.md,
     },
     definitionText: {
-      fontSize: fontSizes.body,
+      fontSize: scaledFontSize(fontSizes.body),
       color: colors.textPrimary,
-      lineHeight: fontSizes.body * 1.5,
+      lineHeight: scaledFontSize(fontSizes.body) * 1.5,
     },
     derivationContainer: {
       marginBottom: spacing.sm,
@@ -790,7 +793,7 @@ const createStyles = (
       marginBottom: spacing.xs,
     },
     derivationText: {
-      fontSize: fontSizes.bodySmall,
+      fontSize: scaledFontSize(fontSizes.bodySmall),
       color: colors.textSecondary,
       fontStyle: 'italic',
     },
@@ -804,7 +807,7 @@ const createStyles = (
       marginBottom: spacing.xs,
     },
     kjvText: {
-      fontSize: fontSizes.bodySmall,
+      fontSize: scaledFontSize(fontSizes.bodySmall),
       color: colors.textSecondary,
     },
     verseReference: {

--- a/components/settings/TextSizeSelector.tsx
+++ b/components/settings/TextSizeSelector.tsx
@@ -1,0 +1,38 @@
+/**
+ * Text Size Selector Component
+ *
+ * Self-contained settings section for text size adjustment.
+ * Follows the same UI pattern as ThemeSelector.
+ */
+
+import { StyleSheet, Text, View } from 'react-native';
+import type { getColors } from '@/constants/bible-design-tokens';
+import { useTheme } from '@/contexts/ThemeContext';
+import { TextSizeStepper } from './TextSizeStepper';
+
+export function TextSizeSelector() {
+  const { colors } = useTheme();
+  const styles = createStyles(colors);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.sectionLabel}>Text Size</Text>
+      <TextSizeStepper />
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    container: {
+      marginBottom: 24,
+      paddingHorizontal: 16,
+    },
+    sectionLabel: {
+      fontSize: 14,
+      fontWeight: '400',
+      color: colors.textSecondary,
+      marginBottom: 12,
+      marginLeft: 4,
+    },
+  });

--- a/components/settings/TextSizeStepper.tsx
+++ b/components/settings/TextSizeStepper.tsx
@@ -1,0 +1,137 @@
+/**
+ * Text Size Stepper Component
+ *
+ * Shared stepper control for adjusting text size presets.
+ * Uses small "A" / large "A" buttons to visually communicate font scaling.
+ * Used in both the popover (compact mode) and settings screen.
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { fontSizes, type getColors, spacing } from '@/constants/bible-design-tokens';
+import { PRESET_LABELS, PRESET_ORDER, useTextSize } from '@/contexts/TextSizeContext';
+import { useTheme } from '@/contexts/ThemeContext';
+
+interface TextSizeStepperProps {
+  compact?: boolean;
+}
+
+export function TextSizeStepper({ compact = false }: TextSizeStepperProps) {
+  const { preset, setPreset, scaledFontSize } = useTextSize();
+  const { colors } = useTheme();
+  const styles = createStyles(colors, compact);
+
+  const currentIndex = PRESET_ORDER.indexOf(preset);
+  const isAtMin = currentIndex <= 0;
+  const isAtMax = currentIndex >= PRESET_ORDER.length - 1;
+
+  const handleDecrease = async () => {
+    if (isAtMin) return;
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await setPreset(PRESET_ORDER[currentIndex - 1]);
+  };
+
+  const handleIncrease = async () => {
+    if (isAtMax) return;
+    await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await setPreset(PRESET_ORDER[currentIndex + 1]);
+  };
+
+  return (
+    <View
+      style={styles.container}
+      accessibilityLabel={`Text size: ${PRESET_LABELS[preset]}`}
+      testID="text-size-stepper"
+    >
+      <View style={styles.stepperRow}>
+        <Pressable
+          onPress={handleDecrease}
+          disabled={isAtMin}
+          style={[styles.stepperButton, isAtMin && styles.stepperButtonDisabled]}
+          accessibilityLabel="Decrease text size"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: isAtMin }}
+          testID="text-size-decrease"
+        >
+          <Ionicons
+            name="remove"
+            size={20}
+            color={isAtMin ? colors.textDisabled : colors.textPrimary}
+          />
+        </Pressable>
+
+        <View style={styles.labelContainer}>
+          <Text style={styles.presetLabel} testID="text-size-label">
+            {PRESET_LABELS[preset]}
+          </Text>
+        </View>
+
+        <Pressable
+          onPress={handleIncrease}
+          disabled={isAtMax}
+          style={[styles.stepperButton, isAtMax && styles.stepperButtonDisabled]}
+          accessibilityLabel="Increase text size"
+          accessibilityRole="button"
+          accessibilityState={{ disabled: isAtMax }}
+          testID="text-size-increase"
+        >
+          <Ionicons
+            name="add"
+            size={20}
+            color={isAtMax ? colors.textDisabled : colors.textPrimary}
+          />
+        </Pressable>
+      </View>
+
+      {/* Preview text */}
+      {!compact && (
+        <Text style={[styles.previewText, { fontSize: scaledFontSize(fontSizes.bodyLarge) }]}>
+          The Lord is my shepherd; I shall not want.
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>, compact: boolean) =>
+  StyleSheet.create({
+    container: {
+      gap: compact ? spacing.sm : spacing.md,
+    },
+    stepperRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: spacing.lg,
+    },
+    stepperButton: {
+      width: 40,
+      height: 40,
+      borderRadius: 20,
+      backgroundColor: colors.backgroundElevated,
+      borderWidth: 1,
+      borderColor: colors.borderSecondary,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    stepperButtonDisabled: {
+      opacity: 0.4,
+    },
+    labelContainer: {
+      minWidth: 100,
+      alignItems: 'center',
+    },
+    presetLabel: {
+      fontSize: 16,
+      fontWeight: '500',
+      color: colors.textPrimary,
+    },
+    previewText: {
+      color: colors.textSecondary,
+      textAlign: 'center',
+      fontStyle: 'italic',
+      lineHeight: fontSizes.bodyLarge * 1.6,
+      paddingHorizontal: spacing.lg,
+    },
+  });

--- a/components/topics/TopicContentPanel.tsx
+++ b/components/topics/TopicContentPanel.tsx
@@ -32,6 +32,7 @@ import {
   lineHeights,
   spacing,
 } from '@/constants/bible-design-tokens';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useTopicReferences } from '@/src/api';
 
@@ -141,8 +142,9 @@ export function TopicContentPanel({
   testID = 'topic-content-panel',
 }: TopicContentPanelProps) {
   const { mode, colors } = useTheme();
+  const { scaledFontSize } = useTextSize();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
-  const { styles, markdownStyles } = createStyles(specs, colors);
+  const { styles, markdownStyles } = createStyles(specs, colors, scaledFontSize);
   const insets = useSafeAreaInsets();
 
   // Reading progress state
@@ -309,7 +311,8 @@ export function TopicContentPanel({
  */
 function createStyles(
   specs: ReturnType<typeof getSplitViewSpecs>,
-  colors: ReturnType<typeof getColors>
+  colors: ReturnType<typeof getColors>,
+  scaledFontSize: (base: number) => number = (b) => b
 ) {
   const styles = StyleSheet.create({
     container: {
@@ -350,14 +353,14 @@ function createStyles(
     },
     topicTitle: {
       flex: 1,
-      fontSize: fontSizes.displayMedium,
+      fontSize: scaledFontSize(fontSizes.displayMedium),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.displayMedium * lineHeights.display,
+      lineHeight: scaledFontSize(fontSizes.displayMedium) * lineHeights.display,
       color: colors.textPrimary,
     },
     topicDescription: {
-      fontSize: fontSizes.body,
-      lineHeight: fontSizes.body * lineHeights.body,
+      fontSize: scaledFontSize(fontSizes.body),
+      lineHeight: scaledFontSize(fontSizes.body) * lineHeights.body,
       color: colors.textSecondary,
       marginBottom: spacing.xxl,
     },
@@ -385,29 +388,29 @@ function createStyles(
 
   const markdownStyles = StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * 2.0,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: scaledFontSize(fontSizes.heading1),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading1) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledFontSize(fontSizes.heading2),
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading2) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },

--- a/components/topics/TopicPage.tsx
+++ b/components/topics/TopicPage.tsx
@@ -33,6 +33,7 @@ import {
   lineHeights,
   spacing,
 } from '@/constants/bible-design-tokens';
+import { useTextSize } from '@/contexts/TextSizeContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import { useTopicById, useTopicReferences } from '@/src/api';
@@ -166,7 +167,9 @@ export function TopicPage({
   onVersePress,
 }: TopicPageProps) {
   const { colors } = useTheme();
-  const { styles, markdownStyles } = createStyles(colors);
+  const { scaledFontSize } = useTextSize();
+  const styles = createStyles(colors, scaledFontSize);
+  const markdownStyles = createMarkdownStyles(colors, scaledFontSize);
 
   // TODO: Implement Bible version selection in Settings page
   // For now, hardcoded to NASB1995 (backend default)
@@ -552,11 +555,15 @@ export function TopicPage({
 }
 
 /**
- * Creates all styles for TopicPage component
- * Returns both component styles and markdown styles in a single factory
+ * Creates component styles for TopicPage.
+ * Only content font sizes (topicTitle, topicDescription) are scaled.
+ * UI chrome (emptyText) is intentionally left unscaled.
  */
-const createStyles = (colors: ReturnType<typeof getColors>) => {
-  const styles = StyleSheet.create({
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  scaledFontSize: (base: number) => number = (b) => b
+) =>
+  StyleSheet.create({
     container: {
       flex: 1,
       backgroundColor: colors.background,
@@ -576,9 +583,9 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
     },
     topicTitle: {
       flex: 1,
-      fontSize: fontSizes.displayMedium,
+      fontSize: scaledFontSize(fontSizes.displayMedium),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.displayMedium * lineHeights.display,
+      lineHeight: scaledFontSize(fontSizes.displayMedium) * lineHeights.display,
       color: colors.textPrimary,
       marginRight: spacing.md,
     },
@@ -588,8 +595,8 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
       gap: spacing.xs,
     },
     topicDescription: {
-      fontSize: fontSizes.body,
-      lineHeight: fontSizes.body * lineHeights.body,
+      fontSize: scaledFontSize(fontSizes.body),
+      lineHeight: scaledFontSize(fontSizes.body) * lineHeights.body,
       color: colors.textSecondary,
       marginBottom: spacing.xxl,
     },
@@ -613,10 +620,16 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
     },
   });
 
-  /**
-   * Markdown Styles
-   * Reused from ChapterReader for consistency
-   */
+/**
+ * Creates markdown styles for TopicPage.
+ * Content font sizes (body, headings, paragraph, list_item) are scaled.
+ * Line heights are recalculated proportionally from the scaled font size.
+ * UI chrome styles are intentionally left unscaled.
+ */
+const createMarkdownStyles = (
+  colors: ReturnType<typeof getColors>,
+  scaledFontSize: (base: number) => number = (b) => b
+) => {
   const verseNumberSuperscriptStyle = {
     fontSize: fontSizes.bodyLarge,
     fontWeight: fontWeights.bold,
@@ -624,45 +637,45 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
     marginRight: spacing.xs / 2,
   };
 
-  const markdownStyles = StyleSheet.create({
+  return StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * 2.0,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: scaledFontSize(fontSizes.heading1),
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading1) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: scaledFontSize(fontSizes.heading2),
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading2) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     heading3: {
-      fontSize: fontSizes.heading3,
+      fontSize: scaledFontSize(fontSizes.heading3),
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading3 * lineHeights.heading,
+      lineHeight: scaledFontSize(fontSizes.heading3) * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },
     list_item: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: scaledFontSize(fontSizes.bodyLarge),
+      lineHeight: scaledFontSize(fontSizes.bodyLarge) * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.xs,
     },
@@ -689,6 +702,4 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
     },
     verseNumberSuperscript: verseNumberSuperscriptStyle,
   });
-
-  return { styles, markdownStyles };
 };

--- a/contexts/TextSizeContext.tsx
+++ b/contexts/TextSizeContext.tsx
@@ -1,0 +1,158 @@
+/**
+ * Text Size Context
+ *
+ * Manages text size preference with AsyncStorage persistence.
+ * Provides a scale factor applied to reading content font sizes.
+ *
+ * Pattern based on ThemeContext for AsyncStorage persistence and PostHog tracking.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { createContext, type ReactNode, useContext, useEffect, useState } from 'react';
+
+import { getPostHogInstance } from '@/lib/analytics/posthog-provider';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * Text size preset options
+ */
+export type TextSizePreset = 'small' | 'medium' | 'large' | 'extraLarge';
+
+/**
+ * Text size context value provided to all consumers
+ */
+export interface TextSizeContextValue {
+  /** Current text size preset */
+  preset: TextSizePreset;
+  /** Scale factor for the current preset */
+  scaleFactor: number;
+  /** Update text size preset and persist to AsyncStorage */
+  setPreset: (preset: TextSizePreset) => Promise<void>;
+  /** Calculate a scaled font size from a base value */
+  scaledFontSize: (base: number) => number;
+  /** Whether text size is still loading from AsyncStorage */
+  isLoading: boolean;
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const TEXT_SIZE_PREFERENCE_KEY = 'text-size-preference';
+const DEFAULT_PRESET: TextSizePreset = 'medium';
+
+export const SCALE_FACTORS: Record<TextSizePreset, number> = {
+  small: 0.85,
+  medium: 1.0,
+  large: 1.15,
+  extraLarge: 1.3,
+};
+
+export const PRESET_LABELS: Record<TextSizePreset, string> = {
+  small: 'Small',
+  medium: 'Medium',
+  large: 'Large',
+  extraLarge: 'Extra Large',
+};
+
+export const PRESET_ORDER: TextSizePreset[] = ['small', 'medium', 'large', 'extraLarge'];
+
+// ============================================================================
+// Context
+// ============================================================================
+
+const TextSizeContext = createContext<TextSizeContextValue | undefined>(undefined);
+
+// ============================================================================
+// Provider Component
+// ============================================================================
+
+interface TextSizeProviderProps {
+  children: ReactNode;
+}
+
+export function TextSizeProvider({ children }: TextSizeProviderProps) {
+  const [preset, setPresetState] = useState<TextSizePreset>(DEFAULT_PRESET);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load text size preference from AsyncStorage on mount
+  useEffect(() => {
+    const loadPreference = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(TEXT_SIZE_PREFERENCE_KEY);
+        if (stored && PRESET_ORDER.includes(stored as TextSizePreset)) {
+          setPresetState(stored as TextSizePreset);
+        }
+      } catch (error) {
+        console.error('Failed to load text size preference:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadPreference();
+  }, []);
+
+  // Function to update text size preference and persist to AsyncStorage
+  const setPreset = async (newPreset: TextSizePreset) => {
+    try {
+      // Optimistically update state first for immediate UI feedback
+      setPresetState(newPreset);
+
+      // Persist to AsyncStorage
+      await AsyncStorage.setItem(TEXT_SIZE_PREFERENCE_KEY, newPreset);
+
+      // Track analytics
+      const posthog = getPostHogInstance();
+      if (posthog) {
+        posthog.capture('$set', {
+          $set: { text_size_preference: newPreset },
+        });
+      }
+    } catch (error) {
+      console.error('Failed to save text size preference:', error);
+
+      if (error instanceof Error && error.message.includes('QuotaExceededError')) {
+        console.warn('Storage quota exceeded. Text size preference not persisted.');
+      }
+    }
+  };
+
+  const scaleFactor = SCALE_FACTORS[preset];
+
+  const scaledFontSize = (base: number): number => {
+    return Math.round(base * SCALE_FACTORS[preset]);
+  };
+
+  const value: TextSizeContextValue = {
+    preset,
+    scaleFactor,
+    setPreset,
+    scaledFontSize,
+    isLoading,
+  };
+
+  return <TextSizeContext.Provider value={value}>{children}</TextSizeContext.Provider>;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook to access text size context
+ *
+ * @throws Error if used outside TextSizeProvider
+ */
+export function useTextSize(): TextSizeContextValue {
+  const context = useContext(TextSizeContext);
+
+  if (context === undefined) {
+    throw new Error('useTextSize must be used within a TextSizeProvider');
+  }
+
+  return context;
+}

--- a/jest-env-setup.js
+++ b/jest-env-setup.js
@@ -143,6 +143,21 @@ jest.mock('@/contexts/ThemeContext', () => ({
   }),
 }));
 
+// Global mock for TextSizeContext to provide default text size in tests
+jest.mock('@/contexts/TextSizeContext', () => ({
+  TextSizeProvider: ({ children }) => children,
+  useTextSize: () => ({
+    preset: 'medium',
+    scaleFactor: 1.0,
+    setPreset: jest.fn(),
+    scaledFontSize: (base) => base,
+    isLoading: false,
+  }),
+  SCALE_FACTORS: { small: 0.85, medium: 1.0, large: 1.15, extraLarge: 1.3 },
+  PRESET_LABELS: { small: 'Small', medium: 'Medium', large: 'Large', extraLarge: 'Extra Large' },
+  PRESET_ORDER: ['small', 'medium', 'large', 'extraLarge'],
+}));
+
 // Mock Dictionary native module for tests
 // This module uses requireNativeModule which isn't available in Jest
 jest.mock('@/modules/dictionary', () => ({


### PR DESCRIPTION
- Add text size selector with 4 presets (Small, Medium, Large, Extra Large) for reading content                                                    
- Accessible from "Aa" button in chapter header (popover) and Settings screen
- Persists preference via AsyncStorage with PostHog analytics tracking                                                                             
- Scales only reading content (verses, explanations, notes, tooltips) — UI chrome unchanged  #94 