### PR TITLE
fix(notes): cross-chapter state leak and stale local cache after add

### DIFF
--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -864,7 +864,16 @@ export function ChapterPage({
       </Animated.ScrollView>
 
       {/* Note Modals - Rendered OUTSIDE ScrollView */}
+      {/*
+        NOTES-1: Force a fresh NotesModal instance per chapter.
+        This route reuses the same ChapterPage component when the
+        bookId/chapterNumber params change (Expo Router behavior),
+        so the modal's local `recentNotes` state would otherwise leak
+        across chapters and surface notes from the previously visited
+        chapter on the current one.
+      */}
       <NotesModal
+        key={`notes-${bookId}-${chapterNumber}`}
         visible={notesModalVisible}
         bookId={bookId}
         chapterNumber={chapterNumber}

--- a/hooks/bible/use-notes.ts
+++ b/hooks/bible/use-notes.ts
@@ -204,7 +204,34 @@ export function useNotes(): UseNotesResult {
       if (!fn) throw new Error('Mutation function missing');
 
       // biome-ignore lint/suspicious/noExplicitAny: context required by type
-      return fn(variables, undefined as any);
+      const response = await fn(variables, undefined as any);
+
+      // NOTES-1: When the user's data is synced locally, the remote notes
+      // query is disabled (see line ~139) and the UI reads from the local
+      // SQLite cache. A bare POST leaves that cache stale, so the standalone
+      // notes screen never sees the new note until the next full sync.
+      // Mirror the server-confirmed note into the local cache so consumers
+      // that read from `localNotesData` reflect the add immediately.
+      if (isUserDataSynced && response?.note && variables.body) {
+        try {
+          await addLocalNote({
+            note_id: response.note.note_id,
+            book_id: variables.body.book_id,
+            chapter_number: variables.body.chapter_number,
+            verse_number:
+              typeof response.note.verse_id === 'number' ? response.note.verse_id : null,
+            content: response.note.content,
+            updated_at: response.note.updated_at,
+          });
+        } catch (err) {
+          // Don't fail the mutation if the local mirror write fails —
+          // the server is still the source of truth and invalidateQueries
+          // below will eventually reconcile.
+          console.warn('[notes] failed to mirror new note into local cache', err);
+        }
+      }
+
+      return response;
     },
     onMutate: async (variables) => {
       // Cancel any outgoing refetches


### PR DESCRIPTION
## Summary

Fixes two related bugs in the chapter notes flow that caused the UI to disagree with what was actually persisted on the server.

| # | Bug | Where it surfaced |
|---|---|---|
| 1 | NotesModal showed the **previous chapter's** notes after navigating | In-chapter Notes modal |
| 2 | Newly added notes **did not appear** on the standalone Notes screen until next full sync | Hamburger menu → Notes → chapter |

In both cases the server side was correct — the data wasn't lost, just not surfaced.

## Bug 1 — Cross-chapter `recentNotes` state leak

**Repro (before fix):**
1. Open Genesis 1 → Notes → add a note ("g-1")
2. Switch to Exodus 1 via the chapter dropdown
3. Open Notes — see "g-1" listed under "Recently Added Notes" on Exodus 1

**Cause:**
`app/bible/[bookId]/[chapterNumber].tsx` is a dynamic route. Expo Router reuses the same `ChapterPage` component instance and only swaps params when navigating between chapters. `NotesModal` lives inside `ChapterPage` and keeps its `recentNotes` local state across the param change, so notes added on one chapter remained visible on every subsequent chapter until app reload.

**Fix (`components/bible/ChapterPage.tsx`):**
Added a chapter-keyed React `key` on `<NotesModal>`:

```tsx
<NotesModal
  key={`notes-${bookId}-${chapterNumber}`}
  ...
/>
```

When the chapter changes, React unmounts the old NotesModal and mounts a fresh one, resetting `recentNotes` (and any other per-chapter state). No state leak across chapters by construction.

## Bug 2 — Stale local cache for the standalone Notes screen

**Repro (before fix):**
1. On Exodus 1, open the in-chapter Notes modal and add a note
2. Confirm it appears in the modal's "Recently Added Notes"
3. Hamburger menu → Notes → Exodus 1
4. The note added in step 1 is missing from the list

**Cause:**
In `useNotes` (`hooks/bible/use-notes.ts`), once `isUserDataSynced` is `true` the remote notes query is **disabled** and the rendered `notes` array is read from the local SQLite cache (`localNotesData`):

```ts
enabled: isAuthenticated && !!user?.id && !isDeviceOffline && !isUserDataSynced
// ...
if ((isDeviceOffline || isUserDataSynced) && localNotesData) {
  return localNotesData as Note[];
}
```

The online add path inside `addMutation.mutationFn` only POSTed to the backend — it never wrote the new note into the local cache. The optimistic `setQueryData` and the post-success `invalidateQueries` both targeted the disabled remote query, so the standalone Notes screen kept returning the pre-add local snapshot until the next full user-data sync.

**Fix (`hooks/bible/use-notes.ts`):**
After a successful online POST, mirror the server-confirmed note into the local cache via `addLocalNote` whenever `isUserDataSynced` is true:

```ts
const response = await fn(variables, undefined as any);

if (isUserDataSynced && response?.note && variables.body) {
  try {
    await addLocalNote({
      note_id: response.note.note_id,
      book_id: variables.body.book_id,
      chapter_number: variables.body.chapter_number,
      verse_number:
        typeof response.note.verse_id === 'number' ? response.note.verse_id : null,
      content: response.note.content,
      updated_at: response.note.updated_at,
    });
  } catch (err) {
    console.warn('[notes] failed to mirror new note into local cache', err);
  }
}

return response;
```

`onSuccess` already invalidates `['local-notes-offline-fallback']`, so the local query refetches and picks up the new row immediately. Local-mirror failures are logged but never fail the mutation — the server stays the source of truth.

## Test plan

- [x] iOS: Add 2 notes on Exodus 1 in the modal — both show in "Recently Added Notes"
- [x] iOS: Switch to Genesis 1 — modal opens with empty "Recently Added Notes" (no leakage from Exodus)
- [x] iOS: Switch back to Exodus 1 — modal opens empty (per-chapter remount, expected)
- [x] iOS: Add a note on Exodus 1, then hamburger → Notes → Exodus 1 — the new note is listed
- [x] iOS: Repeat for a logged-in user with `isUserDataSynced=true` (post-onboarding) and `false` (pre-onboarding) — both paths work
- [x] iOS offline: Add a note while offline, regain connectivity — note still surfaces correctly (offline path unchanged)
- [ ] Android: same flows (no platform-specific code touched)

## Out of scope / follow-up

The in-chapter NotesModal still uses a per-instance `recentNotes` array as its sole display source. After the fix in this PR, it correctly resets per chapter — but it still doesn't surface notes added in earlier sessions for the current chapter. A follow-up could replace `recentNotes` with a derivation from `useNotes()` filtered by `(bookId, chapterNumber)` so the modal mirrors the standalone Notes screen and stays consistent across app restarts. Tracked as: TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)