### PR TITLE
fix(test): mock expo-secure-store in jest-env-setup so ThemeContext tests load

### DIFF
--- a/jest-env-setup.js
+++ b/jest-env-setup.js
@@ -13,6 +13,33 @@ if (typeof global.structuredClone === 'undefined') {
   global.structuredClone = (obj) => JSON.parse(JSON.stringify(obj));
 }
 
+// Mock expo-secure-store. Per D-024, token-storage.ts imports SecureStore
+// (Keychain on iOS, EncryptedSharedPreferences on Android). The native
+// module isn't available under jest-expo, so without this mock any test
+// that transitively loads token-storage (via ThemeContext -> client-interceptors)
+// fails on require with "Cannot find native module 'ExpoSecureStore'".
+jest.mock('expo-secure-store', () => {
+  const storage = {};
+  return {
+    getItemAsync: jest.fn((key) => Promise.resolve(storage[key] ?? null)),
+    setItemAsync: jest.fn((key, value) => {
+      storage[key] = value;
+      return Promise.resolve();
+    }),
+    deleteItemAsync: jest.fn((key) => {
+      delete storage[key];
+      return Promise.resolve();
+    }),
+    isAvailableAsync: jest.fn(() => Promise.resolve(true)),
+    WHEN_UNLOCKED: 'whenUnlocked',
+    WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+    AFTER_FIRST_UNLOCK: 'afterFirstUnlock',
+    AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY: 'afterFirstUnlockThisDeviceOnly',
+    ALWAYS: 'always',
+    ALWAYS_THIS_DEVICE_ONLY: 'alwaysThisDeviceOnly',
+  };
+});
+
 // Mock AsyncStorage for tests
 // This provides a simple in-memory implementation for testing
 jest.mock('@react-native-async-storage/async-storage', () => {


### PR DESCRIPTION
## Summary

Unblocks CI on epic/spec-implementation-2026-05-03. Per D-024, `token-storage.ts` now imports `expo-secure-store`, but the native module isn't available under jest-expo, so any test that transitively loads token-storage fails on require:

  ThemeContext.tsx → client-interceptors.ts → token-storage.ts → expo-secure-store

This was the only failing suite in the umbrella mobile PR (#281) and was the trigger for the "Quality Checks" / "Test Results Summary" failures cascading from it.

## Fix

Adds an in-memory `jest.mock('expo-secure-store', …)` in `jest-env-setup.js`, same shape as the AsyncStorage mock right above it: `getItemAsync` / `setItemAsync` / `deleteItemAsync` / `isAvailableAsync` plus the keychain-accessibility constants.

## Test plan

- [x] `npx jest __tests__/contexts/ThemeContext.test.tsx` — 16/16 pass
- [x] `npx jest` (full suite) — 146 suites pass / 1 skipped (slow tests, expected) / 0 fail. 1336 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)