### PR TITLE
feat: enable native text selection for Bible verse copy/paste (#90)

### DIFF
--- a/__tests__/components/bible/HighlightedText.test.tsx
+++ b/__tests__/components/bible/HighlightedText.test.tsx
@@ -1,14 +1,13 @@
 /**
  * HighlightedText Component Tests
  *
- * Tests for text highlighting rendering and tap detection.
- * Includes tests for theme-aware highlight colors.
+ * Tests for text highlighting rendering, tap detection, and native text selection.
  *
  * @see Task 4.1: Write 2-8 focused tests for text selection
  * @see Task 7.3: Add highlight color dark variants
  */
 
-import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { fireEvent, render } from '@testing-library/react-native';
 import * as Haptics from 'expo-haptics';
 import { Text } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
@@ -24,6 +23,18 @@ const mockUseTheme = jest.fn();
 jest.mock('@/contexts/ThemeContext', () => ({
   useTheme: () => mockUseTheme(),
 }));
+
+// Helper to recursively extract text from React element children
+const extractText = (children: any): string => {
+  if (typeof children === 'string') return children;
+  if (Array.isArray(children)) {
+    return children.map((c) => extractText(c)).join('');
+  }
+  if (children?.props?.children) {
+    return extractText(children.props.children);
+  }
+  return '';
+};
 
 describe('HighlightedText', () => {
   const mockHighlight: Highlight = {
@@ -66,6 +77,38 @@ describe('HighlightedText', () => {
     expect(getByText('In the beginning God created the heavens and the earth.')).toBeTruthy();
   });
 
+  it('should have selectable={true} on root Text for native text selection', () => {
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[]}
+      />
+    );
+
+    // Root Text should be the verse-text testID element
+    const rootText = root.findByProps({ testID: 'verse-text-1' });
+    expect(rootText.props.selectable).toBe(true);
+  });
+
+  it('should have onLongPress handlers on segment Text elements for dictionary lookup', () => {
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[mockHighlight]}
+      />
+    );
+
+    const textElements = root.findAllByType(Text);
+
+    // Segment Text elements should have onLongPress for dictionary
+    const elementsWithLongPress = textElements.filter(
+      (el: ReactTestInstance) => el.props.onLongPress !== undefined
+    );
+    expect(elementsWithLongPress.length).toBeGreaterThan(0);
+  });
+
   it('should render text with semi-transparent highlight background', () => {
     const { root } = render(
       <HighlightedText
@@ -89,19 +132,7 @@ describe('HighlightedText', () => {
 
     expect(highlightedSegment).toBeTruthy();
 
-    // Helper to recursively extract text from React elements
-    const extractText = (children: any): string => {
-      if (typeof children === 'string') return children;
-      if (Array.isArray(children)) {
-        return children.map((c) => extractText(c)).join('');
-      }
-      if (children?.props?.children) {
-        return extractText(children.props.children);
-      }
-      return '';
-    };
-
-    // Component now renders each word separately, so collect all highlighted text
+    // Tokenized rendering nests words as children — use recursive extraction
     const highlightedTexts = textElements
       .filter((el: ReactTestInstance) => {
         const style = el.props.style;
@@ -141,19 +172,6 @@ describe('HighlightedText', () => {
 
     expect(highlightedSegment).toBeTruthy();
 
-    // Helper to recursively extract text from React elements
-    const extractText = (children: any): string => {
-      if (typeof children === 'string') return children;
-      if (Array.isArray(children)) {
-        return children.map((c) => extractText(c)).join('');
-      }
-      if (children?.props?.children) {
-        return extractText(children.props.children);
-      }
-      return '';
-    };
-
-    // Component now renders each word separately, so collect all highlighted text
     const highlightedTexts = textElements
       .filter((el: ReactTestInstance) => {
         const style = el.props.style;
@@ -206,28 +224,6 @@ describe('HighlightedText', () => {
       return style?.backgroundColor?.includes(HIGHLIGHT_COLORS_DARK.green);
     });
     expect(greenSegment).toBeTruthy();
-
-    // Collect text from tokenized structure (may be nested)
-    const collectTextContent = (elements: ReactTestInstance[]): string => {
-      return elements
-        .filter((el: ReactTestInstance) => {
-          const style = el.props.style;
-          return style?.backgroundColor?.includes(HIGHLIGHT_COLORS_DARK.yellow);
-        })
-        .map((el: ReactTestInstance) => {
-          const children = el.props.children;
-          if (typeof children === 'string') return children;
-          if (Array.isArray(children)) {
-            return children
-              .flatMap((c: any) => (typeof c === 'string' ? c : c?.props?.children || ''))
-              .join('');
-          }
-          return '';
-        })
-        .join('');
-    };
-    const highlightedTexts = collectTextContent(textElements);
-    expect(highlightedTexts).toContain('beginning');
   });
 
   it('should handle multiple non-overlapping highlights in same verse', () => {
@@ -278,93 +274,110 @@ describe('HighlightedText', () => {
     expect(greenSegment).toBeTruthy();
   });
 
-  it('should call onWordLongPress when a word is long-pressed', async () => {
-    const mockOnWordLongPress = jest.fn();
+  it('should call onVerseTap with haptic feedback when plain text is tapped', async () => {
+    jest.useFakeTimers();
+    const mockOnVerseTap = jest.fn();
 
-    const { UNSAFE_root } = render(
-      <HighlightedText
-        text="In the beginning God created the heavens and the earth."
-        verseNumber={1}
-        highlights={[]}
-        onWordLongPress={mockOnWordLongPress}
-      />
-    );
-
-    // Find ALL elements recursively, not just by type
-    const findElementWithHandler = (node: any): any => {
-      if (node?.props?.onLongPress) {
-        return node;
-      }
-      if (node?.children) {
-        for (const child of node.children) {
-          const found = findElementWithHandler(child);
-          if (found) return found;
-        }
-      }
-      return null;
-    };
-
-    const parentElement = findElementWithHandler(UNSAFE_root);
-
-    // Create mock event with nativeEvent (required for tokenized word handler)
-    const mockEvent = {
-      nativeEvent: {
-        pageX: 100,
-        pageY: 200,
-        locationX: 50,
-        locationY: 10,
-      },
-    };
-
-    // Simulate long press on parent element (a word)
-    if (parentElement) {
-      fireEvent(parentElement, 'longPress', mockEvent);
-    }
-
-    // Wait for async handler to complete
-    await waitFor(() => {
-      // Expects 2 arguments: verseNumber and the word that was long-pressed
-      expect(mockOnWordLongPress).toHaveBeenCalledWith(
-        1,
-        expect.any(String) // the word that was long-pressed
-      );
-    });
-
-    // Verify haptic feedback
-    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Medium);
-  });
-
-  it('should not call onWordLongPress when callback not provided', () => {
     const { root } = render(
       <HighlightedText
         text="In the beginning God created the heavens and the earth."
         verseNumber={1}
         highlights={[]}
+        onVerseTap={mockOnVerseTap}
       />
     );
 
-    // Find the parent Text element that has the onLongPress handler
     const textElements = root.findAllByType(Text);
-    const parentTextElement = textElements.find((el: ReactTestInstance) => {
-      return el.props.onLongPress !== undefined;
-    });
+    // Find a segment with onPress (plain text segment)
+    const pressableSegment = textElements.find(
+      (el: ReactTestInstance) => el.props.onPress !== undefined
+    );
 
-    // Create mock event with nativeEvent (required for tokenized word handler)
-    const mockEvent = {
-      nativeEvent: {
-        pageX: 100,
-        pageY: 200,
-        locationX: 50,
-        locationY: 10,
-      },
-    };
+    expect(pressableSegment).toBeTruthy();
+    if (pressableSegment) {
+      fireEvent.press(pressableSegment);
+    }
 
-    // Should not throw error when long-pressing without callback
-    expect(() => {
-      if (parentTextElement) {
-        fireEvent(parentTextElement, 'longPress', mockEvent);
-      }
-    }).not.toThrow();
+    // onPress is debounced by 300ms to distinguish from double-tap
+    jest.advanceTimersByTime(300);
+
+    expect(mockOnVerseTap).toHaveBeenCalledWith(1);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+  });
+
+  it('should NOT call onVerseTap on double-tap (native selection)', () => {
+    jest.useFakeTimers();
+    const mockOnVerseTap = jest.fn();
+
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[]}
+        onVerseTap={mockOnVerseTap}
+      />
+    );
+
+    const textElements = root.findAllByType(Text);
+    const pressableSegment = textElements.find(
+      (el: ReactTestInstance) => el.props.onPress !== undefined
+    );
+
+    // Simulate double-tap: two presses within 300ms
+    if (pressableSegment) {
+      fireEvent.press(pressableSegment);
+      fireEvent.press(pressableSegment);
+    }
+
+    jest.advanceTimersByTime(300);
+
+    // Should NOT have been called — double-tap cancels the debounced handler
+    expect(mockOnVerseTap).not.toHaveBeenCalled();
+  });
+
+  it('should call onHighlightTap when highlighted text is tapped', () => {
+    jest.useFakeTimers();
+    const mockOnHighlightTap = jest.fn();
+
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[mockHighlight]}
+        onHighlightTap={mockOnHighlightTap}
+      />
+    );
+
+    const textElements = root.findAllByType(Text);
+
+    // With tokenized rendering, individual word children have onPress.
+    // Find a word element inside a highlighted segment that has onPress.
+    const pressableWord =
+      textElements.find((el: ReactTestInstance) => {
+        return (
+          el.props.onPress !== undefined &&
+          el.parent?.props?.style?.backgroundColor?.includes(HIGHLIGHT_COLORS.yellow)
+        );
+      }) ||
+      textElements.find((el: ReactTestInstance) => {
+        // Fallback: find any element with onPress inside the highlight tree
+        const style = el.props.style;
+        return (
+          el.props.onPress !== undefined &&
+          style?.backgroundColor?.includes(HIGHLIGHT_COLORS.yellow)
+        );
+      });
+
+    expect(pressableWord).toBeTruthy();
+    if (pressableWord) {
+      fireEvent.press(pressableWord);
+    }
+
+    // onPress is debounced by 300ms
+    jest.advanceTimersByTime(300);
+
+    expect(mockOnHighlightTap).toHaveBeenCalledWith(1);
+    expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
   });
 
   it('should handle multi-verse highlight spanning first verse', () => {
@@ -394,18 +407,6 @@ describe('HighlightedText', () => {
     });
 
     expect(highlightedSegment).toBeTruthy();
-    // Component renders each word separately, so we need to extract text from nested structure
-    // Helper to recursively extract text from React elements
-    const extractText = (children: any): string => {
-      if (typeof children === 'string') return children;
-      if (Array.isArray(children)) {
-        return children.map((c) => extractText(c)).join('');
-      }
-      if (children?.props?.children) {
-        return extractText(children.props.children);
-      }
-      return '';
-    };
 
     // First verse should be highlighted from char 29 to end
     const highlightedTexts = textElements

--- a/__tests__/components/bible/HighlightedText.test.tsx
+++ b/__tests__/components/bible/HighlightedText.test.tsx
@@ -298,11 +298,13 @@ describe('HighlightedText', () => {
       fireEvent.press(pressableSegment);
     }
 
-    // onPress is debounced by 300ms to distinguish from double-tap
-    jest.advanceTimersByTime(300);
-
-    expect(mockOnVerseTap).toHaveBeenCalledWith(1);
+    // Haptics fire immediately on press (not debounced)
     expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+
+    // Callback is debounced by 300ms to distinguish from double-tap
+    expect(mockOnVerseTap).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(300);
+    expect(mockOnVerseTap).toHaveBeenCalledWith(1);
   });
 
   it('should NOT call onVerseTap on double-tap (native selection)', () => {
@@ -409,11 +411,13 @@ describe('HighlightedText', () => {
       fireEvent.press(pressableWord);
     }
 
-    // onPress is debounced by 300ms
-    jest.advanceTimersByTime(300);
-
-    expect(mockOnHighlightTap).toHaveBeenCalledWith(1);
+    // Haptics fire immediately on press
     expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
+
+    // Callback is debounced by 300ms
+    expect(mockOnHighlightTap).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(300);
+    expect(mockOnHighlightTap).toHaveBeenCalledWith(1);
   });
 
   it('should handle multi-verse highlight spanning first verse', () => {

--- a/__tests__/components/bible/HighlightedText.test.tsx
+++ b/__tests__/components/bible/HighlightedText.test.tsx
@@ -335,6 +335,42 @@ describe('HighlightedText', () => {
     expect(mockOnVerseTap).not.toHaveBeenCalled();
   });
 
+  it('should cancel pending tap when long-press fires (dictionary)', () => {
+    jest.useFakeTimers();
+    const mockOnVerseTap = jest.fn();
+
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[]}
+        onVerseTap={mockOnVerseTap}
+        onWordSelect={jest.fn()}
+      />
+    );
+
+    const textElements = root.findAllByType(Text);
+    // Find an element with both onPress and onLongPress
+    const element = textElements.find(
+      (el: ReactTestInstance) => el.props.onPress && el.props.onLongPress
+    );
+
+    expect(element).toBeTruthy();
+    if (element) {
+      // Tap first (starts 300ms timer)
+      fireEvent.press(element);
+      // Then long-press (should cancel the pending tap)
+      fireEvent(element, 'longPress', {
+        nativeEvent: { pageX: 100, pageY: 200, locationX: 50, locationY: 10 },
+      });
+    }
+
+    jest.advanceTimersByTime(300);
+
+    // Tooltip should NOT have fired — long-press cancelled it
+    expect(mockOnVerseTap).not.toHaveBeenCalled();
+  });
+
   it('should call onHighlightTap when highlighted text is tapped', () => {
     jest.useFakeTimers();
     const mockOnHighlightTap = jest.fn();

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -545,6 +545,7 @@ export function ChapterReader({
                     >
                       <Text
                         style={styles.verseTextParagraph}
+                        selectable={true}
                         onTextLayout={(e) => handleTextLayout(groupKey, e)}
                       >
                         {group.map((verse, verseIndex) => {

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -21,7 +21,7 @@
  */
 
 import * as Haptics from 'expo-haptics';
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   type GestureResponderEvent,
   type LayoutChangeEvent,
@@ -306,6 +306,15 @@ export function HighlightedText({
       tapTimerRef.current = null;
     }
   };
+
+  // Clean up pending tap timer on unmount
+  useEffect(() => {
+    return () => {
+      if (tapTimerRef.current) {
+        clearTimeout(tapTimerRef.current);
+      }
+    };
+  }, []);
 
   // Track text layout for coordinate-based word detection
   const textLayoutRef = useRef<TextLayoutLine[]>([]);

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -309,11 +309,7 @@ export function HighlightedText({
 
   // Clean up pending tap timer on unmount
   useEffect(() => {
-    return () => {
-      if (tapTimerRef.current) {
-        clearTimeout(tapTimerRef.current);
-      }
-    };
+    return cancelPendingTap;
   }, []);
 
   // Track text layout for coordinate-based word detection
@@ -462,8 +458,8 @@ export function HighlightedText({
    */
   const handleHighlightTap = (highlightId: number) => {
     if (!onHighlightTap) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     debouncedPress(() => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       onHighlightTap(highlightId);
     });
   };
@@ -474,8 +470,8 @@ export function HighlightedText({
    */
   const handleAutoHighlightPress = (autoHighlight: AutoHighlight) => {
     if (!onAutoHighlightPress) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     debouncedPress(() => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       onAutoHighlightPress(autoHighlight);
     });
   };
@@ -486,8 +482,8 @@ export function HighlightedText({
    */
   const handleVerseTap = () => {
     if (!onVerseTap) return;
+    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     debouncedPress(() => {
-      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       onVerseTap(verseNumber);
     });
   };

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -281,6 +281,32 @@ export function HighlightedText({
   // Get current theme mode for highlight color selection
   const { mode } = useTheme();
 
+  // Debounce timer to distinguish single-tap from double-tap
+  // When selectable={true}, double-tap triggers native text selection.
+  // We delay onPress by 300ms and cancel if a second tap (double-tap) or long-press occurs.
+  const tapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const debouncedPress = (callback: () => void) => {
+    if (tapTimerRef.current) {
+      // Second tap within 300ms = double-tap for native selection, cancel tooltip
+      clearTimeout(tapTimerRef.current);
+      tapTimerRef.current = null;
+      return;
+    }
+    tapTimerRef.current = setTimeout(() => {
+      tapTimerRef.current = null;
+      callback();
+    }, 300);
+  };
+
+  // Cancel pending tap when long-press fires (dictionary lookup)
+  const cancelPendingTap = () => {
+    if (tapTimerRef.current) {
+      clearTimeout(tapTimerRef.current);
+      tapTimerRef.current = null;
+    }
+  };
+
   // Track text layout for coordinate-based word detection
   const textLayoutRef = useRef<TextLayoutLine[]>([]);
   const containerWidthRef = useRef<number>(0);
@@ -423,32 +449,38 @@ export function HighlightedText({
 
   /**
    * Handle tap on a user highlight segment
-   * Shows grouped/single highlight tooltip
+   * Debounced to avoid firing on double-tap (native text selection)
    */
   const handleHighlightTap = (highlightId: number) => {
     if (!onHighlightTap) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onHighlightTap(highlightId);
+    debouncedPress(() => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onHighlightTap(highlightId);
+    });
   };
 
   /**
    * Handle tap on auto-highlight segment
-   * Shows auto-highlight tooltip
+   * Debounced to avoid firing on double-tap (native text selection)
    */
   const handleAutoHighlightPress = (autoHighlight: AutoHighlight) => {
     if (!onAutoHighlightPress) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onAutoHighlightPress(autoHighlight);
+    debouncedPress(() => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onAutoHighlightPress(autoHighlight);
+    });
   };
 
   /**
    * Handle tap on plain text
-   * Shows verse insight tooltip
+   * Debounced to avoid firing on double-tap (native text selection)
    */
   const handleVerseTap = () => {
     if (!onVerseTap) return;
-    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    onVerseTap(verseNumber);
+    debouncedPress(() => {
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      onVerseTap(verseNumber);
+    });
   };
 
   /**
@@ -477,6 +509,7 @@ export function HighlightedText({
     segmentStartChar: number,
     event: GestureResponderEvent
   ) => {
+    cancelPendingTap();
     const { locationX, locationY, pageX, pageY } = event.nativeEvent;
 
     // Use line layout for accurate wrapped text detection
@@ -564,6 +597,7 @@ export function HighlightedText({
     endChar: number,
     event: GestureResponderEvent
   ) => {
+    cancelPendingTap();
     const { pageX, pageY } = event.nativeEvent;
 
     // Clean punctuation from word
@@ -696,7 +730,7 @@ export function HighlightedText({
     const tokens = tokenizeText(segment.text);
 
     return (
-      <Text key={segment.key} style={segmentStyle} suppressHighlighting={true}>
+      <Text key={segment.key} style={segmentStyle}>
         {tokens.map((token) => {
           // Calculate absolute char positions in verse text
           const absoluteStartChar = segment.startChar + token.startChar;
@@ -723,7 +757,6 @@ export function HighlightedText({
               onLongPress={(e) =>
                 handleTokenizedWordLongPress(token.word, absoluteStartChar, absoluteEndChar, e)
               }
-              suppressHighlighting={true}
               {...responderProps}
             >
               {token.word}
@@ -738,8 +771,7 @@ export function HighlightedText({
   return (
     <Text
       style={style}
-      selectable={false}
-      suppressHighlighting={true}
+      selectable={true}
       onTextLayout={handleTextLayout}
       onLayout={handleLayout}
       onPress={handleOuterPress}
@@ -785,7 +817,6 @@ export function HighlightedText({
                 style={highlightStyle}
                 onPress={() => handleHighlightTap(highlightId)}
                 onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-                suppressHighlighting={true}
               >
                 {selectionParts.before}
                 <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -800,7 +831,6 @@ export function HighlightedText({
               style={highlightStyle}
               onPress={() => handleHighlightTap(highlightId)}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-              suppressHighlighting={true}
             >
               {segment.text}
             </Text>
@@ -820,7 +850,6 @@ export function HighlightedText({
                 style={autoHighlightStyle}
                 onPress={() => handleAutoHighlightPress(autoHighlight)}
                 onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-                suppressHighlighting={true}
               >
                 {selectionParts.before}
                 <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -835,7 +864,6 @@ export function HighlightedText({
               style={autoHighlightStyle}
               onPress={() => handleAutoHighlightPress(autoHighlight)}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-              suppressHighlighting={true}
             >
               {segment.text}
             </Text>
@@ -850,7 +878,6 @@ export function HighlightedText({
               key={segment.key}
               onPress={handleVerseTap}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-              suppressHighlighting={true}
             >
               {selectionParts.before}
               <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -864,7 +891,6 @@ export function HighlightedText({
             key={segment.key}
             onPress={handleVerseTap}
             onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
-            suppressHighlighting={true}
           >
             {segment.text}
           </Text>


### PR DESCRIPTION
## Summary                                       
                                                                                                                                                 
  - Enable native double-tap text selection for copy/paste on Bible verse text                                                                   
  - Add debounced tap handlers (300ms) to prevent tooltip flash on double-tap/long-press                                                         
  - Preserve all existing interactions: single-tap (tooltip), long-press (dictionary)
                                                                                                                                                 
  ## Gesture Model                                                 
                                                                                                                                                 
  | Gesture | Action |
  |---------|--------|                                                                                                                           
  | Single tap | Verse insight tooltip (300ms debounce) |          
  | Long-press | Bible dictionary (Easton's/Strong's) |                                                                                          
  | Double-tap | Native text selection + copy/paste |              
                                                   
  ## Changes                              
                                                                                                                                                 
  - `HighlightedText.tsx`: Set `selectable={true}`, removed `suppressHighlighting`, added tap debounce to distinguish single-tap from double-tap 
  - `ChapterReader.tsx`: Set `selectable={true}` on paragraph group Text for cross-verse selection                                               
  - `HighlightedText.test.tsx`: Added tests for selectable, debounce, double-tap cancellation                                                    
                                                                                                                                                 
  ## Test plan                                     
                                                                                                                                                 
  - [ ] Double-tap selects a word on iOS and Android                                                                                             
  - [ ] Drag selection handles across multiple words/lines/verses                                                                                
  - [ ] Copy from native context menu works                                                                                                      
  - [ ] Single tap still opens verse insight tooltip (with ~300ms delay)                                                                         
  - [ ] Long-press still opens Bible dictionary    
  - [ ] Tap on highlighted text still opens highlight tooltip                                                                                    
  - [ ] Scrolling works normally alongside text selection          