### PR TITLE
fix(deploy): mobile.versemate.org as Custom Domain (VER-23)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,7 +7,8 @@
   //     No custom domain; uses the *.workers.dev URL. Distinct from the
   //     verse-mate-web preview slot so the two repos no longer collide.
   //   - production (`verse-mate-mobile-web`): deployed on push to main.
-  //     Bound to `mobile.versemate.org/*` via Cloudflare zone routes.
+  //     Bound to `mobile.versemate.org` as a Cloudflare Custom Domain
+  //     (auto-provisions DNS + TLS on first deploy).
   //
   // The repo CF API token must cover both Worker services. Token scope
   // expansion is operator-managed (VER-19).
@@ -44,8 +45,8 @@
       "workers_dev": false,
       "routes": [
         {
-          "pattern": "mobile.versemate.org/*",
-          "zone_name": "versemate.org"
+          "pattern": "mobile.versemate.org",
+          "custom_domain": true
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fix `mobile.versemate.org` returning `NXDOMAIN`. Production deploy at `ae4e013` (run [25734093836](https://github.com/verse-mate/verse-mate-mobile/actions/runs/25734093836)) registered `mobile.versemate.org/*` as a plain Workers Route. Plain routes need a pre-existing proxied DNS record in the zone; none was created, so the hostname is unreachable.

Swapping to Cloudflare **Custom Domain** auto-provisions the proxied DNS + TLS cert on deploy. This is what VER-19 already documented as the intent (commit `3b502e1`).

## Change

`wrangler.jsonc` production env:

```diff
       "routes": [
         {
-          "pattern": "mobile.versemate.org/*",
-          "zone_name": "versemate.org"
+          "pattern": "mobile.versemate.org",
+          "custom_domain": true
         }
       ]
```

## Token scope

Requires `CLOUDFLARE_API_TOKEN` to include `Zone:DNS:Edit` on the `versemate.org` zone. If missing, the next deploy fails **loud** (no more silent fallback to route-only).

If the token already covers DNS Edit on the zone, no operator action is needed — push triggers deploy, wrangler creates the Custom Domain (~1-5 min DNS + TLS provisioning).

## Verification (post-merge)

```sh
dig @1.1.1.1 mobile.versemate.org +short  # expect Cloudflare IPs
curl -fsS -o /dev/null -w '%{http_code}\n' https://mobile.versemate.org/  # expect 200
```

## Test plan

- [ ] Push to `main` triggers `Deploy Web (Cloudflare Workers)` workflow with `--env production`
- [ ] Deploy log shows `Custom Domains:` line for `mobile.versemate.org` (not `mobile.versemate.org/*`)
- [ ] `dig mobile.versemate.org` returns Cloudflare proxy IPs
- [ ] `curl https://mobile.versemate.org/` returns 200 with Expo web build
- [ ] If token lacks scope: deploy fails on Custom Domain creation step (loud error)

## Notes

- Preview env unchanged — still served on `*.workers.dev`.
- Worker name stays `verse-mate-mobile-web` for production; no orphan worker created.