### PR TITLE
Fix 4 flaky E2E tests: scroll, wait, and timing issues

### DIFF
--- a/.maestro/bible-reading/verse-insight-flow.yaml
+++ b/.maestro/bible-reading/verse-insight-flow.yaml
@@ -18,11 +18,13 @@ tags:
 - runFlow: ../shared/setup.yaml
 
 # Wait for app to fully load (Genesis 1)
-# Extended timeout: previous test may leave app in unexpected state
 - extendedWaitUntil:
     visible:
       id: "chapter-selector-button"
-    timeout: 60000
+    timeout: 30000
+
+# Wait for page to settle before interacting
+- waitForAnimationToEnd
 
 # Explicitly tap Bible view button to ensure we're in Bible view
 # (idempotent — stays in Bible view if already there)

--- a/.maestro/highlights/highlights-authenticated-flow.yaml
+++ b/.maestro/highlights/highlights-authenticated-flow.yaml
@@ -36,6 +36,12 @@ tags:
 # Test 1: Create Highlight via Verse Tap
 # ============================================
 
+# Wait for verse content to load after login redirect
+- extendedWaitUntil:
+    visible:
+      id: "verse-text-1"
+    timeout: 15000
+
 # Tap verse 1 to open highlight selection
 - tapOn:
     id: "verse-text-1"

--- a/.maestro/notes/notes-authenticated-flow.yaml
+++ b/.maestro/notes/notes-authenticated-flow.yaml
@@ -60,6 +60,12 @@ tags:
 # Test 2: Verify Note in Notes List
 # ============================================
 
+# Wait for Bible screen to fully settle after modal close
+- extendedWaitUntil:
+    visible:
+      id: "hamburger-menu-button"
+    timeout: 10000
+
 # Open hamburger menu
 - tapOn:
     id: "hamburger-menu-button"
@@ -67,7 +73,7 @@ tags:
 - extendedWaitUntil:
     visible:
       id: "hamburger-menu"
-    timeout: 5000
+    timeout: 15000
 
 # Navigate to Notes
 - tapOn:

--- a/.maestro/settings/settings-flow.yaml
+++ b/.maestro/settings/settings-flow.yaml
@@ -60,9 +60,12 @@ tags:
 - assertVisible:
     text: "Bible Version"
 
-# For unauthenticated user, sign in button should be visible
-- assertVisible:
-    id: "settings-sign-in-button"
+# Scroll down to find sign-in button (may be below fold)
+- scrollUntilVisible:
+    element:
+      id: "settings-sign-in-button"
+    direction: DOWN
+    timeout: 10000
 
 # ============================================
 # Test 3: Navigate Back to Chapter


### PR DESCRIPTION
## Summary
- **Settings Flow**: scroll to sign-in button (below fold on CI emulator)
- **Highlights CRUD**: wait for `verse-text-1` to load after login redirect
- **Notes CRUD**: wait for `hamburger-menu-button` visibility before tapping, increase menu timeout
- **Verse Insight**: add `waitForAnimationToEnd` before interacting with UI

## Context
Full E2E run on main after merging #255 showed 34/38 passing. These 4 failures are timing/scroll issues, not functional bugs.

## Test plan
- [ ] Run full E2E suite on this branch