### PR TITLE
fix(web-deploy-script): target preview env in web:deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "ios": "expo run:ios",
     "web": "expo start --web",
     "web:export": "expo export --platform web",
-    "web:deploy": "expo export --platform web && bunx wrangler deploy --env production",
+    "web:deploy": "expo export --platform web && bunx wrangler deploy --env preview",
     "format": "biome format --write app components hooks constants utils types scripts __tests__ src services",
     "lint": "biome check app components hooks constants utils types scripts __tests__ src services && eslint .",
     "lint:fix": "biome check --write app components hooks constants utils types scripts __tests__ src services && eslint --fix .",


### PR DESCRIPTION
## Summary

Follow-up from VER-12 PR #292. The `web:deploy` script in `package.json` referenced `--env production`, but `wrangler.jsonc` only defines a `preview` env block (production was intentionally omitted when mobile web was scoped to share the `verse-mate-web-preview` Worker service). Running `bun run web:deploy` from an operator machine failed with `Environment 'production' not found`.

Change: `web:deploy` now targets `--env preview`, matching the current preview-only deploy model documented in `wrangler.jsonc`'s header comment.

Resolves VER-17.

## Test plan

- [ ] `bun run web:deploy` from an operator machine no longer fails with `Environment 'production' not found` (full deploy verification deferred to operator; this PR only fixes the env flag)
- [ ] CI deploy paths unchanged (CI calls `wrangler deploy` directly, not via this script)