### PR TITLE
feat(i18n): codemod onboarding + settings screens (D-016 follow-up)

### DIFF
--- a/__tests__/lib/i18n/i18n.test.ts
+++ b/__tests__/lib/i18n/i18n.test.ts
@@ -27,7 +27,7 @@ describe('lib/i18n', () => {
   it('translates nested settings keys', async () => {
     const i18n = await initI18n();
     expect(i18n.t('settings.theme_auto')).toBe('Auto');
-    expect(i18n.t('settings.delete_account')).toBe('Delete account');
+    expect(i18n.t('settings.delete_account')).toBe('Delete Account');
   });
 
   it('returns the key itself when missing (no infinite fallback)', async () => {

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -4,6 +4,7 @@ import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   Extrapolation,
@@ -78,6 +79,7 @@ const PaginationDot = ({
 };
 
 export default function OnboardingScreen() {
+  const { t } = useTranslation();
   const router = useRouter();
   const pagerRef = useRef<PagerView>(null);
   const [currentPage, setCurrentPage] = useState(0);
@@ -175,7 +177,7 @@ export default function OnboardingScreen() {
           {currentPage < slides.length - 1 ? (
             <>
               <Pressable onPress={() => completeOnboarding('skipped')} style={styles.skipButton}>
-                <Text style={styles.skipText}>Skip</Text>
+                <Text style={styles.skipText}>{t('onboarding.skip')}</Text>
               </Pressable>
               <Pressable onPress={handleNext} style={styles.nextButton}>
                 <Ionicons name="arrow-forward" size={24} color="#000" />
@@ -187,10 +189,10 @@ export default function OnboardingScreen() {
                 onPress={() => completeOnboarding('completed')}
                 style={styles.getStartedButton}
               >
-                <Text style={styles.getStartedText}>Get Started</Text>
+                <Text style={styles.getStartedText}>{t('onboarding.get_started')}</Text>
               </Pressable>
               <Pressable onPress={handleLogin} style={styles.loginButton}>
-                <Text style={styles.loginText}>Log In</Text>
+                <Text style={styles.loginText}>{t('onboarding.login')}</Text>
               </Pressable>
             </View>
           )}

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -19,6 +19,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { router, useFocusEffect } from 'expo-router';
 import { useCallback, useEffect, useRef, useState } from 'react'; // NOTE: useCallback is still used for useFocusEffect which requires it
+import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
   Alert,
@@ -92,6 +93,7 @@ const LANGUAGE_NAMES: Record<string, string> = {
 };
 
 export default function SettingsScreen() {
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const { user, isAuthenticated, logout, restoreSession } = useAuth();
   const { colors } = useTheme();
@@ -482,7 +484,7 @@ export default function SettingsScreen() {
       await setBibleVersion(version.key);
       setShowVersionPicker(false);
     } catch (_error) {
-      Alert.alert('Error', 'Failed to save Bible version selection');
+      Alert.alert(t('common.error_title'), t('settings.errors.save_bible_version'));
     }
   };
 
@@ -529,15 +531,15 @@ export default function SettingsScreen() {
       }
     } catch (error) {
       console.error('Failed to save language preference:', error);
-      Alert.alert('Error', 'Failed to save language preference');
+      Alert.alert(t('common.error_title'), t('settings.errors.save_language'));
     }
   };
 
   const handleLogout = async () => {
-    Alert.alert('Logout', 'Are you sure you want to logout?', [
-      { text: 'Cancel', style: 'cancel' },
+    Alert.alert(t('settings.logout_confirm_title'), t('settings.logout_confirm_message'), [
+      { text: t('common.cancel'), style: 'cancel' },
       {
-        text: 'Logout',
+        text: t('settings.logout'),
         style: 'destructive',
         onPress: async () => {
           await logout();
@@ -623,13 +625,13 @@ export default function SettingsScreen() {
         <Pressable
           onPress={handleBackPress}
           style={styles.backButton}
-          accessibilityLabel="Go back"
+          accessibilityLabel={t('settings.go_back')}
           accessibilityRole="button"
           testID="settings-back-button"
         >
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </Pressable>
-        <Text style={styles.headerTitle}>Settings</Text>
+        <Text style={styles.headerTitle}>{t('settings.title')}</Text>
         <View style={styles.headerSpacer} />
       </View>
 
@@ -643,14 +645,14 @@ export default function SettingsScreen() {
         {/* Profile Information Section - Authenticated Only */}
         {isAuthenticated && user && (
           <View style={styles.section}>
-            <Text style={styles.sectionLabel}>Profile Information</Text>
+            <Text style={styles.sectionLabel}>{t('settings.profile_information')}</Text>
             <View style={styles.profileHeader}>
               <View style={styles.profileIconWrapper}>
                 <Avatar url={user.imageSrc} size={48} />
               </View>
               <View style={styles.profileInfo}>
                 <View style={styles.profileNameRow}>
-                  <Text style={styles.profileName}>Profile Details</Text>
+                  <Text style={styles.profileName}>{t('settings.profile_details')}</Text>
                   {saveStatus === 'saving' && (
                     <ActivityIndicator
                       size="small"
@@ -678,33 +680,33 @@ export default function SettingsScreen() {
                 {saveStatus === 'error' && globalError ? (
                   <Text style={styles.profileErrorText}>{globalError}</Text>
                 ) : (
-                  <Text style={styles.profileSubtext}>Update your personal information</Text>
+                  <Text style={styles.profileSubtext}>{t('settings.profile_subtext')}</Text>
                 )}
               </View>
             </View>
 
             <View style={styles.form}>
               <TextInput
-                label="First Name"
+                label={t('settings.first_name')}
                 value={firstName}
                 onChangeText={setFirstName}
-                placeholder="Enter your first name"
+                placeholder={t('settings.first_name_placeholder')}
                 testID="settings-first-name-input"
               />
 
               <TextInput
-                label="Last Name"
+                label={t('settings.last_name')}
                 value={lastName}
                 onChangeText={setLastName}
-                placeholder="Enter your last name"
+                placeholder={t('settings.last_name_placeholder')}
                 testID="settings-last-name-input"
               />
 
               <TextInput
-                label="Email"
+                label={t('settings.email')}
                 value={email}
                 onChangeText={setEmail}
-                placeholder="Enter your email"
+                placeholder={t('settings.email_placeholder')}
                 keyboardType="email-address"
                 autoCapitalize="none"
                 testID="settings-email-input"
@@ -715,13 +717,13 @@ export default function SettingsScreen() {
 
         {/* Bible Version Section */}
         <View style={styles.section}>
-          <Text style={styles.sectionLabel}>Bible Version</Text>
+          <Text style={styles.sectionLabel}>{t('settings.bible_version')}</Text>
           <Pressable
             style={styles.selectButton}
             onPress={() => setShowVersionPicker(!showVersionPicker)}
           >
             <Text style={styles.selectButtonText}>
-              {selectedVersionData?.value || 'Select Version'}
+              {selectedVersionData?.value || t('settings.select_version')}
             </Text>
             <Ionicons
               name={showVersionPicker ? 'chevron-up' : 'chevron-down'}
@@ -760,7 +762,7 @@ export default function SettingsScreen() {
 
         {/* Language Preferences Section */}
         <View style={styles.section}>
-          <Text style={styles.sectionLabel}>Language Preferences</Text>
+          <Text style={styles.sectionLabel}>{t('settings.language_preferences')}</Text>
           <Pressable
             style={styles.selectButton}
             onPress={() => setShowLanguagePicker(!showLanguagePicker)}
@@ -770,7 +772,9 @@ export default function SettingsScreen() {
                 const selectedLang = availableLanguages.find(
                   (lang) => lang.code === selectedLanguage
                 );
-                return selectedLang ? formatLanguageDisplay(selectedLang) : 'Select Language';
+                return selectedLang
+                  ? formatLanguageDisplay(selectedLang)
+                  : t('settings.select_language');
               })()}
             </Text>
             <Ionicons
@@ -819,11 +823,11 @@ export default function SettingsScreen() {
         {/* Downloads & Offline — hidden on web (online-only) */}
         {Platform.OS !== 'web' && (
           <View style={styles.section}>
-            <Text style={styles.sectionLabel}>Downloads & Offline</Text>
+            <Text style={styles.sectionLabel}>{t('settings.downloads_offline')}</Text>
             <Pressable
               style={[styles.selectButton, styles.manageDownloadsButton]}
               onPress={() => router.push('/manage-downloads')}
-              accessibilityLabel="Manage offline downloads"
+              accessibilityLabel={t('settings.manage_downloads_a11y')}
               accessibilityRole="button"
             >
               <Ionicons
@@ -837,9 +841,11 @@ export default function SettingsScreen() {
                   style={[styles.selectButtonText, styles.manageDownloadsTitle]}
                   numberOfLines={1}
                 >
-                  Manage Downloads
+                  {t('settings.manage_downloads')}
                 </Text>
-                <Text style={styles.manageDownloadsSubtitle}>Download content for offline use</Text>
+                <Text style={styles.manageDownloadsSubtitle}>
+                  {t('settings.manage_downloads_subtitle')}
+                </Text>
               </View>
               <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
             </Pressable>
@@ -850,7 +856,7 @@ export default function SettingsScreen() {
         {isAuthenticated && (
           <View style={styles.section}>
             <Button
-              title="Logout"
+              title={t('settings.logout')}
               onPress={handleLogout}
               variant="outlineGold"
               fullWidth
@@ -865,12 +871,12 @@ export default function SettingsScreen() {
             <Pressable
               style={styles.deleteAccountButton}
               onPress={handleDeleteAccountPress}
-              accessibilityLabel="Delete account permanently"
+              accessibilityLabel={t('settings.delete_account_a11y')}
               accessibilityRole="button"
-              accessibilityHint="This action cannot be undone"
+              accessibilityHint={t('settings.delete_account_hint')}
             >
               <Ionicons name="trash-outline" size={20} color="#dc2626" />
-              <Text style={styles.deleteAccountText}>Delete Account</Text>
+              <Text style={styles.deleteAccountText}>{t('settings.delete_account')}</Text>
             </Pressable>
           </View>
         )}
@@ -879,11 +885,9 @@ export default function SettingsScreen() {
         {!isAuthenticated && (
           <View style={styles.notAuthenticatedContainer}>
             <Ionicons name="person-outline" size={64} color={colors.textTertiary} />
-            <Text style={styles.notAuthenticatedText}>
-              Sign in to access auto-highlights and profile settings.
-            </Text>
+            <Text style={styles.notAuthenticatedText}>{t('settings.sign_in_message')}</Text>
             <Button
-              title="Sign In"
+              title={t('auth.login.title')}
               onPress={() => router.push('/auth/login')}
               variant="primary"
               testID="settings-sign-in-button"

--- a/locales/en.json
+++ b/locales/en.json
@@ -40,7 +40,8 @@
   "onboarding": {
     "skip": "Skip",
     "next": "Next",
-    "get_started": "Get started"
+    "get_started": "Get Started",
+    "login": "Log In"
   },
 
   "settings": {
@@ -49,17 +50,42 @@
     "preferences": "Preferences",
     "storage": "Storage",
     "help": "Help",
-    "logout": "Log out",
-    "delete_account": "Delete account",
+    "logout": "Logout",
+    "logout_confirm_title": "Logout",
+    "logout_confirm_message": "Are you sure you want to logout?",
+    "delete_account": "Delete Account",
+    "delete_account_a11y": "Delete account permanently",
+    "delete_account_hint": "This action cannot be undone",
     "language": "Language",
+    "language_preferences": "Language Preferences",
+    "select_language": "Select Language",
     "theme": "Theme",
     "theme_auto": "Auto",
     "theme_light": "Light",
     "theme_dark": "Dark",
     "font_size": "Font size",
-    "bible_version": "Bible version",
+    "bible_version": "Bible Version",
+    "select_version": "Select Version",
     "auto_highlights": "Auto-highlights",
-    "manage_downloads": "Manage downloads"
+    "manage_downloads": "Manage Downloads",
+    "manage_downloads_a11y": "Manage offline downloads",
+    "manage_downloads_subtitle": "Download content for offline use",
+    "downloads_offline": "Downloads & Offline",
+    "profile_information": "Profile Information",
+    "profile_details": "Profile Details",
+    "profile_subtext": "Update your personal information",
+    "first_name": "First Name",
+    "last_name": "Last Name",
+    "email": "Email",
+    "first_name_placeholder": "Enter your first name",
+    "last_name_placeholder": "Enter your last name",
+    "email_placeholder": "Enter your email",
+    "go_back": "Go back",
+    "sign_in_message": "Sign in to access auto-highlights and profile settings.",
+    "errors": {
+      "save_bible_version": "Failed to save Bible version selection",
+      "save_language": "Failed to save language preference"
+    }
   },
 
   "chapter_reader": {
@@ -108,6 +134,7 @@
     "close": "Close",
     "loading": "Loading…",
     "error": "Something went wrong",
+    "error_title": "Error",
     "unknown_error": "Unknown error"
   }
 }

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -1,7 +1,26 @@
 import '@testing-library/jest-native/extend-expect';
+import i18next from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import { FormData, fetch, Headers, Request, Response } from 'undici';
 import { resetPostHogMock } from './__tests__/mocks/posthog-mock';
 import { server } from './__tests__/mocks/server';
+import en from './locales/en.json';
+
+// Initialize i18next synchronously for tests so `useTranslation()` resolves keys
+// to English strings. Without this, `t('settings.title')` returns the literal
+// key and every getByText/i18n assertion fails. Mirrors lib/i18n/index.ts but
+// avoids expo-localization (RN-only, breaks under jest-expo node env).
+if (!i18next.isInitialized) {
+  i18next.use(initReactI18next).init({
+    resources: { en: { translation: en } },
+    lng: 'en',
+    fallbackLng: 'en',
+    interpolation: { escapeValue: false },
+    react: { useSuspense: false },
+    returnNull: false,
+    returnEmptyString: false,
+  });
+}
 
 // Mock toast context — no-op showToast/hideToast so hooks calling useToast() in
 // tests don't blow up on the "must be within ToastProvider" guard.


### PR DESCRIPTION
## Summary

Externalizes user-facing strings on two screens (D-016 part 2 follow-up):

- **Onboarding** (3 strings): Skip / Get Started / Log In.
- **Settings** (25 strings): header, profile section labels & placeholders, picker fallbacks, manage downloads tile, logout/delete-account buttons, error alerts, sign-in prompt, accessibility labels.

Also wires synchronous i18n init into jest's `test-setup.ts` so `useTranslation()` resolves keys instead of returning the literal key string — without it every getByText assertion on i18n'd screens breaks.

## Catalog updates

- New `settings.{profile_information,profile_details,profile_subtext,first_name,last_name,email,first_name_placeholder,last_name_placeholder,email_placeholder,select_version,language_preferences,select_language,downloads_offline,manage_downloads_subtitle,manage_downloads_a11y,delete_account_a11y,delete_account_hint,go_back,sign_in_message,logout_confirm_title,logout_confirm_message,errors.save_bible_version,errors.save_language}`
- New `common.error_title` for Alert titles
- New `onboarding.login`
- Existing `bible_version`, `logout`, `delete_account`, `manage_downloads` flipped to title case to match rendered labels (no UX change)

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] `npx jest __tests__/app/settings.test.tsx` — 19 pass
- [x] `npx jest __tests__/app/auth/` — 13 pass (login + signup unchanged)
- [x] `npx jest __tests__/lib/i18n/` — 5 pass (catalog test updated for new title casing)
- [ ] Manual smoke on iOS simulator: settings screen + back button + logout dialog render in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)