### PR TITLE
fix(notes): merge instead of wipe-and-replace user-data sync (VER-9)

### DIFF
--- a/services/offline/__tests__/sqlite-manager.test.ts
+++ b/services/offline/__tests__/sqlite-manager.test.ts
@@ -195,8 +195,8 @@ describe('SQLite Manager', () => {
     });
   });
 
-  describe('insertUserNotes', () => {
-    it('wraps DELETE and all inserts in a single transaction', async () => {
+  describe('insertUserNotes (VER-9: merge, not wipe)', () => {
+    it('merges via INSERT OR REPLACE and never deletes existing rows', async () => {
       const notes = [
         {
           note_id: 'n1',
@@ -210,30 +210,39 @@ describe('SQLite Manager', () => {
 
       await insertUserNotes(notes);
 
-      // There should be exactly one execSync call that contains BOTH DELETE and INSERT
-      const atomicCall = mockExecSync.mock.calls.find(
+      const mergeCall = mockExecSync.mock.calls.find(
         (call: any[]) =>
-          typeof call[0] === 'string' &&
-          call[0].includes('DELETE FROM offline_notes') &&
-          call[0].includes('INSERT INTO offline_notes')
+          typeof call[0] === 'string' && call[0].includes('INSERT OR REPLACE INTO offline_notes')
       );
-      expect(atomicCall).toBeDefined();
-      expect(atomicCall?.[0]).toContain('My note');
-    });
+      expect(mergeCall).toBeDefined();
+      expect(mergeCall?.[0]).toContain('My note');
 
-    it('only issues a DELETE when notes array is empty', async () => {
-      await insertUserNotes([]);
-
-      const atomicCall = mockExecSync.mock.calls.find(
+      // Critical: no DELETE FROM offline_notes — locally-mirrored notes that
+      // the server snapshot hasn't propagated yet must survive this sync.
+      const deleteCall = mockExecSync.mock.calls.find(
         (call: any[]) =>
           typeof call[0] === 'string' && call[0].includes('DELETE FROM offline_notes')
       );
-      expect(atomicCall).toBeDefined();
+      expect(deleteCall).toBeUndefined();
+    });
+
+    it('is a no-op for an empty notes payload (does not wipe local rows)', async () => {
+      mockExecSync.mockClear();
+      await insertUserNotes([]);
+
+      const mutatingCall = mockExecSync.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' &&
+          (call[0].includes('DELETE FROM offline_notes') ||
+            call[0].includes('INSERT INTO offline_notes') ||
+            call[0].includes('INSERT OR REPLACE INTO offline_notes'))
+      );
+      expect(mutatingCall).toBeUndefined();
     });
   });
 
-  describe('insertUserHighlights', () => {
-    it('wraps DELETE and all inserts in a single transaction', async () => {
+  describe('insertUserHighlights (VER-9: merge, not wipe)', () => {
+    it('merges via INSERT OR REPLACE and never deletes existing rows', async () => {
       const highlights = [
         {
           highlight_id: 1,
@@ -250,14 +259,19 @@ describe('SQLite Manager', () => {
 
       await insertUserHighlights(highlights);
 
-      const atomicCall = mockExecSync.mock.calls.find(
+      const mergeCall = mockExecSync.mock.calls.find(
         (call: any[]) =>
           typeof call[0] === 'string' &&
-          call[0].includes('DELETE FROM offline_highlights') &&
-          call[0].includes('INSERT INTO offline_highlights')
+          call[0].includes('INSERT OR REPLACE INTO offline_highlights')
       );
-      expect(atomicCall).toBeDefined();
-      expect(atomicCall?.[0]).toContain('yellow');
+      expect(mergeCall).toBeDefined();
+      expect(mergeCall?.[0]).toContain('yellow');
+
+      const deleteCall = mockExecSync.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' && call[0].includes('DELETE FROM offline_highlights')
+      );
+      expect(deleteCall).toBeUndefined();
     });
 
     it('escapes all numeric fields via escapeSQL', async () => {
@@ -277,17 +291,18 @@ describe('SQLite Manager', () => {
 
       await insertUserHighlights(highlights);
 
-      const atomicCall = mockExecSync.mock.calls.find(
+      const mergeCall = mockExecSync.mock.calls.find(
         (call: any[]) =>
-          typeof call[0] === 'string' && call[0].includes('INSERT INTO offline_highlights')
+          typeof call[0] === 'string' &&
+          call[0].includes('INSERT OR REPLACE INTO offline_highlights')
       );
-      expect(atomicCall?.[0]).toContain('42');
-      expect(atomicCall?.[0]).toContain('7');
+      expect(mergeCall?.[0]).toContain('42');
+      expect(mergeCall?.[0]).toContain('7');
     });
   });
 
-  describe('insertUserBookmarks', () => {
-    it('wraps DELETE and all inserts in a single transaction', async () => {
+  describe('insertUserBookmarks (VER-9: merge, not wipe)', () => {
+    it('merges via INSERT OR REPLACE and never deletes existing rows', async () => {
       const bookmarks = [
         {
           favorite_id: 10,
@@ -300,13 +315,18 @@ describe('SQLite Manager', () => {
 
       await insertUserBookmarks(bookmarks);
 
-      const atomicCall = mockExecSync.mock.calls.find(
+      const mergeCall = mockExecSync.mock.calls.find(
         (call: any[]) =>
           typeof call[0] === 'string' &&
-          call[0].includes('DELETE FROM offline_bookmarks') &&
-          call[0].includes('INSERT INTO offline_bookmarks')
+          call[0].includes('INSERT OR REPLACE INTO offline_bookmarks')
       );
-      expect(atomicCall).toBeDefined();
+      expect(mergeCall).toBeDefined();
+
+      const deleteCall = mockExecSync.mock.calls.find(
+        (call: any[]) =>
+          typeof call[0] === 'string' && call[0].includes('DELETE FROM offline_bookmarks')
+      );
+      expect(deleteCall).toBeUndefined();
     });
   });
 });

--- a/services/offline/sqlite-manager.ts
+++ b/services/offline/sqlite-manager.ts
@@ -966,7 +966,16 @@ export async function getLocalTopicExplanations(
 
 export async function insertUserNotes(notes: OfflineNote[]): Promise<void> {
   const database = await initDatabase();
-  if (__DEV__) console.log(`[Offline DB] Inserting ${notes.length} notes`);
+  if (__DEV__) console.log(`[Offline DB] Merging ${notes.length} notes`);
+
+  // VER-9: merge instead of wipe-and-replace. The previous DELETE+INSERT was
+  // racy with NOTES-1's local mirror: a freshly POST-confirmed note that the
+  // server's /offline/user-data snapshot hadn't yet propagated would be
+  // deleted here and the standalone Notes screen would show empty.
+  // Trade-off: a note deleted on web won't disappear from mobile via this
+  // sync until an explicit local-data clear; that's smaller than silently
+  // losing user-authored notes.
+  if (notes.length === 0) return;
 
   const batchSize = 100;
   const inserts: string[] = [];
@@ -979,22 +988,20 @@ export async function insertUserNotes(notes: OfflineNote[]): Promise<void> {
       )
       .join(', ');
     inserts.push(
-      `INSERT INTO offline_notes (note_id, book_id, chapter_number, verse_number, content, updated_at) VALUES ${values}`
+      `INSERT OR REPLACE INTO offline_notes (note_id, book_id, chapter_number, verse_number, content, updated_at) VALUES ${values}`
     );
   }
 
-  // DELETE + all inserts in a single transaction so a crash cannot leave the
-  // table empty after the delete but before the inserts complete.
-  execSafe(
-    database,
-    ['BEGIN', 'DELETE FROM offline_notes', ...inserts, 'COMMIT'].join(';\n'),
-    'notes-replace-all'
-  );
+  execSafe(database, ['BEGIN', ...inserts, 'COMMIT'].join(';\n'), 'notes-merge');
 }
 
 export async function insertUserHighlights(highlights: OfflineHighlight[]): Promise<void> {
   const database = await initDatabase();
-  if (__DEV__) console.log(`[Offline DB] Inserting ${highlights.length} highlights`);
+  if (__DEV__) console.log(`[Offline DB] Merging ${highlights.length} highlights`);
+
+  // VER-9: see insertUserNotes for rationale. Merge instead of wipe-and-replace
+  // so locally-mirrored highlights survive a stale server snapshot.
+  if (highlights.length === 0) return;
 
   const batchSize = 100;
   const inserts: string[] = [];
@@ -1007,20 +1014,19 @@ export async function insertUserHighlights(highlights: OfflineHighlight[]): Prom
       )
       .join(', ');
     inserts.push(
-      `INSERT INTO offline_highlights (highlight_id, book_id, chapter_number, start_verse, end_verse, color, start_char, end_char, updated_at) VALUES ${values}`
+      `INSERT OR REPLACE INTO offline_highlights (highlight_id, book_id, chapter_number, start_verse, end_verse, color, start_char, end_char, updated_at) VALUES ${values}`
     );
   }
 
-  execSafe(
-    database,
-    ['BEGIN', 'DELETE FROM offline_highlights', ...inserts, 'COMMIT'].join(';\n'),
-    'highlights-replace-all'
-  );
+  execSafe(database, ['BEGIN', ...inserts, 'COMMIT'].join(';\n'), 'highlights-merge');
 }
 
 export async function insertUserBookmarks(bookmarks: OfflineBookmark[]): Promise<void> {
   const database = await initDatabase();
-  if (__DEV__) console.log(`[Offline DB] Inserting ${bookmarks.length} bookmarks`);
+  if (__DEV__) console.log(`[Offline DB] Merging ${bookmarks.length} bookmarks`);
+
+  // VER-9: see insertUserNotes for rationale.
+  if (bookmarks.length === 0) return;
 
   const batchSize = 200;
   const inserts: string[] = [];
@@ -1033,15 +1039,11 @@ export async function insertUserBookmarks(bookmarks: OfflineBookmark[]): Promise
       )
       .join(', ');
     inserts.push(
-      `INSERT INTO offline_bookmarks (favorite_id, book_id, chapter_number, created_at, insight_type) VALUES ${values}`
+      `INSERT OR REPLACE INTO offline_bookmarks (favorite_id, book_id, chapter_number, created_at, insight_type) VALUES ${values}`
     );
   }
 
-  execSafe(
-    database,
-    ['BEGIN', 'DELETE FROM offline_bookmarks', ...inserts, 'COMMIT'].join(';\n'),
-    'bookmarks-replace-all'
-  );
+  execSafe(database, ['BEGIN', ...inserts, 'COMMIT'].join(';\n'), 'bookmarks-merge');
 }
 
 export async function getLocalNotes(


### PR DESCRIPTION
## Summary

- Fixes VER-9 (Andy Tryba's "notes don't appear in menu" bug).
- Root cause: `downloadUserData` ran `DELETE FROM offline_notes; INSERT ...` (also for highlights/bookmarks). NOTES-1's local mirror of a freshly POST-confirmed note could be wiped by the next sync if the server's `/offline/user-data` snapshot hadn't propagated the note yet (read-after-write lag). The standalone Notes screen reads from the local cache when `isUserDataSynced`, so the note vanished.
- Fix: switch `insertUserNotes` / `insertUserHighlights` / `insertUserBookmarks` to `INSERT OR REPLACE` merges and drop the destructive `DELETE`. Locally-mirrored rows survive even if the server snapshot is stale.
- Trade-off: a note/highlight/bookmark deleted via the web won't disappear from mobile via this sync until an explicit local-data clear. Accepted — silently losing user-authored content is worse than a temporarily stale row.

## Evidence

PostHog (team 262395), user `a2e6fabb…` = andytryba@gmail.com, build `1.2.1 / 47` (includes NOTES-1 fix `3e49a6c`):

- `2026-05-11T17:43:41Z` `NOTE_CREATED` (server POST succeeded).
- `2026-05-11T18:39Z` VER-9 filed: "doesn't appear in menu notes".
- No notes-related exceptions in the window. Two unrelated `$exception`s: `HTTP 504: Network Error - GET /support/conversations`.

## Test plan

- [x] `npm test -- --testPathPattern='sqlite-manager'` — 49/49 pass, new VER-9 merge assertions in place.
- [x] `npm test -- --testPathPattern='useNotes|offline-sync-service'` — 25/25 pass, no regression in add/update/delete flows.
- [x] `bun run type-check` — clean.
- [x] `bun x biome check` on changed files — clean (after autofix).
- [ ] Manual: cut a fresh TestFlight build off this branch and reproduce Andy's flow (open app, add a note, navigate to hamburger → Notes, confirm new note is listed).
