### PR TITLE
feat: Add font size setting for scripture text

### DIFF
--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -34,6 +34,7 @@ import { DeleteAccountFinalModal } from '@/components/account/DeleteAccountFinal
 import { DeleteAccountPasswordModal } from '@/components/account/DeleteAccountPasswordModal';
 import { DeleteAccountWarningModal } from '@/components/account/DeleteAccountWarningModal';
 import { Button } from '@/components/Button';
+import { FontSizeSelector } from '@/components/settings/FontSizeSelector';
 import { ThemeSelector } from '@/components/settings/ThemeSelector';
 import { Avatar } from '@/components/ui/Avatar';
 import { TextInput } from '@/components/ui/TextInput';
@@ -808,6 +809,9 @@ export default function SettingsScreen() {
             </View>
           )}
         </View>
+
+        {/* Font Size Section */}
+        <FontSizeSelector />
 
         {/* Theme Selector Section */}
         <ThemeSelector />

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -50,6 +50,7 @@ import { useBibleInteraction } from '@/contexts/BibleInteractionContext';
 import { isElementVisible, useTextVisibility } from '@/contexts/TextVisibilityContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useToast } from '@/contexts/ToastContext';
+import { useFontSize } from '@/hooks/bible/use-font-size';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import type { AutoHighlight } from '@/types/auto-highlights';
 import type { ChapterContent, ContentTabType, ExplanationContent } from '@/types/bible';
@@ -263,7 +264,8 @@ export function ChapterReader({
 }: ChapterReaderProps) {
   const { colors, mode } = useTheme();
   const specs = getHeaderSpecs(mode);
-  const styles = createStyles(colors, explanationsOnly);
+  const { fontSize: userFontSize } = useFontSize();
+  const styles = createStyles(colors, explanationsOnly, userFontSize);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
   const { showToast } = useToast();
 
@@ -776,7 +778,11 @@ export function ChapterReader({
   );
 }
 
-const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: boolean) =>
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  explanationsOnly?: boolean,
+  userFontSize: number = fontSizes.bodyLarge
+) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -836,21 +842,21 @@ const createStyles = (colors: ReturnType<typeof getColors>, explanationsOnly?: b
       color: colors.textTertiary,
     },
     verseText: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: userFontSize,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: userFontSize * 2.0,
       color: colors.textPrimary,
     },
     verseTextInline: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: userFontSize,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: userFontSize * 2.0,
       color: colors.textPrimary,
     },
     verseTextParagraph: {
-      fontSize: fontSizes.bodyLarge,
+      fontSize: userFontSize,
       fontWeight: fontWeights.regular,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      lineHeight: userFontSize * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },

--- a/components/settings/FontSizeSelector.tsx
+++ b/components/settings/FontSizeSelector.tsx
@@ -1,0 +1,162 @@
+/**
+ * Font Size Selector Component
+ *
+ * Provides a UI for adjusting Bible text font size with minus/plus buttons
+ * and a visual size indicator. No external dependencies — uses only
+ * React Native built-ins.
+ *
+ * Follows the same section pattern as ThemeSelector.
+ * Persists preference via useFontSize hook (AsyncStorage).
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { type getColors, spacing } from '@/constants/bible-design-tokens';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useFontSize } from '@/hooks/bible/use-font-size';
+
+export function FontSizeSelector() {
+  const { colors } = useTheme();
+  const { fontSize, setFontSize, minFontSize, maxFontSize } = useFontSize();
+  const styles = createStyles(colors);
+
+  const handleChange = async (delta: number) => {
+    const next = fontSize + delta;
+    if (next >= minFontSize && next <= maxFontSize) {
+      if (Platform.OS !== 'web') {
+        await Haptics.selectionAsync();
+      }
+      await setFontSize(next);
+    }
+  };
+
+  // Visual indicator width (0-100%)
+  const progress = ((fontSize - minFontSize) / (maxFontSize - minFontSize)) * 100;
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Display</Text>
+      <View style={styles.container}>
+        <View style={styles.headerRow}>
+          <Text style={styles.label}>Font size</Text>
+          <Text style={styles.valueText}>{fontSize}px</Text>
+        </View>
+
+        <View style={styles.controlRow}>
+          <Pressable
+            onPress={() => handleChange(-1)}
+            disabled={fontSize <= minFontSize}
+            style={[styles.button, fontSize <= minFontSize && styles.buttonDisabled]}
+          >
+            <Ionicons
+              name="remove"
+              size={20}
+              color={fontSize <= minFontSize ? colors.textDisabled : colors.textPrimary}
+            />
+          </Pressable>
+
+          <View style={styles.trackContainer}>
+            <View style={styles.track}>
+              <View style={[styles.trackFill, { width: `${progress}%` }]} />
+            </View>
+          </View>
+
+          <Pressable
+            onPress={() => handleChange(1)}
+            disabled={fontSize >= maxFontSize}
+            style={[styles.button, fontSize >= maxFontSize && styles.buttonDisabled]}
+          >
+            <Ionicons
+              name="add"
+              size={20}
+              color={fontSize >= maxFontSize ? colors.textDisabled : colors.textPrimary}
+            />
+          </Pressable>
+        </View>
+
+        <View style={styles.rangeLabels}>
+          <Text style={styles.rangeText}>Small</Text>
+          <Text style={styles.rangeText}>Large</Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    section: {
+      paddingHorizontal: spacing.lg,
+      marginBottom: spacing.xxxl,
+    },
+    sectionTitle: {
+      fontSize: 20,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      marginBottom: spacing.lg,
+    },
+    container: {
+      backgroundColor: colors.backgroundElevated,
+      borderWidth: 1,
+      borderColor: colors.borderSecondary,
+      borderRadius: 8,
+      padding: spacing.xl,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: spacing.md,
+    },
+    label: {
+      fontSize: 14,
+      fontWeight: '500',
+      color: colors.textPrimary,
+    },
+    valueText: {
+      fontSize: 12,
+      color: colors.textSecondary,
+    },
+    controlRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.md,
+    },
+    button: {
+      width: 36,
+      height: 36,
+      borderRadius: 18,
+      backgroundColor: colors.borderSecondary,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    buttonDisabled: {
+      opacity: 0.4,
+    },
+    trackContainer: {
+      flex: 1,
+      height: 36,
+      justifyContent: 'center',
+    },
+    track: {
+      height: 6,
+      backgroundColor: colors.divider,
+      borderRadius: 3,
+      overflow: 'hidden',
+    },
+    trackFill: {
+      height: '100%',
+      backgroundColor: colors.gold,
+      borderRadius: 3,
+    },
+    rangeLabels: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      marginTop: spacing.sm,
+    },
+    rangeText: {
+      fontSize: 11,
+      color: colors.textTertiary,
+    },
+  });

--- a/hooks/bible/use-font-size.ts
+++ b/hooks/bible/use-font-size.ts
@@ -1,0 +1,148 @@
+/**
+ * useFontSize Hook
+ *
+ * Manages the user's preferred Bible text font size with persistence
+ * to AsyncStorage. The font size persists across app restarts and
+ * chapter navigation.
+ *
+ * @example
+ * ```tsx
+ * const { fontSize, setFontSize, isLoading } = useFontSize();
+ *
+ * // Apply to verse text
+ * <Text style={{ fontSize }}>In the beginning...</Text>
+ *
+ * // Settings slider
+ * <Slider value={fontSize} onValueChange={setFontSize} />
+ * ```
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const STORAGE_KEY = '@versemate:font_size';
+const DEFAULT_FONT_SIZE = 18;
+const MIN_FONT_SIZE = 13;
+const MAX_FONT_SIZE = 26;
+
+// Module-level cache to prevent flickering on remount
+let inMemoryCache: number | null = null;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface UseFontSizeResult {
+  /** Current font size in pixels */
+  fontSize: number;
+  /** Update font size (persists to AsyncStorage) */
+  setFontSize: (size: number) => Promise<void>;
+  /** Whether initial load from storage is in progress */
+  isLoading: boolean;
+  /** Error if loading or saving failed */
+  error: Error | null;
+  /** Minimum allowed font size */
+  minFontSize: number;
+  /** Maximum allowed font size */
+  maxFontSize: number;
+  /** Default font size */
+  defaultFontSize: number;
+}
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+/**
+ * FOR TEST ENVIRONMENTS ONLY
+ * Resets the in-memory cache for this hook.
+ */
+export function __TEST_ONLY_RESET_CACHE() {
+  inMemoryCache = null;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+/**
+ * Hook to manage font size state with AsyncStorage persistence
+ */
+export function useFontSize(): UseFontSizeResult {
+  const [fontSize, setFontSizeState] = useState<number>(inMemoryCache || DEFAULT_FONT_SIZE);
+  const [isLoading, setIsLoading] = useState(!inMemoryCache);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Load persisted font size from AsyncStorage on mount
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadPersistedFontSize() {
+      if (inMemoryCache !== null) {
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        setError(null);
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+
+        if (isMounted) {
+          let finalSize = DEFAULT_FONT_SIZE;
+          if (stored) {
+            const parsed = Number(stored);
+            if (Number.isFinite(parsed) && parsed >= MIN_FONT_SIZE && parsed <= MAX_FONT_SIZE) {
+              finalSize = parsed;
+            }
+          }
+          setFontSizeState(finalSize);
+          inMemoryCache = finalSize;
+        }
+      } catch (err) {
+        if (isMounted) {
+          setError(err instanceof Error ? err : new Error('Failed to load font size'));
+          setFontSizeState(DEFAULT_FONT_SIZE);
+          inMemoryCache = DEFAULT_FONT_SIZE;
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    }
+
+    loadPersistedFontSize();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const setFontSize = async (size: number): Promise<void> => {
+    try {
+      const clamped = Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, Math.round(size)));
+      setFontSizeState(clamped);
+      inMemoryCache = clamped;
+      await AsyncStorage.setItem(STORAGE_KEY, String(clamped));
+      setError(null);
+    } catch (err) {
+      const storageError = err instanceof Error ? err : new Error('Failed to save font size');
+      setError(storageError);
+      console.error('useFontSize: Failed to persist font size to storage:', storageError);
+    }
+  };
+
+  return {
+    fontSize,
+    setFontSize,
+    isLoading,
+    error,
+    minFontSize: MIN_FONT_SIZE,
+    maxFontSize: MAX_FONT_SIZE,
+    defaultFontSize: DEFAULT_FONT_SIZE,
+  };
+}


### PR DESCRIPTION
## Summary
Adds a font size control (13–26px) to Settings that adjusts verse text size in the reading view. Persists to AsyncStorage across app restarts.

## Changes
| File | What |
|---|---|
| `hooks/bible/use-font-size.ts` | New hook with AsyncStorage persistence, in-memory cache, min/max/default constants. Follows `useActiveTab` pattern. |
| `components/settings/FontSizeSelector.tsx` | "Display" section with ±1px buttons and visual progress track. Uses only RN built-ins (Pressable, View), no external slider dependency. Follows ThemeSelector section pattern. |
| `app/settings.tsx` | Added `<FontSizeSelector />` between Language and Theme sections |
| `components/bible/ChapterReader.tsx` | `createStyles` accepts `userFontSize` param. `verseText`, `verseTextInline`, `verseTextParagraph` use it instead of hardcoded `fontSizes.bodyLarge` (18px). |

## How it works
1. User opens Settings → Display → Font size
2. Tapping ＋/－ buttons adjusts size by 1px with haptic feedback
3. `useFontSize` hook updates AsyncStorage + in-memory cache
4. `ChapterReader` reads the hook and passes `userFontSize` to `createStyles`
5. All three verse text styles (`verseText`, `verseTextInline`, `verseTextParagraph`) use the dynamic value
6. Default is 18px (matching `fontSizes.bodyLarge`)

## Design decisions
- **No external slider dependency** — used ±1px Pressable buttons with a visual progress track instead of `@react-native-community/slider` to avoid adding a native dependency
- **Same hook pattern as `useActiveTab`** — in-memory cache prevents flicker on remount, `__TEST_ONLY_RESET_CACHE` for test isolation
- **Only verse text is affected** — chapter titles, subtitles, verse numbers, and UI text stay at their design-token sizes

## Test plan
- [ ] Open Settings, verify "Display" section appears between Language and Theme
- [ ] Tap ＋ button — verify verse text gets larger, value label updates
- [ ] Tap ＋ until 26px — verify button disables
- [ ] Tap － until 13px — verify button disables
- [ ] Kill and relaunch app — verify font size persists
- [ ] Navigate between chapters — verify font size stays consistent

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>