### PR TITLE
fix(offline): read local user data when synced even while online

### DIFF
--- a/hooks/bible/use-bookmarks.ts
+++ b/hooks/bible/use-bookmarks.ts
@@ -167,12 +167,14 @@ export function useBookmarks(): UseBookmarksResult {
   });
 
   // Extract bookmarks array from response (offline or remote)
+  // When user data is synced locally, the remote query is disabled, so we must
+  // read from the local cache regardless of network state.
   const bookmarks = useMemo(() => {
-    if (isDeviceOffline && localBookmarksData) {
+    if ((isDeviceOffline || isUserDataSynced) && localBookmarksData) {
       return localBookmarksData as Bookmark[];
     }
     return bookmarksData?.favorites || [];
-  }, [isDeviceOffline, localBookmarksData, bookmarksData]);
+  }, [isDeviceOffline, isUserDataSynced, localBookmarksData, bookmarksData]);
 
   // Add bookmark mutation
   const addMutation = useMutation({

--- a/hooks/bible/use-highlights.ts
+++ b/hooks/bible/use-highlights.ts
@@ -263,19 +263,21 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
   });
 
   // Extract highlights arrays from responses (offline or remote)
+  // When user data is synced locally, the remote query is disabled, so we must
+  // read from the local cache regardless of network state.
   const allHighlights = useMemo(() => {
-    if (isDeviceOffline && localAllHighlights) {
+    if ((isDeviceOffline || isUserDataSynced) && localAllHighlights) {
       return mapOfflineHighlights(localAllHighlights);
     }
     return allHighlightsData?.highlights || [];
-  }, [isDeviceOffline, localAllHighlights, allHighlightsData]);
+  }, [isDeviceOffline, isUserDataSynced, localAllHighlights, allHighlightsData]);
 
   const chapterHighlights = useMemo(() => {
-    if (isDeviceOffline && localChapterHighlights) {
+    if ((isDeviceOffline || isUserDataSynced) && localChapterHighlights) {
       return mapOfflineHighlights(localChapterHighlights);
     }
     return chapterHighlightsData?.highlights || [];
-  }, [isDeviceOffline, localChapterHighlights, chapterHighlightsData]);
+  }, [isDeviceOffline, isUserDataSynced, localChapterHighlights, chapterHighlightsData]);
 
   // Add highlight mutation
   const addMutation = useMutation({

--- a/hooks/bible/use-notes.ts
+++ b/hooks/bible/use-notes.ts
@@ -162,12 +162,14 @@ export function useNotes(): UseNotesResult {
   });
 
   // Extract notes array from response (offline or remote)
+  // When user data is synced locally, the remote query is disabled, so we must
+  // read from the local cache regardless of network state.
   const notes = useMemo(() => {
-    if (isDeviceOffline && localNotesData) {
+    if ((isDeviceOffline || isUserDataSynced) && localNotesData) {
       return localNotesData as Note[];
     }
     return notesData?.notes || [];
-  }, [isDeviceOffline, localNotesData, notesData]);
+  }, [isDeviceOffline, isUserDataSynced, localNotesData, notesData]);
 
   // Add note mutation
   const addMutation = useMutation({


### PR DESCRIPTION
## Summary

Logged-in online users see empty Notes / Highlights / Bookmarks pages once `isUserDataSynced=true`. The remote query is intentionally disabled (added in #124) but the data-source memo still gates on `isDeviceOffline` only — so it returns the empty remote data instead of the local cache.

The companion fix #235 ("Fix infinite spinner on Bookmarks and Notes") patched the loading-guard side of this same regression by adding `!isUserDataSynced` to the `dataUpdatedAt === 0` check. That stopped the permanent spinner — but uncovered the empty-page state since the memo was never updated. This PR finishes the job.

Andy is hitting this exact state: empty pages on all three screens, no spinner, despite his data being in the DB and visible on the web app.

## Changes

In `hooks/bible/use-notes.ts`, `hooks/bible/use-bookmarks.ts`, `hooks/bible/use-highlights.ts`:

- Memo now prefers local data when `isDeviceOffline || isUserDataSynced` (was `isDeviceOffline` only)

## Test plan

- [x] `bun run type-check` passes
- [x] `npm test -- --testPathPattern="use-(notes|highlights|bookmarks)"` — all 13 hook tests green (including the existing `isUserDataSynced gating` tests)
- [ ] Manual: log in online with an account that has notes/highlights/bookmarks → verify they appear on each list page (this is what we want Andy to verify)
- [ ] Manual: airplane mode → verify offline data still shows
- [ ] Manual: log in fresh on an account with no data → verify empty state shows correctly

## Edge case

If the fix doesn't resolve a user's empty-page report, the local SQLite tables themselves are likely empty (sync wrote the metadata row but no actual data). That points to a separate bug in `downloadUserData` and would need investigation of the API payload for that user.