### PR TITLE
fix(bookmarks, highlights, notes): show toast on mutation failure

### DIFF
--- a/hooks/bible/use-bookmarks.ts
+++ b/hooks/bible/use-bookmarks.ts
@@ -34,6 +34,7 @@ import { useMemo } from 'react';
 import { getBookById } from '@/constants/bible-books';
 import { useAuth } from '@/contexts/AuthContext';
 import { useOfflineContext } from '@/contexts/OfflineContext';
+import { useToast } from '@/contexts/ToastContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
   addLocalBookmark,
@@ -119,6 +120,7 @@ export function useBookmarks(): UseBookmarksResult {
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { isUserDataSynced, isOnline } = useOfflineContext();
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   const isDeviceOffline = !isOnline;
 
@@ -260,6 +262,7 @@ export function useBookmarks(): UseBookmarksResult {
         queryClient.setQueryData(bookmarksQueryKey, context.previousBookmarks);
       }
       console.error('Failed to add bookmark:', error);
+      showToast('Failed to add bookmark. Please try again.');
     },
     onSuccess: (_data, variables) => {
       // Track analytics: BOOKMARK_ADDED event
@@ -340,6 +343,7 @@ export function useBookmarks(): UseBookmarksResult {
         queryClient.setQueryData(bookmarksQueryKey, context.previousBookmarks);
       }
       console.error('Failed to remove bookmark:', error);
+      showToast('Failed to remove bookmark. Please try again.');
     },
     onSuccess: (_data, variables) => {
       // Track analytics: BOOKMARK_REMOVED event

--- a/hooks/bible/use-highlights.ts
+++ b/hooks/bible/use-highlights.ts
@@ -49,6 +49,7 @@ import { useMemo } from 'react';
 import type { HighlightColor } from '@/constants/highlight-colors';
 import { useAuth } from '@/contexts/AuthContext';
 import { useOfflineContext } from '@/contexts/OfflineContext';
+import { useToast } from '@/contexts/ToastContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
   addLocalHighlight,
@@ -177,6 +178,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { isUserDataSynced, isOnline } = useOfflineContext();
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   const { bookId, chapterNumber } = options || {};
   const isDeviceOffline = !isOnline;
@@ -399,6 +401,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
         queryClient.setQueryData(chapterHighlightsQueryKey, context.previousChapterHighlights);
       }
       console.error('Failed to add highlight:', error);
+      showToast('Failed to save highlight. Please try again.');
 
       // Re-throw error for component to handle (especially overlap errors)
       throw error;
@@ -557,6 +560,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
         queryClient.setQueryData(chapterHighlightsQueryKey, context.previousChapterHighlights);
       }
       console.error('Failed to update highlight color:', error);
+      showToast('Failed to update highlight. Please try again.');
     },
     onSuccess: (_data, variables) => {
       try {
@@ -649,6 +653,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
         queryClient.setQueryData(chapterHighlightsQueryKey, context.previousChapterHighlights);
       }
       console.error('Failed to delete highlight:', error);
+      showToast('Failed to remove highlight. Please try again.');
     },
     onSuccess: (_data, variables) => {
       try {

--- a/hooks/bible/use-notes.ts
+++ b/hooks/bible/use-notes.ts
@@ -43,6 +43,7 @@ import { useMemo } from 'react';
 import { getBookById } from '@/constants/bible-books';
 import { useAuth } from '@/contexts/AuthContext';
 import { useOfflineContext } from '@/contexts/OfflineContext';
+import { useToast } from '@/contexts/ToastContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
   addLocalNote,
@@ -111,6 +112,7 @@ export function useNotes(): UseNotesResult {
   const { user, isAuthenticated, isLoading: isAuthLoading } = useAuth();
   const { isUserDataSynced, isOnline } = useOfflineContext();
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
 
   const isDeviceOffline = !isOnline;
 
@@ -250,6 +252,7 @@ export function useNotes(): UseNotesResult {
         queryClient.setQueryData(notesQueryKey, context.previousNotes);
       }
       console.error('Failed to add note:', error);
+      showToast('Failed to save note. Please try again.');
     },
     onSuccess: (_data, variables) => {
       // Track analytics: NOTE_CREATED event (never track note content)
@@ -329,6 +332,7 @@ export function useNotes(): UseNotesResult {
         queryClient.setQueryData(notesQueryKey, context.previousNotes);
       }
       console.error('Failed to update note:', error);
+      showToast('Failed to update note. Please try again.');
     },
     onSuccess: (_data, variables) => {
       // Track analytics: NOTE_EDITED event (never track note content)
@@ -387,6 +391,7 @@ export function useNotes(): UseNotesResult {
         queryClient.setQueryData(notesQueryKey, context.previousNotes);
       }
       console.error('Failed to delete note:', error);
+      showToast('Failed to delete note. Please try again.');
     },
     onSuccess: (_data, variables) => {
       // Track analytics: NOTE_DELETED event

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -3,6 +3,16 @@ import { FormData, fetch, Headers, Request, Response } from 'undici';
 import { resetPostHogMock } from './__tests__/mocks/posthog-mock';
 import { server } from './__tests__/mocks/server';
 
+// Mock toast context — no-op showToast/hideToast so hooks calling useToast() in
+// tests don't blow up on the "must be within ToastProvider" guard.
+jest.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({
+    showToast: jest.fn(),
+    hideToast: jest.fn(),
+  }),
+  ToastProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+
 // Mock offline context to avoid SQLite initialization in tests
 jest.mock('@/contexts/OfflineContext', () => ({
   useOfflineContext: () => ({


### PR DESCRIPTION
## Summary

Cross-cutting gap caught during reverse-spec audit: the 8 `onError` handlers across the 3 sister hooks silently `console.error`'d without surfacing anything to the user. Failed add/remove/update flowed through optimistic add → server error → rollback → user sees the row vanish with no explanation.

This wires the existing `useToast` hook (already in `ToastContext`, already mounted in `app/_layout.tsx`, already used by `BibleInteractionContext`) into all 8 sites.

## Changes

- `use-bookmarks.ts` × 2: `addMutation`, `removeMutation`
- `use-highlights.ts` × 3: add, update, delete
- `use-notes.ts` × 3: add, update, delete
- `test-setup.ts`: globally mocks `ToastContext` (mirrors the existing `OfflineContext` mock) so existing tests don't trip the "useToast must be within a ToastProvider" guard

Toast messages are user-friendly and action-suggestive ("Failed to save highlight. Please try again.") — never raw network errors.

## Test plan

- [x] `npm test -- --testPathPattern="use-bookmarks|use-notes|use-highlights"` → 13/13 pass
- [x] `npm test -- --testPathPattern="bookmarks|highlights|notes|BookmarkToggle|NotesModal"` → 109/109 pass across 17 suites
- [x] `bun run type-check` → 0 errors
- [x] `bun run lint` → 0 errors (2 pre-existing warnings in unrelated storybook file)
- [ ] Manual verification: trigger a mutation while server is unreachable; confirm toast appears with the rollback

## Spec traceability

Resolves the gap surfaced by reverse-engineering passes in versemate-meta:
- `specs/feat-bookmarks/questions.md` QA-004
- `specs/feat-highlights/questions.md` QA-H-004
- `specs/feat-notes/questions.md` QA-N-005

Paired spec update on verse-mate-meta branch `feat-mutation-error-toasts-spec-update` (adds br-009 / br-H-005 / br-N-005).

🤖 Generated with [Claude Code](https://claude.com/claude-code)