### PR TITLE
feat(mobile-web-prod): bind mobile.versemate.org prod deploy on main

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -2,20 +2,21 @@ name: Deploy Web (Cloudflare Workers)
 
 on:
   pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
 
-# Cancel in-flight runs for the same branch — last push wins.
+# Cancel in-flight runs for the same ref — last push wins.
 concurrency:
   group: deploy-web-${{ github.ref }}
   cancel-in-progress: true
 
 env:
-  # Preview-only: mobile web shares the verse-mate-web-preview Worker
-  # slot with verse-mate-web (operator decision, VER-12). No production
-  # deploy from this workflow — mobile.versemate.org binding is
-  # deferred until the repo CF API token is broadened to cover a
-  # dedicated mobile Worker. Pushes to main do not deploy.
-  CLOUDFLARE_ENV: preview
+  # PRs deploy to the `preview` env (verse-mate-mobile-web-preview); pushes
+  # to main deploy to the `production` env (verse-mate-mobile-web), which
+  # is bound to mobile.versemate.org via wrangler routes. The repo CF API
+  # token must cover both Worker services.
+  CLOUDFLARE_ENV: ${{ github.event_name == 'push' && 'production' || 'preview' }}
 
 jobs:
   build:
@@ -113,13 +114,19 @@ jobs:
         env:
           DEPLOY_URL: ${{ steps.deploy.outputs.deployment-url }}
         run: |
+          if [ "${{ env.CLOUDFLARE_ENV }}" = "production" ]; then
+            PROD_URL="https://mobile.versemate.org"
+          else
+            PROD_URL="${DEPLOY_URL:-(deploy step did not emit a URL)}"
+          fi
           cat >> $GITHUB_STEP_SUMMARY << EOF
           ## Mobile Web Deployment
 
           | Property | Value |
           |----------|-------|
           | **Environment** | ${{ env.CLOUDFLARE_ENV }} |
-          | **URL** | ${DEPLOY_URL:-(deploy step did not emit a URL)} |
+          | **Worker URL** | ${DEPLOY_URL:-(deploy step did not emit a URL)} |
+          | **Public URL** | ${PROD_URL} |
           | **Branch** | ${{ github.ref_name }} |
           | **Commit** | ${{ github.sha }} |
           EOF

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,19 +2,17 @@
   // Wrangler configuration for the VerseMate mobile web export (Expo for
   // web) on Cloudflare Workers.
   //
-  // Preview-only deploy. Mobile web shares the `verse-mate-web-preview`
-  // Worker service with verse-mate-web (operator decision, VER-12). The
-  // existing repo CF API token covers that service slot; rotating to a
-  // broader-scoped token was declined.
+  // Two environments:
+  //   - preview (`verse-mate-mobile-web-preview`): deployed on every PR.
+  //     No custom domain; uses the *.workers.dev URL. Distinct from the
+  //     verse-mate-web preview slot so the two repos no longer collide.
+  //   - production (`verse-mate-mobile-web`): deployed on push to main.
+  //     Bound to `mobile.versemate.org/*` via Cloudflare zone routes.
   //
-  // Trade-off: any PR (mobile OR web) that triggers a preview deploy
-  // overwrites whichever build was deployed last. Preview URLs reflect
-  // the most recent deploy, not the PR being reviewed. No production
-  // env here so mobile cannot deploy to mobile.versemate.org or
-  // app.versemate.org. Custom-domain binding for mobile is deferred to
-  // a future token-scope expansion.
+  // The repo CF API token must cover both Worker services. Token scope
+  // expansion is operator-managed (VER-19).
   "$schema": "https://raw.githubusercontent.com/cloudflare/wrangler/main/config-schema.json",
-  "name": "verse-mate-web-preview",
+  "name": "verse-mate-mobile-web-preview",
   "main": "worker.js",
   "compatibility_date": "2025-08-06",
   "account_id": "e8f0b566ba1c8227a25e3784def4300e",
@@ -39,7 +37,17 @@
 
   "env": {
     "preview": {
-      "name": "verse-mate-web-preview"
+      "name": "verse-mate-mobile-web-preview"
+    },
+    "production": {
+      "name": "verse-mate-mobile-web",
+      "workers_dev": false,
+      "routes": [
+        {
+          "pattern": "mobile.versemate.org/*",
+          "zone_name": "versemate.org"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Follow-up to VER-12. Production deploy on merge to main.

## Changes

- **`wrangler.jsonc`** — split into distinct envs:
  - `preview` → `verse-mate-mobile-web-preview` (no longer collides with the verse-mate-web preview slot)
  - `production` → `verse-mate-mobile-web`, bound to `mobile.versemate.org/*` via zone `versemate.org` routes
- **`.github/workflows/deploy-web.yml`** — add `push: branches: [main]` trigger; `CLOUDFLARE_ENV` is computed per event (`production` on push, `preview` on PR). PR comment stays preview-only; production runs emit the public URL in the job summary.

## Operator prerequisites (before merge)

1. **CF API token scope** — broaden the existing `CLOUDFLARE_API_TOKEN` (or issue a new one) so it can edit both Worker services: `verse-mate-mobile-web` and `verse-mate-mobile-web-preview`. Verify with `wrangler whoami`.
2. **DNS** — add CNAME `mobile.versemate.org` (or rely on Cloudflare zone routes auto-binding once the Worker is deployed on the same account).

Without step 1 the production deploy step will fail with a CF auth error. Without step 2 the route binds but DNS won't resolve.

## Verification (post-merge)

- Confirm push-to-main run hits `production` env
- `https://mobile.versemate.org` returns the Expo web export from `verse-mate-mobile` (not verse-mate-web)
- Open a follow-up PR; confirm preview deploys to `verse-mate-mobile-web-preview.*.workers.dev` (no overlap with verse-mate-web)

Resolves VER-19.