### PR TITLE
fix(chapter-reader): restore suppressHighlighting on verse-tap targets (BUG-003)

### DIFF
--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -735,7 +735,7 @@ export function HighlightedText({
     const tokens = tokenizeText(segment.text);
 
     return (
-      <Text key={segment.key} style={segmentStyle}>
+      <Text key={segment.key} style={segmentStyle} suppressHighlighting={true}>
         {tokens.map((token) => {
           // Calculate absolute char positions in verse text
           const absoluteStartChar = segment.startChar + token.startChar;
@@ -762,6 +762,7 @@ export function HighlightedText({
               onLongPress={(e) =>
                 handleTokenizedWordLongPress(token.word, absoluteStartChar, absoluteEndChar, e)
               }
+              suppressHighlighting={true}
               {...responderProps}
             >
               {token.word}
@@ -777,6 +778,7 @@ export function HighlightedText({
     <Text
       style={style}
       selectable={true}
+      suppressHighlighting={true}
       onTextLayout={handleTextLayout}
       onLayout={handleLayout}
       onPress={handleOuterPress}
@@ -822,6 +824,7 @@ export function HighlightedText({
                 style={highlightStyle}
                 onPress={() => handleHighlightTap(highlightId)}
                 onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+                suppressHighlighting={true}
               >
                 {selectionParts.before}
                 <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -836,6 +839,7 @@ export function HighlightedText({
               style={highlightStyle}
               onPress={() => handleHighlightTap(highlightId)}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+              suppressHighlighting={true}
             >
               {segment.text}
             </Text>
@@ -855,6 +859,7 @@ export function HighlightedText({
                 style={autoHighlightStyle}
                 onPress={() => handleAutoHighlightPress(autoHighlight)}
                 onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+                suppressHighlighting={true}
               >
                 {selectionParts.before}
                 <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -869,6 +874,7 @@ export function HighlightedText({
               style={autoHighlightStyle}
               onPress={() => handleAutoHighlightPress(autoHighlight)}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+              suppressHighlighting={true}
             >
               {segment.text}
             </Text>
@@ -883,6 +889,7 @@ export function HighlightedText({
               key={segment.key}
               onPress={handleVerseTap}
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+              suppressHighlighting={true}
             >
               {selectionParts.before}
               <Text style={selectionStyles.selected}>{selectionParts.selected}</Text>
@@ -896,6 +903,7 @@ export function HighlightedText({
             key={segment.key}
             onPress={handleVerseTap}
             onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
+            suppressHighlighting={true}
           >
             {segment.text}
           </Text>


### PR DESCRIPTION
## Summary

Andy reported that single-tapping a verse on iOS no longer shows the whole-verse underline — instead a single word flashes in iOS yellow/blue tint for ~200ms before the verse-insight popover opens (BUG-003).

**Root cause:** PR #260 (native text selection for copy/paste) removed `suppressHighlighting={true}` from every `<Text onPress=...>` site in `HighlightedText.tsx`. With the RN default (`false`), iOS shows its native press tint on the tapped substring.

**Fix:** Restored `suppressHighlighting={true}` on all 8 inner `<Text onPress=...>` Pressables. Safe — `suppressHighlighting` only suppresses press-feedback tint and does not interfere with `selectable={true}` text selection on the outer paragraph (copy/paste from PR #260 still works).

The whole-verse underline restoration is filed as a follow-up (requires plumbing pressed-state up to ChapterReader's verse-group View).

## Test plan

- [ ] Manual iOS: tap a verse — no word flashes, popover still opens after 300ms debounce
- [ ] Manual iOS: long-press / double-tap — native text selection still works for copy/paste
- [ ] Unit tests: 12 existing HighlightedText tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)