### PR TITLE
feat(remove-spa-fallback): drop dead SPA fallback branch from worker.js

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -2,30 +2,15 @@
  * Cloudflare Worker for serving the VerseMate mobile web export
  * (Expo for web / expo-router).
  *
- * Responsibilities:
- *   1. Static asset serving from the Expo web build output (dist/).
- *   2. SPA fallback to /index.html for any non-asset path so
- *      expo-router handles client-side routing.
- *
- * No legacy URL redirects here — those live in verse-mate-web's
- * Worker for app.versemate.org. The mobile.versemate.org surface is
- * new and only ever serves the Expo web shell.
+ * The assets binding handles both static asset serving and the SPA
+ * fallback to /index.html, via wrangler.jsonc's
+ * `assets.not_found_handling: "single-page-application"`. That makes
+ * the worker a thin passthrough — kept here so future request-level
+ * logic (auth, headers, logging) has an obvious place to land.
  */
 
 export default {
   async fetch(request, env) {
-    const url = new URL(request.url);
-
-    const response = await env.ASSETS.fetch(request);
-    if (response.status !== 404) {
-      return response;
-    }
-
-    if (!url.pathname.includes('.')) {
-      const indexRequest = new Request(new URL('/index.html', request.url).toString(), request);
-      return env.ASSETS.fetch(indexRequest);
-    }
-
-    return response;
+    return env.ASSETS.fetch(request);
   },
 };


### PR DESCRIPTION
## Summary

Drops the dead SPA fallback branch from `worker.js`. The assets binding's `not_found_handling: "single-page-application"` (wrangler.jsonc) already serves `/index.html` (200) for any unmatched route, so `env.ASSETS.fetch(request)` never returns 404 in SPA mode — the manual fallback `if` was unreachable.

Cosmetic cleanup; no runtime behavior change.

Closes VER-18. Follow-up to #292.

## Test plan

- [x] `node --check worker.js` — syntax OK
- [x] `biome check worker.js` — passes
- [x] `eslint worker.js` — passes
- [ ] Cloudflare preview deploy still serves `/` and a deep route (e.g. `/bible/genesis/1`) as 200 with the SPA shell