### PR TITLE
feat(i18n): codemod bookmarks/highlights/notes lists + eslint-plugin-i18next rule (D-016 follow-up)

### DIFF
--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -155,8 +155,8 @@ export default function Login() {
         <View style={styles.content}>
           {/* Header */}
           <View style={styles.header}>
-            <Text style={styles.heading}>Welcome back</Text>
-            <Text style={styles.subtitle}>Login into your account</Text>
+            <Text style={styles.heading}>{t('auth.login.welcome_back')}</Text>
+            <Text style={styles.subtitle}>{t('auth.login.subtitle')}</Text>
           </View>
 
           {/* Form */}

--- a/app/bookmarks.tsx
+++ b/app/bookmarks.tsx
@@ -24,6 +24,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
+import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
   Alert,
@@ -58,6 +59,7 @@ import { fontSizes, fontWeights, type getColors, spacing } from '@/theme/tokens'
  * - Navigates to /bible/{bookId}/{chapterNumber}
  */
 export default function Bookmarks() {
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -150,27 +152,25 @@ export default function Bookmarks() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="bookmarks-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Bookmarks</Text>
+          <Text style={styles.headerTitle}>{t('bookmarks.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
           <IconBookmarkFilled width={64} height={64} color={colors.textDisabled} />
-          <Text style={styles.emptyStateTitle}>Please login to view your bookmarks</Text>
-          <Text style={styles.emptyStateSubtitle}>
-            Sign in to save and access your favorite Bible chapters
-          </Text>
+          <Text style={styles.emptyStateTitle}>{t('bookmarks.login_required')}</Text>
+          <Text style={styles.emptyStateSubtitle}>{t('bookmarks.login_subtitle')}</Text>
           <Pressable
             style={styles.loginButton}
             onPress={handleLoginPress}
             testID="bookmarks-login-button"
           >
-            <Text style={styles.loginButtonText}>Login</Text>
+            <Text style={styles.loginButtonText}>{t('auth.login.submit')}</Text>
           </Pressable>
         </View>
       </View>
@@ -190,13 +190,13 @@ export default function Bookmarks() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="bookmarks-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Bookmarks</Text>
+          <Text style={styles.headerTitle}>{t('bookmarks.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
@@ -219,21 +219,19 @@ export default function Bookmarks() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="bookmarks-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Bookmarks</Text>
+          <Text style={styles.headerTitle}>{t('bookmarks.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
           <IconBookmarkFilled width={64} height={64} color={colors.textDisabled} />
-          <Text style={styles.emptyStateTitle}>No bookmarked chapters yet</Text>
-          <Text style={styles.emptyStateSubtitle}>
-            Tap the bookmark icon while reading to save chapters for later.
-          </Text>
+          <Text style={styles.emptyStateTitle}>{t('bookmarks.empty_title')}</Text>
+          <Text style={styles.emptyStateSubtitle}>{t('bookmarks.empty_subtitle')}</Text>
         </View>
       </View>
     );
@@ -248,13 +246,13 @@ export default function Bookmarks() {
         <Pressable
           onPress={handleBackPress}
           style={styles.backButton}
-          accessibilityLabel="Go back"
+          accessibilityLabel={t('common.go_back')}
           accessibilityRole="button"
           testID="bookmarks-back-button"
         >
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </Pressable>
-        <Text style={styles.headerTitle}>Bookmarks</Text>
+        <Text style={styles.headerTitle}>{t('bookmarks.title')}</Text>
         <View style={styles.headerSpacer} />
       </View>
       <FlatList

--- a/app/highlights/index.tsx
+++ b/app/highlights/index.tsx
@@ -2,6 +2,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
   FlatList,
@@ -140,6 +141,7 @@ function groupHighlightsByChapter(highlights: Highlight[]): ChapterGroup[] {
  * Highlights List Screen Component
  */
 export default function HighlightsScreen() {
+  const { t } = useTranslation();
   const { colors } = useTheme();
   const styles = createStyles(colors);
   const insets = useSafeAreaInsets();
@@ -207,20 +209,20 @@ export default function HighlightsScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="highlights-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Highlights</Text>
+          <Text style={styles.headerTitle}>{t('highlights.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <ScrollView style={styles.scrollView} contentContainerStyle={styles.scrollContent}>
           {/* Auto-Highlights Section */}
           <View style={styles.sectionDivider}>
             <View style={styles.dividerLine} />
-            <Text style={styles.dividerText}>Auto-Highlights</Text>
+            <Text style={styles.dividerText}>{t('highlights.auto_highlights')}</Text>
             <View style={styles.dividerLine} />
           </View>
 
@@ -247,13 +249,13 @@ export default function HighlightsScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="highlights-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Highlights</Text>
+          <Text style={styles.headerTitle}>{t('highlights.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
@@ -279,13 +281,13 @@ export default function HighlightsScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="highlights-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Highlights</Text>
+          <Text style={styles.headerTitle}>{t('highlights.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <ScrollView
@@ -302,23 +304,21 @@ export default function HighlightsScreen() {
           {/* My Highlights Section Header */}
           <View style={styles.sectionDivider}>
             <View style={styles.dividerLine} />
-            <Text style={styles.dividerText}>My Highlights</Text>
+            <Text style={styles.dividerText}>{t('highlights.my_highlights')}</Text>
             <View style={styles.dividerLine} />
           </View>
 
           {/* Empty State */}
           <View style={styles.emptyStateContainer}>
             <IconHighlight width={64} height={64} color={colors.textDisabled} />
-            <Text style={styles.emptyStateTitle}>No highlights yet</Text>
-            <Text style={styles.emptyStateSubtitle}>
-              Start highlighting verses to see them here.
-            </Text>
+            <Text style={styles.emptyStateTitle}>{t('highlights.empty_title')}</Text>
+            <Text style={styles.emptyStateSubtitle}>{t('highlights.empty_subtitle')}</Text>
           </View>
 
           {/* Divider */}
           <View style={styles.sectionDivider}>
             <View style={styles.dividerLine} />
-            <Text style={styles.dividerText}>Auto-Highlights</Text>
+            <Text style={styles.dividerText}>{t('highlights.auto_highlights')}</Text>
             <View style={styles.dividerLine} />
           </View>
 
@@ -342,13 +342,13 @@ export default function HighlightsScreen() {
         <Pressable
           onPress={handleBackPress}
           style={styles.backButton}
-          accessibilityLabel="Go back"
+          accessibilityLabel={t('common.go_back')}
           accessibilityRole="button"
           testID="highlights-back-button"
         >
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </Pressable>
-        <Text style={styles.headerTitle}>Highlights</Text>
+        <Text style={styles.headerTitle}>{t('highlights.title')}</Text>
         <View style={styles.headerSpacer} />
       </View>
 
@@ -396,7 +396,7 @@ export default function HighlightsScreen() {
             {/* Divider */}
             <View style={styles.sectionDivider}>
               <View style={styles.dividerLine} />
-              <Text style={styles.dividerText}>Auto-Highlights</Text>
+              <Text style={styles.dividerText}>{t('highlights.auto_highlights')}</Text>
               <View style={styles.dividerLine} />
             </View>
 

--- a/app/notes/index.tsx
+++ b/app/notes/index.tsx
@@ -21,6 +21,7 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router } from 'expo-router';
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   ActivityIndicator,
   FlatList,
@@ -83,6 +84,7 @@ function groupNotesByChapter(notes: Note[]): ChapterGroup[] {
  * Notes List Screen Component
  */
 export default function NotesScreen() {
+  const { t } = useTranslation();
   const insets = useSafeAreaInsets();
   const { colors } = useTheme();
   const styles = createStyles(colors);
@@ -158,27 +160,25 @@ export default function NotesScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="notes-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Notes</Text>
+          <Text style={styles.headerTitle}>{t('notes.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
           <IconDocument width={64} height={64} color={colors.textDisabled} />
-          <Text style={styles.emptyStateTitle}>Please login to view your notes</Text>
-          <Text style={styles.emptyStateSubtitle}>
-            Sign in to create and access your Bible study notes
-          </Text>
+          <Text style={styles.emptyStateTitle}>{t('notes.login_required')}</Text>
+          <Text style={styles.emptyStateSubtitle}>{t('notes.login_subtitle')}</Text>
           <Pressable
             style={styles.loginButton}
             onPress={handleLoginPress}
             testID="notes-login-button"
           >
-            <Text style={styles.loginButtonText}>Login</Text>
+            <Text style={styles.loginButtonText}>{t('auth.login.submit')}</Text>
           </Pressable>
         </View>
       </View>
@@ -198,13 +198,13 @@ export default function NotesScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="notes-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Notes</Text>
+          <Text style={styles.headerTitle}>{t('notes.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <View style={styles.centerContent}>
@@ -230,13 +230,13 @@ export default function NotesScreen() {
           <Pressable
             onPress={handleBackPress}
             style={styles.backButton}
-            accessibilityLabel="Go back"
+            accessibilityLabel={t('common.go_back')}
             accessibilityRole="button"
             testID="notes-back-button"
           >
             <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
           </Pressable>
-          <Text style={styles.headerTitle}>Notes</Text>
+          <Text style={styles.headerTitle}>{t('notes.title')}</Text>
           <View style={styles.headerSpacer} />
         </View>
         <ScrollView
@@ -252,10 +252,8 @@ export default function NotesScreen() {
         >
           <View style={styles.emptyStateContainer}>
             <IconDocument width={64} height={64} color={colors.textDisabled} />
-            <Text style={styles.emptyStateTitle}>No notes yet</Text>
-            <Text style={styles.emptyStateSubtitle}>
-              Start taking notes while reading chapters to see them here.
-            </Text>
+            <Text style={styles.emptyStateTitle}>{t('notes.empty_title')}</Text>
+            <Text style={styles.emptyStateSubtitle}>{t('notes.empty_subtitle')}</Text>
           </View>
         </ScrollView>
       </View>
@@ -271,13 +269,13 @@ export default function NotesScreen() {
         <Pressable
           onPress={handleBackPress}
           style={styles.backButton}
-          accessibilityLabel="Go back"
+          accessibilityLabel={t('common.go_back')}
           accessibilityRole="button"
           testID="notes-back-button"
         >
           <Ionicons name="arrow-back" size={24} color={colors.textPrimary} />
         </Pressable>
-        <Text style={styles.headerTitle}>Notes</Text>
+        <Text style={styles.headerTitle}>{t('notes.title')}</Text>
         <View style={styles.headerSpacer} />
       </View>
 

--- a/bun.lock
+++ b/bun.lock
@@ -89,6 +89,7 @@
         "eslint": "^9.25.0",
         "eslint-config-biome": "^2.1.3",
         "eslint-config-expo": "~10.0.0",
+        "eslint-plugin-i18next": "^6.1.4",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "husky": "^9.1.7",
         "jest": "~29.7.0",
@@ -1276,6 +1277,8 @@
 
     "eslint-plugin-expo": ["eslint-plugin-expo@1.0.0", "", { "dependencies": { "@typescript-eslint/types": "^8.29.1", "@typescript-eslint/utils": "^8.29.1", "eslint": "^9.24.0" } }, "sha512-qLtunR+cNFtC+jwYCBia5c/PJurMjSLMOV78KrEOyQK02ohZapU4dCFFnS2hfrJuw0zxfsjVkjqg3QBqi933QA=="],
 
+    "eslint-plugin-i18next": ["eslint-plugin-i18next@6.1.4", "", { "dependencies": { "lodash": "^4.17.21", "requireindex": "~1.1.0" } }, "sha512-BekXQu1VaVFkREepQGsntBYoKuPsf89V16n/s2xpKMtsw0/lDseds1wBhj3RtO1dKnHsfTPaG+xul1vF0R7LEQ=="],
+
     "eslint-plugin-import": ["eslint-plugin-import@2.32.0", "", { "dependencies": { "@rtsao/scc": "^1.1.0", "array-includes": "^3.1.9", "array.prototype.findlastindex": "^1.2.6", "array.prototype.flat": "^1.3.3", "array.prototype.flatmap": "^1.3.3", "debug": "^3.2.7", "doctrine": "^2.1.0", "eslint-import-resolver-node": "^0.3.9", "eslint-module-utils": "^2.12.1", "hasown": "^2.0.2", "is-core-module": "^2.16.1", "is-glob": "^4.0.3", "minimatch": "^3.1.2", "object.fromentries": "^2.0.8", "object.groupby": "^1.0.3", "object.values": "^1.2.1", "semver": "^6.3.1", "string.prototype.trimend": "^1.0.9", "tsconfig-paths": "^3.15.0" }, "peerDependencies": { "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9" } }, "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA=="],
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
@@ -2187,6 +2190,8 @@
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "requireg": ["requireg@0.2.2", "", { "dependencies": { "nested-error-stacks": "~2.0.1", "rc": "~1.2.7", "resolve": "~1.7.1" } }, "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg=="],
+
+    "requireindex": ["requireindex@1.1.0", "", {}, "sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg=="],
 
     "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@
 const { defineConfig } = require('eslint/config');
 const expoConfig = require('eslint-config-expo/flat');
 const reactCompilerPlugin = require('eslint-plugin-react-compiler');
+const i18nextPlugin = require('eslint-plugin-i18next');
 const biomeConfig = require('eslint-config-biome');
 
 module.exports = defineConfig([
@@ -29,6 +30,35 @@ module.exports = defineConfig([
       'react-hooks/rules-of-hooks': 'error',
       // React Compiler rules for Rules of React violations
       'react-compiler/react-compiler': 'error',
+    },
+  },
+
+  // i18n: forbid raw English strings in user-facing UI (D-016 part 3).
+  // Warn (not error) until the chapter-reader and remaining modal/component
+  // screens are codemodded — escalate to error once coverage is complete.
+  // Scoped to app/ and components/ where rendered strings live; lib/, hooks/,
+  // utils/ are exempt because they don't render text directly.
+  {
+    files: ['app/**/*.{ts,tsx}', 'components/**/*.{ts,tsx}'],
+    ignores: ['**/*.test.{ts,tsx}', '**/*.stories.{ts,tsx}', 'components/ui/icons/**'],
+    plugins: { i18next: i18nextPlugin },
+    rules: {
+      'i18next/no-literal-string': [
+        'warn',
+        {
+          markupOnly: true,
+          // Function args to skip — already wrapped in i18n or pure config.
+          callees: { exclude: ['^(t|i18n\\.t|i18next\\.t)$'] },
+          // JSX attributes that don't surface to users.
+          'jsx-attributes': {
+            exclude: [
+              '^(testID|nativeID|accessibilityRole|placeholderTextColor|keyboardType|autoCapitalize|autoComplete|autoCorrect|textContentType|returnKeyType|secureTextEntry|spellCheck|name|source|style|className|key|color|size|variant|fullWidth|numberOfLines|ellipsizeMode)$',
+            ],
+          },
+          // Words/phrases short enough to be technical or already-localized.
+          words: { exclude: ['^[A-Z_]+$', '^\\d+$', '^\\s*$'] },
+        },
+      ],
     },
   },
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -103,18 +103,30 @@
   "bookmarks": {
     "title": "Bookmarks",
     "empty": "No bookmarks yet. Tap the bookmark icon while reading.",
+    "empty_title": "No bookmarked chapters yet",
+    "empty_subtitle": "Tap the bookmark icon while reading to save chapters for later.",
+    "login_required": "Please login to view your bookmarks",
+    "login_subtitle": "Sign in to save and access your favorite Bible chapters",
     "remove_confirm": "Remove this bookmark?"
   },
 
   "highlights": {
     "title": "Highlights",
     "empty": "No highlights yet. Long-press a verse and pick a color.",
+    "empty_title": "No highlights yet",
+    "empty_subtitle": "Start highlighting verses to see them here.",
+    "auto_highlights": "Auto-Highlights",
+    "my_highlights": "My Highlights",
     "remove_confirm": "Remove this highlight?"
   },
 
   "notes": {
     "title": "Notes",
     "empty": "No notes yet. Tap a verse to add one.",
+    "empty_title": "No notes yet",
+    "empty_subtitle": "Start taking notes while reading chapters to see them here.",
+    "login_required": "Please login to view your notes",
+    "login_subtitle": "Sign in to create and access your Bible study notes",
     "edit": "Edit note",
     "delete": "Delete note",
     "delete_confirm": "Delete this note?",
@@ -131,6 +143,7 @@
     "confirm": "Confirm",
     "retry": "Retry",
     "back": "Back",
+    "go_back": "Go back",
     "close": "Close",
     "loading": "Loading…",
     "error": "Something went wrong",

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,6 +9,8 @@
   "auth": {
     "login": {
       "title": "Sign In",
+      "welcome_back": "Welcome back",
+      "subtitle": "Login into your account",
       "email_label": "Email",
       "email_placeholder": "you@example.com",
       "password_label": "Password",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "eslint": "^9.25.0",
     "eslint-config-biome": "^2.1.3",
     "eslint-config-expo": "~10.0.0",
+    "eslint-plugin-i18next": "^6.1.4",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "husky": "^9.1.7",
     "jest": "~29.7.0",


### PR DESCRIPTION
## Summary

Two-part D-016 follow-up that closes out the i18n cascade for the list screens and adds a guard-rail rule to surface remaining untranslated strings.

### 1. Codemod the three list screens

External izes the user-facing strings on `app/bookmarks.tsx`, `app/highlights/index.tsx`, and `app/notes/index.tsx`:

- Header titles (4-5x each in render branches)
- Empty-state title + subtitle pairs
- Login-prompt title + subtitle pairs (unauthenticated branch)
- "Login" CTA buttons (reuses `auth.login.submit`)
- Section dividers in highlights ("Auto-Highlights", "My Highlights")
- "Go back" accessibility labels (new shared `common.go_back`)

Catalog adds: `bookmarks.{empty_title,empty_subtitle,login_required,login_subtitle}`, `highlights.{empty_title,empty_subtitle,auto_highlights,my_highlights}`, `notes.{empty_title,empty_subtitle,login_required,login_subtitle}`, plus `common.go_back`.

### 2. Add eslint-plugin-i18next rule

Adds `i18next/no-literal-string` lint rule scoped to `app/**` and `components/**` (excluding tests, stories, the icons sprite). Set to **warn** initially because chapter-reader, audio components, and many modals are still untranslated — a steady signal without breaking the build. Once those screens are codemodded, escalate the rule to `error`.

Escape hatches:
- `callees.exclude` skips function args inside `t(...)`, `i18n.t(...)`, `i18next.t(...)`.
- `jsx-attributes.exclude` skips technical attrs (testID, accessibilityRole, keyboardType, etc.).
- `words.exclude` skips ALL_CAPS, numeric-only, and whitespace strings.

Current count: **260 warnings** across the surface that still needs codemod — good visibility signal without blocking lint.

Also cleans the last two leftover hardcoded strings in `app/auth/login.tsx` (Welcome back / Login into your account) that the prior i18n pass missed.

## Test plan

- [x] `bun tsc --noEmit` clean
- [x] `npx jest __tests__/app/bookmarks __tests__/app/notes __tests__/app/highlights` — 19 pass
- [x] `npx jest __tests__/app/auth/login.test.tsx` — 4 pass (catalog updates verified)
- [x] `bun run lint` exits 0 (260 warnings, 0 errors)
- [ ] Manual smoke on iOS simulator: empty/loading/login-prompt states render in English

🤖 Generated with [Claude Code](https://claude.com/claude-code)