### PR TITLE
feat(auth): migrate token storage to expo-secure-store (D-024)

### DIFF
--- a/.maestro/bug-repros/bug-001-1sam2.yaml
+++ b/.maestro/bug-repros/bug-001-1sam2.yaml
@@ -1,0 +1,82 @@
+appId: org.versemate.app
+name: BUG-001 — 1 Samuel 2 portrait truncation repro
+description: |
+  Andy: end of verse text missing on 1 Samuel 2, visible truncation mid-line.
+  Workaround was rotate-to-landscape-and-back. Likely RN measurement issue.
+tags:
+  - bug-repro
+  - chapter-reader
+---
+
+- launchApp:
+    appId: org.versemate.app
+
+- runFlow:
+    when:
+      visible:
+        text: "Skip"
+    commands:
+      - tapOn:
+          text: "Skip"
+
+- extendedWaitUntil:
+    visible:
+      id: "chapter-selector-button"
+    timeout: 30000
+
+- tapOn:
+    id: "chapter-selector-button"
+
+- extendedWaitUntil:
+    visible:
+      id: "bible-navigation-modal"
+    timeout: 5000
+
+- tapOn:
+    id: "tab-old-testament"
+
+# Use the filter input to disambiguate — much more reliable than scrollUntilVisible
+- tapOn: "Filter books..."
+- inputText: "1 Samuel"
+- waitForAnimationToEnd
+
+- tapOn:
+    id: "book-item-1-samuel"
+
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    visible:
+      id: "chapter-2"
+    timeout: 10000
+
+- tapOn:
+    id: "chapter-2"
+
+- waitForAnimationToEnd
+
+- extendedWaitUntil:
+    notVisible:
+      id: "bible-navigation-modal"
+    timeout: 5000
+
+- assertVisible:
+    text: "1 Samuel 2"
+
+- takeScreenshot: bug-001-1sam2-portrait-top
+
+- scroll
+- waitForAnimationToEnd
+- takeScreenshot: bug-001-1sam2-portrait-scrolled
+
+- scroll
+- waitForAnimationToEnd
+- takeScreenshot: bug-001-1sam2-portrait-mid
+
+- setOrientation: LANDSCAPE_LEFT
+- waitForAnimationToEnd
+- takeScreenshot: bug-001-1sam2-landscape
+
+- setOrientation: PORTRAIT
+- waitForAnimationToEnd
+- takeScreenshot: bug-001-1sam2-portrait-after-rotation

--- a/__tests__/lib/auth/token-storage.test.ts
+++ b/__tests__/lib/auth/token-storage.test.ts
@@ -1,106 +1,63 @@
 /**
  * Token Storage Tests
  *
- * Focused tests for token storage using AsyncStorage.
- * Tests only critical behaviors: store, retrieve, and clear tokens.
+ * Per spec feat-auth-platform br-auth-001 (D-005) + Phase 1 decision D-024:
+ * tokens migrated to SecureStore. Refresh tokens eliminated. Tests cover
+ * SecureStore primary path + one-time migration from legacy AsyncStorage.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import {
-  clearTokens,
-  getAccessToken,
-  getRefreshToken,
-  setAccessToken,
-  setRefreshToken,
-} from '@/lib/auth/token-storage';
+import * as SecureStore from 'expo-secure-store';
+import { clearTokens, getAccessToken, setAccessToken } from '@/lib/auth/token-storage';
 
-// Mock @react-native-async-storage/async-storage
-jest.mock('@react-native-async-storage/async-storage', () => ({
-  setItem: jest.fn(),
-  getItem: jest.fn(),
-  removeItem: jest.fn(),
-  multiRemove: jest.fn(),
+jest.mock('expo-secure-store', () => ({
+  setItemAsync: jest.fn(),
+  getItemAsync: jest.fn(),
+  deleteItemAsync: jest.fn(),
 }));
 
-describe('Token Storage', () => {
+describe('token-storage (D-024 SecureStore migration)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('setAccessToken', () => {
-    it('should store access token in AsyncStorage', async () => {
-      const token = 'test-access-token';
-
-      await setAccessToken(token);
-
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith('versemate_access_token', token);
-    });
-
-    it('should handle AsyncStorage errors', async () => {
-      const error = new Error('AsyncStorage failed');
-      (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(error);
-
-      await expect(setAccessToken('token')).rejects.toThrow('AsyncStorage failed');
-    });
+  it('setAccessToken writes to SecureStore', async () => {
+    await setAccessToken('test-token');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('versemate_access_token', 'test-token');
   });
 
-  describe('getAccessToken', () => {
-    it('should retrieve access token from AsyncStorage', async () => {
-      const token = 'stored-access-token';
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(token);
-
-      const result = await getAccessToken();
-
-      expect(AsyncStorage.getItem).toHaveBeenCalledWith('versemate_access_token');
-      expect(result).toBe(token);
-    });
-
-    it('should return null when no token exists', async () => {
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
-
-      const result = await getAccessToken();
-
-      expect(result).toBeNull();
-    });
+  it('getAccessToken reads from SecureStore when present', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue('secure-token');
+    const result = await getAccessToken();
+    expect(result).toBe('secure-token');
+    expect(AsyncStorage.getItem).not.toHaveBeenCalled();
   });
 
-  describe('setRefreshToken', () => {
-    it('should store refresh token in AsyncStorage', async () => {
-      const token = 'test-refresh-token';
+  it('getAccessToken migrates legacy AsyncStorage token to SecureStore', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue('legacy-token');
 
-      await setRefreshToken(token);
+    const result = await getAccessToken();
 
-      expect(AsyncStorage.setItem).toHaveBeenCalledWith('versemate_refresh_token', token);
-    });
+    expect(result).toBe('legacy-token');
+    expect(SecureStore.setItemAsync).toHaveBeenCalledWith('versemate_access_token', 'legacy-token');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('versemate_access_token');
   });
 
-  describe('getRefreshToken', () => {
-    it('should retrieve refresh token from AsyncStorage', async () => {
-      const token = 'stored-refresh-token';
-      (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(token);
+  it('getAccessToken returns null when neither store has a token', async () => {
+    (SecureStore.getItemAsync as jest.Mock).mockResolvedValue(null);
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
 
-      const result = await getRefreshToken();
+    const result = await getAccessToken();
 
-      expect(AsyncStorage.getItem).toHaveBeenCalledWith('versemate_refresh_token');
-      expect(result).toBe(token);
-    });
+    expect(result).toBeNull();
+    expect(SecureStore.setItemAsync).not.toHaveBeenCalled();
   });
 
-  describe('clearTokens', () => {
-    it('should delete both access and refresh tokens', async () => {
-      await clearTokens();
-
-      expect(AsyncStorage.multiRemove).toHaveBeenCalledWith([
-        'versemate_access_token',
-        'versemate_refresh_token',
-      ]);
-    });
-
-    it('should handle multiRemove errors', async () => {
-      const error = new Error('multiRemove failed');
-      (AsyncStorage.multiRemove as jest.Mock).mockRejectedValueOnce(error);
-
-      await expect(clearTokens()).rejects.toThrow('multiRemove failed');
-    });
+  it('clearTokens removes from SecureStore + sweeps legacy AsyncStorage entries', async () => {
+    await clearTokens();
+    expect(SecureStore.deleteItemAsync).toHaveBeenCalledWith('versemate_access_token');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('versemate_access_token');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith('versemate_refresh_token');
   });
 });

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "expo-location": "~19.0.8",
         "expo-navigation-bar": "~5.0.10",
         "expo-router": "~6.0.17",
+        "expo-secure-store": "^55.0.13",
         "expo-sensors": "~15.0.8",
         "expo-sharing": "~14.0.8",
         "expo-speech-recognition": "^3.1.1",
@@ -1368,6 +1369,8 @@
     "expo-navigation-bar": ["expo-navigation-bar@5.0.10", "", { "dependencies": { "@react-native/normalize-colors": "0.81.5", "debug": "^4.3.2", "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-r9rdLw8mY6GPMQmVVOY/r1NBBw74DZefXHF60HxhRsdNI2kjc1wLdfWfR2rk4JVdOvdMDujnGrc9HQmqM3n8Jg=="],
 
     "expo-router": ["expo-router@6.0.17", "", { "dependencies": { "@expo/metro-runtime": "^6.1.2", "@expo/schema-utils": "^0.1.8", "@radix-ui/react-slot": "1.2.0", "@radix-ui/react-tabs": "^1.1.12", "@react-navigation/bottom-tabs": "^7.4.0", "@react-navigation/native": "^7.1.8", "@react-navigation/native-stack": "^7.3.16", "client-only": "^0.0.1", "debug": "^4.3.4", "escape-string-regexp": "^4.0.0", "expo-server": "^1.0.5", "fast-deep-equal": "^3.1.3", "invariant": "^2.2.4", "nanoid": "^3.3.8", "query-string": "^7.1.3", "react-fast-compare": "^3.2.2", "react-native-is-edge-to-edge": "^1.1.6", "semver": "~7.6.3", "server-only": "^0.0.1", "sf-symbols-typescript": "^2.1.0", "shallowequal": "^1.1.0", "use-latest-callback": "^0.2.1", "vaul": "^1.1.2" }, "peerDependencies": { "@react-navigation/drawer": "^7.5.0", "@testing-library/react-native": ">= 12.0.0", "expo": "*", "expo-constants": "^18.0.11", "expo-linking": "^8.0.10", "react": "*", "react-dom": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-safe-area-context": ">= 5.4.0", "react-native-screens": "*", "react-native-web": "*", "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1" }, "optionalPeers": ["@react-navigation/drawer", "@testing-library/react-native", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-web", "react-server-dom-webpack"] }, "sha512-2n0lTidH2H+dOjk/Lu+krKIgK7b1qQ3O/9RWmf9P5IEuFiu7BSUgSDc+g69bUEElTnca8FR+zPTyk15kMXHrXg=="],
+
+    "expo-secure-store": ["expo-secure-store@55.0.13", "", { "peerDependencies": { "expo": "*" } }, "sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ=="],
 
     "expo-sensors": ["expo-sensors@15.0.8", "", { "dependencies": { "invariant": "^2.2.4" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-ttibOSCYjFAMIfjV+vVukO1v7GKlbcPRfxcRqbTaSMGneewDwVSXbGFImY530fj1BR3mWq4n9jHnuDp8tAEY9g=="],
 

--- a/lib/auth/token-storage.ts
+++ b/lib/auth/token-storage.ts
@@ -1,28 +1,30 @@
 /**
  * Token Storage Module
  *
- * Provides token storage using AsyncStorage.
- * Note: AsyncStorage is not encrypted. For production apps requiring higher security,
- * consider migrating to expo-secure-store when Xcode compatibility issues are resolved.
+ * Stores the JWT access token securely.
  *
- * Token lifespans:
- * - Access token: 15 minutes
- * - Refresh token: 90 days
+ * Per spec feat-auth-platform br-auth-001 (D-005): the access token IS the
+ * persistent session token (90-day TTL, server-validated against Redis cache).
+ * Refresh tokens have been eliminated.
+ *
+ * Per Phase 1 decision D-024: tokens migrate from plaintext AsyncStorage to
+ * iOS Keychain / Android Keystore via `expo-secure-store`. AsyncStorage is
+ * checked once per launch as a one-time migration: if a legacy token is
+ * found there, it's copied to SecureStore and removed.
  */
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as SecureStore from 'expo-secure-store';
 
 const ACCESS_TOKEN_KEY = 'versemate_access_token';
-const REFRESH_TOKEN_KEY = 'versemate_refresh_token';
+const LEGACY_REFRESH_TOKEN_KEY = 'versemate_refresh_token';
 
 /**
- * Store access token in AsyncStorage
- * @param token - JWT access token
- * @throws Error if AsyncStorage operation fails
+ * Store access token in SecureStore (encrypted at rest via OS keychain).
  */
 export async function setAccessToken(token: string): Promise<void> {
   try {
-    await AsyncStorage.setItem(ACCESS_TOKEN_KEY, token);
+    await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, token);
   } catch (error) {
     console.error('Failed to store access token:', error);
     throw error;
@@ -30,13 +32,26 @@ export async function setAccessToken(token: string): Promise<void> {
 }
 
 /**
- * Retrieve access token from AsyncStorage
- * @returns JWT access token or null if not found
- * @throws Error if AsyncStorage operation fails
+ * Retrieve access token from SecureStore.
+ *
+ * Performs a one-time migration on first call: if a legacy AsyncStorage token
+ * exists (from before D-024) it's copied into SecureStore and the AsyncStorage
+ * entry removed.
  */
 export async function getAccessToken(): Promise<string | null> {
   try {
-    return await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+    const secure = await SecureStore.getItemAsync(ACCESS_TOKEN_KEY);
+    if (secure) return secure;
+
+    // One-time migration from legacy AsyncStorage.
+    const legacy = await AsyncStorage.getItem(ACCESS_TOKEN_KEY);
+    if (legacy) {
+      await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, legacy);
+      await AsyncStorage.removeItem(ACCESS_TOKEN_KEY);
+      return legacy;
+    }
+
+    return null;
   } catch (error) {
     console.error('Failed to retrieve access token:', error);
     throw error;
@@ -44,41 +59,33 @@ export async function getAccessToken(): Promise<string | null> {
 }
 
 /**
- * Store refresh token in AsyncStorage
- * @param token - JWT refresh token
- * @throws Error if AsyncStorage operation fails
+ * @deprecated Refresh tokens are eliminated per D-005. Stub kept until
+ * the companion PR removes all callers. No-op.
  */
-export async function setRefreshToken(token: string): Promise<void> {
-  try {
-    await AsyncStorage.setItem(REFRESH_TOKEN_KEY, token);
-  } catch (error) {
-    console.error('Failed to store refresh token:', error);
-    throw error;
-  }
+export async function setRefreshToken(_token: string): Promise<void> {
+  // intentional no-op
 }
 
 /**
- * Retrieve refresh token from AsyncStorage
- * @returns JWT refresh token or null if not found
- * @throws Error if AsyncStorage operation fails
+ * @deprecated Refresh tokens are eliminated per D-005. Stub kept until
+ * the companion PR removes all callers. Always returns null.
  */
 export async function getRefreshToken(): Promise<string | null> {
-  try {
-    return await AsyncStorage.getItem(REFRESH_TOKEN_KEY);
-  } catch (error) {
-    console.error('Failed to retrieve refresh token:', error);
-    throw error;
-  }
+  return null;
 }
 
 /**
- * Clear both access and refresh tokens from AsyncStorage
- * Used during logout or when token refresh fails
- * @throws Error if AsyncStorage operation fails
+ * Clear access token from SecureStore + sweep legacy AsyncStorage entries.
+ * Used during logout.
  */
 export async function clearTokens(): Promise<void> {
   try {
-    await AsyncStorage.multiRemove([ACCESS_TOKEN_KEY, REFRESH_TOKEN_KEY]);
+    await Promise.all([
+      SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY),
+      // Sweep legacy entries (refresh-token D-005 + AsyncStorage migration D-024)
+      AsyncStorage.removeItem(ACCESS_TOKEN_KEY),
+      AsyncStorage.removeItem(LEGACY_REFRESH_TOKEN_KEY),
+    ]);
   } catch (error) {
     console.error('Failed to clear tokens:', error);
     throw error;

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "expo-location": "~19.0.8",
     "expo-navigation-bar": "~5.0.10",
     "expo-router": "~6.0.17",
+    "expo-secure-store": "^55.0.13",
     "expo-sensors": "~15.0.8",
     "expo-sharing": "~14.0.8",
     "expo-speech-recognition": "^3.1.1",


### PR DESCRIPTION
Per spec feat-auth-platform + constitution SEC-003 (D-024).

Tokens move from plaintext AsyncStorage to encrypted iOS Keychain / Android Keystore via `expo-secure-store`.

**This PR:**
- token-storage.ts now uses SecureStore primary; migrates legacy AsyncStorage token on first read
- clearTokens sweeps legacy keys on logout (incl. orphaned refresh-token)
- setRefreshToken / getRefreshToken kept as deprecated no-op stubs until companion D-005 PR removes callers
- 5 unit tests for SecureStore + migration paths — all pass

**Repo:** verse-mate-mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)