### PR TITLE
feat(byline): quick-verse-jump control for long chapters

### DIFF
--- a/__tests__/components/bible/VerseJumpButton.test.tsx
+++ b/__tests__/components/bible/VerseJumpButton.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * VerseJumpButton — UI behavior tests
+ *
+ * Verifies the quick-verse-jump control rendered above the By Line tab:
+ * - hides itself when there are no verses to jump to
+ * - opens a modal listing every verse on tap
+ * - emits the chosen verse number on cell tap and dismisses the modal
+ * - dismisses on backdrop tap without emitting
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react-native';
+import { VerseJumpButton } from '@/components/bible/VerseJumpButton';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  ImpactFeedbackStyle: { Light: 'light', Medium: 'medium', Heavy: 'heavy' },
+}));
+
+const renderWithProviders = (ui: React.ReactNode) => render(<ThemeProvider>{ui}</ThemeProvider>);
+
+describe('VerseJumpButton', () => {
+  it('renders nothing when verses list is empty', () => {
+    const onSelect = jest.fn();
+    renderWithProviders(<VerseJumpButton verses={[]} onSelect={onSelect} />);
+    expect(screen.queryByTestId('verse-jump-button')).toBeNull();
+  });
+
+  it('renders nothing when visible=false', () => {
+    const onSelect = jest.fn();
+    renderWithProviders(<VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} visible={false} />);
+    expect(screen.queryByTestId('verse-jump-button')).toBeNull();
+  });
+
+  it('opens the modal and lists every supplied verse on tap', () => {
+    const onSelect = jest.fn();
+    renderWithProviders(<VerseJumpButton verses={[1, 2, 17, 176]} onSelect={onSelect} />);
+    fireEvent.press(screen.getByTestId('verse-jump-button'));
+    expect(screen.getByTestId('verse-jump-button-verse-1')).toBeTruthy();
+    expect(screen.getByTestId('verse-jump-button-verse-2')).toBeTruthy();
+    expect(screen.getByTestId('verse-jump-button-verse-17')).toBeTruthy();
+    expect(screen.getByTestId('verse-jump-button-verse-176')).toBeTruthy();
+  });
+
+  it('emits the verse number on cell press and closes the modal', () => {
+    jest.useFakeTimers();
+    const onSelect = jest.fn();
+    renderWithProviders(<VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} />);
+    fireEvent.press(screen.getByTestId('verse-jump-button'));
+    fireEvent.press(screen.getByTestId('verse-jump-button-verse-2'));
+    act(() => {
+      jest.runAllTimers();
+    });
+    expect(onSelect).toHaveBeenCalledWith(2);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    jest.useRealTimers();
+  });
+
+  it('dismisses on backdrop tap without emitting', () => {
+    const onSelect = jest.fn();
+    renderWithProviders(<VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} />);
+    fireEvent.press(screen.getByTestId('verse-jump-button'));
+    fireEvent.press(screen.getByTestId('verse-jump-button-backdrop'));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/bible/VerseJumpButton.test.tsx
+++ b/__tests__/components/bible/VerseJumpButton.test.tsx
@@ -3,6 +3,9 @@
  *
  * Verifies the quick-verse-jump control rendered above the By Line tab:
  * - hides itself when there are no verses to jump to
+ * - fades (rather than unmounts) when visible=false so the pill auto-hides
+ *   on the same trigger as the chapter-nav scroll arrows (VERA-39)
+ * - keeps the hit-target during fade-out and reveals the picker on tap
  * - opens a modal listing every verse on tap
  * - emits the chosen verse number on cell tap and dismisses the modal
  * - dismisses on backdrop tap without emitting
@@ -26,10 +29,30 @@ describe('VerseJumpButton', () => {
     expect(screen.queryByTestId('verse-jump-button')).toBeNull();
   });
 
-  it('renders nothing when visible=false', () => {
+  it('stays mounted but fades out when visible=false (mirrors scroll-arrow auto-hide)', () => {
     const onSelect = jest.fn();
     renderWithProviders(<VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} visible={false} />);
-    expect(screen.queryByTestId('verse-jump-button')).toBeNull();
+    // Pill stays in the tree so the hit-target survives the fade — no dead-zone
+    // regression vs. the previous always-visible pill.
+    expect(screen.getByTestId('verse-jump-button')).toBeTruthy();
+  });
+
+  it('still opens the picker when tapped while faded out', () => {
+    const onSelect = jest.fn();
+    const onInteraction = jest.fn();
+    renderWithProviders(
+      <VerseJumpButton
+        verses={[1, 2, 3]}
+        onSelect={onSelect}
+        visible={false}
+        onInteraction={onInteraction}
+      />
+    );
+    fireEvent.press(screen.getByTestId('verse-jump-button'));
+    expect(screen.getByTestId('verse-jump-button-verse-2')).toBeTruthy();
+    // Tap also signals interaction so the host can reset the auto-hide timer
+    // and re-show the pill alongside the scroll arrows.
+    expect(onInteraction).toHaveBeenCalledTimes(1);
   });
 
   it('opens the modal and lists every supplied verse on tap', () => {

--- a/__tests__/utils/bible/byLineJump.test.ts
+++ b/__tests__/utils/bible/byLineJump.test.ts
@@ -34,4 +34,28 @@ describe('computeByLineJumpY', () => {
     const y = computeByLineJumpY({ top: 0, scrollTop: 0 }, { top: 127425 }, 12);
     expect(y).toBe(127413);
   });
+
+  // VERA-36: desktop viewport regression. At width >= 900dp the app renders
+  // the explanations panel as a split-view right panel, so the byline
+  // ScrollView's rect.top is offset by the panel header + tab bar (~120dp).
+  // The math must produce the correct target when scrollTop is mid-chapter.
+  it('computes desktop-viewport target when ScrollView sits below the split-panel header', () => {
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 800 }, 12);
+    expect(y).toBe(668); // 800 - 120 + 0 - 12
+  });
+
+  it('preserves desktop forward-jump magnitude when user has scrolled mid-chapter', () => {
+    // Right panel scrolled 1200px; the section's viewport-relative top is just
+    // below the visible area. Result must equal the absolute scroll target,
+    // unaffected by the panel's chrome offset.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 1200 }, { top: 400 }, 12);
+    expect(y).toBe(1468); // 400 - 120 + 1200 - 12
+  });
+
+  it('handles Psalm 119 v176 magnitude inside a split-view right panel', () => {
+    // Same offsetTop magnitude as the phone case above (~127425), but with the
+    // ScrollView mounted inside a 120dp-tall chrome stack.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 127425 }, 12);
+    expect(y).toBe(127293);
+  });
 });

--- a/__tests__/utils/bible/byLineJump.test.ts
+++ b/__tests__/utils/bible/byLineJump.test.ts
@@ -1,0 +1,37 @@
+/**
+ * Regression coverage for the quick-verse-jump scroll-target math used on
+ * react-native-web. Round-1 fix landed the pill above the chapter-nav FAB row;
+ * round-2 QA found `View.measureLayout` is a no-op on RNW so the integration
+ * scroll dispatch silently died. This helper isolates the web math so a
+ * non-zero scroll target is asserted by unit test (QA round-2 explicit ask).
+ */
+
+import { computeByLineJumpY } from '@/utils/bible/byLineJump';
+
+describe('computeByLineJumpY', () => {
+  it('returns a non-zero target when the section is below the viewport', () => {
+    // Section sits 800px down the page; scroll container starts at top of viewport.
+    const y = computeByLineJumpY({ top: 100, scrollTop: 0 }, { top: 900 }, 12);
+    expect(y).toBe(788); // 900 - 100 + 0 - 12
+    expect(y).toBeGreaterThan(0);
+  });
+
+  it('preserves the existing scrollTop offset (forward jump from mid-page)', () => {
+    // User already scrolled 500px; section's viewport top reflects that.
+    const y = computeByLineJumpY({ top: 0, scrollTop: 500 }, { top: 200 }, 12);
+    expect(y).toBe(688); // 200 - 0 + 500 - 12
+  });
+
+  it('clamps to 0 instead of returning a negative scroll target', () => {
+    // Section is above the current scroll position (negative top), bias would
+    // otherwise produce a negative y; scrollTo expects non-negative.
+    const y = computeByLineJumpY({ top: 0, scrollTop: 0 }, { top: -50 }, 12);
+    expect(y).toBe(0);
+  });
+
+  it('handles long-chapter offsets without overflow (Psalm 119 v176 magnitude)', () => {
+    // v176 was reported at offsetTop ~127425 in QA round-2 evidence.
+    const y = computeByLineJumpY({ top: 0, scrollTop: 0 }, { top: 127425 }, 12);
+    expect(y).toBe(127413);
+  });
+});

--- a/__tests__/utils/bible/parseByLineExplanation.test.ts
+++ b/__tests__/utils/bible/parseByLineExplanation.test.ts
@@ -1,4 +1,4 @@
-import { parseByLineExplanation } from '@/utils/bible/parseByLineExplanation';
+import { parseByLineExplanation, parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 
 const MOCK_MARKDOWN = `# Line-by-Line Analysis of Genesis 1
 
@@ -50,5 +50,61 @@ Simple summary.
 `;
     const result = parseByLineExplanation(simpleMarkdown, 'Genesis', 1, 1, 1);
     expect(result).toContain('Simple summary');
+  });
+});
+
+describe('parseByLineSections', () => {
+  it('splits markdown into ordered per-verse sections', () => {
+    const sections = parseByLineSections(MOCK_MARKDOWN, 1);
+    const verseNumbers = sections.filter((s) => s.verseNumber > 0).map((s) => s.verseNumber);
+    expect(verseNumbers).toEqual([1, 2, 3]);
+  });
+
+  it('keeps the ## heading inside the section markdown so headings still render', () => {
+    const sections = parseByLineSections(MOCK_MARKDOWN, 1);
+    const verseOne = sections.find((s) => s.verseNumber === 1);
+    expect(verseOne).toBeDefined();
+    expect(verseOne?.markdown).toContain('## Genesis 1:1');
+    expect(verseOne?.markdown).toContain('### Summary');
+    expect(verseOne?.markdown).toContain('uncaused origin');
+  });
+
+  it('captures intro / prelude markdown before the first verse header as verseNumber 0', () => {
+    const sections = parseByLineSections(MOCK_MARKDOWN, 1);
+    expect(sections[0]?.verseNumber).toBe(0);
+    expect(sections[0]?.markdown).toContain('# Line-by-Line Analysis of Genesis 1');
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseByLineSections('', 1)).toEqual([]);
+  });
+
+  it('skips ## headings from a different chapter', () => {
+    const markdown = `## Genesis 1:1\n> A\n\n### Summary\nFirst.\n\n## Genesis 2:1\n> B\n\n### Summary\nSecond.`;
+    const sections = parseByLineSections(markdown, 1);
+    const verseNumbers = sections.filter((s) => s.verseNumber > 0).map((s) => s.verseNumber);
+    expect(verseNumbers).toEqual([1]);
+    // Chapter 2 content folds into chapter 1's section because we don't see a
+    // matching ## header to switch into. That's fine — the quick-jump UX only
+    // surfaces the verses we DID detect, and the contiguous markdown still
+    // renders correctly.
+    expect(sections[sections.length - 1]?.markdown).toContain('Genesis 2:1');
+  });
+
+  it('handles long chapters (e.g. Psalm 119) without dropping verses', () => {
+    const lines: string[] = ['# Psalm 119'];
+    for (let v = 1; v <= 176; v++) {
+      lines.push('');
+      lines.push(`## Psalm 119:${v}`);
+      lines.push(`> verse ${v} text`);
+      lines.push('');
+      lines.push('### Summary');
+      lines.push(`Summary for verse ${v}.`);
+    }
+    const sections = parseByLineSections(lines.join('\n'), 119);
+    const verseNumbers = sections.filter((s) => s.verseNumber > 0).map((s) => s.verseNumber);
+    expect(verseNumbers).toHaveLength(176);
+    expect(verseNumbers[0]).toBe(1);
+    expect(verseNumbers[175]).toBe(176);
   });
 });

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -393,6 +393,8 @@ export default function ChapterScreen() {
           isPreloading={!isCurrent}
           targetVerse={isCurrent ? targetVerse : undefined}
           targetEndVerse={isCurrent ? targetEndVerse : undefined}
+          fabVisible={fabVisible}
+          onFABInteraction={showButtons}
         />
       );
     },
@@ -405,6 +407,8 @@ export default function ChapterScreen() {
       chapterNumber,
       targetVerse,
       targetEndVerse,
+      fabVisible,
+      showButtons,
     ]
   );
 
@@ -535,6 +539,8 @@ export default function ChapterScreen() {
                   onMenuPress={() => setIsMenuOpen(true)}
                   onScroll={handleScroll}
                   onTap={handleTap}
+                  fabVisible={fabVisible}
+                  onFABInteraction={showButtons}
                 />
               }
             />

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -88,6 +88,20 @@ export interface BibleExplanationsPanelProps {
   /** Callback for tap events (for FAB visibility control) */
   onTap?: () => void;
 
+  /**
+   * Drives the verse-jump pill fade. Pass the same `fabVisible` state used
+   * by the chapter-nav scroll arrows so the pill auto-hides on the same
+   * trigger (VERA-39 / VERA-36). Defaults to `true` for callers that don't
+   * track FAB visibility.
+   */
+  fabVisible?: boolean;
+
+  /**
+   * Called when the user taps the verse-jump pill. Wire to `showButtons`
+   * from `useFABVisibility` so the arrows and the pill re-show together.
+   */
+  onFABInteraction?: () => void;
+
   /** Test ID for testing */
   testID?: string;
 }
@@ -106,6 +120,8 @@ export function BibleExplanationsPanel({
   onMenuPress,
   onScroll,
   onTap,
+  fabVisible = true,
+  onFABInteraction,
   testID = 'bible-explanations-panel',
 }: BibleExplanationsPanelProps) {
   const { mode, colors } = useTheme();
@@ -508,14 +524,18 @@ export function BibleExplanationsPanel({
 
       {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
           beneath this ScrollView in split / desktop right panel, so use a
-          tighter bottom offset than the phone-portrait default. */}
-      <VerseJumpButton
-        verses={byLineVerses}
-        onSelect={handleByLineVerseJump}
-        visible={activeTab === 'byline'}
-        bottomOffset={spacing.lg}
-        testID={`${testID}-verse-jump`}
-      />
+          tighter bottom offset than the phone-portrait default.
+          Fades with the scroll-arrow auto-hide (VERA-39 / VERA-36 parity). */}
+      {activeTab === 'byline' && (
+        <VerseJumpButton
+          verses={byLineVerses}
+          onSelect={handleByLineVerseJump}
+          visible={fabVisible}
+          onInteraction={onFABInteraction}
+          bottomOffset={spacing.lg}
+          testID={`${testID}-verse-jump`}
+        />
+      )}
     </View>
   );
 }

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -14,9 +14,18 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Animated,
+  findNodeHandle,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
@@ -36,8 +45,11 @@ import {
   spacing,
 } from '@/theme/tokens';
 import type { ContentTabType } from '@/types/bible';
+import { computeByLineJumpY } from '@/utils/bible/byLineJump';
+import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { AudioInlineEntry } from './AudioInlineEntry';
 import { ShareButton } from './ShareButton';
+import { VerseJumpButton } from './VerseJumpButton';
 
 /**
  * Tab configuration for explanation types
@@ -128,12 +140,18 @@ export function BibleExplanationsPanel({
   const byLineScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
 
+  // Quick-verse-jump (VERA-35 / VERA-36): refs to each rendered By Line
+  // verse-section View. Populated when byline content is split into per-verse
+  // sections below. Reset on chapter swap so stale nodes can't be reached.
+  const byLineSectionRefs = useRef<Record<number, View | null>>({});
+
   // Reset all scroll positions only when chapter changes (not on tab switch)
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps are intentional triggers for scroll reset
   useEffect(() => {
     summaryScrollRef.current?.scrollTo({ y: 0, animated: false });
     byLineScrollRef.current?.scrollTo({ y: 0, animated: false });
     detailedScrollRef.current?.scrollTo({ y: 0, animated: false });
+    byLineSectionRefs.current = {};
   }, [bookId, chapterNumber]);
 
   // Animate indicator when active tab changes
@@ -194,6 +212,66 @@ export function BibleExplanationsPanel({
   const summaryContent = extractContent(summaryData);
   const byLineContent = extractContent(byLineData);
   const detailedContent = extractContent(detailedData);
+
+  // Quick-verse-jump for the By Line tab (VERA-36): desktop / split-view path.
+  // ChapterPage handles the phone-portrait path; this panel covers
+  // landscape-tablet and web desktop (width >= 900dp, see
+  // utils/device-detection.ts -> shouldUseSplitView).
+  const byLineSections = useMemo(() => {
+    if (!byLineContent) return [] as ReturnType<typeof parseByLineSections>;
+    return parseByLineSections(byLineContent, chapterNumber);
+  }, [byLineContent, chapterNumber]);
+
+  const byLineVerses = useMemo(
+    () => byLineSections.map((section) => section.verseNumber).filter((v) => v > 0),
+    [byLineSections]
+  );
+
+  const handleByLineVerseJump = useCallback((verseNumber: number) => {
+    const node = byLineSectionRefs.current[verseNumber];
+    const scrollView = byLineScrollRef.current;
+    if (!node || !scrollView) return;
+
+    // react-native-web's `View.measureLayout` is a no-op stub, so the native
+    // path silently fails on web. On web, read positions from the DOM via
+    // getBoundingClientRect + the ScrollView's scrollTop. Mirrors the logic in
+    // ChapterPage.tsx (VERA-35 QA round 2 / verse-mate-mobile #77).
+    if (Platform.OS === 'web') {
+      const scrollNode = (
+        scrollView as unknown as { getScrollableNode?: () => HTMLElement | null }
+      ).getScrollableNode?.();
+      const sectionEl = node as unknown as HTMLElement;
+      if (scrollNode && typeof sectionEl.getBoundingClientRect === 'function') {
+        const sRect = scrollNode.getBoundingClientRect();
+        const nRect = sectionEl.getBoundingClientRect();
+        const y = computeByLineJumpY(
+          { top: sRect.top, scrollTop: scrollNode.scrollTop },
+          { top: nRect.top },
+          spacing.md
+        );
+        scrollView.scrollTo({ y, animated: true });
+      }
+      return;
+    }
+
+    const scrollHandle = findNodeHandle(scrollView);
+    if (scrollHandle == null) return;
+    (
+      node as unknown as {
+        measureLayout: (
+          node: number,
+          onSuccess: (x: number, y: number, w: number, h: number) => void,
+          onFail: () => void
+        ) => void;
+      }
+    ).measureLayout(
+      scrollHandle,
+      (_x, y) => {
+        scrollView.scrollTo({ y: Math.max(0, y - spacing.md), animated: true });
+      },
+      () => {}
+    );
+  }, []);
 
   /**
    * Handle touch start - record time and position
@@ -396,7 +474,27 @@ export function BibleExplanationsPanel({
                 />
               ) : null}
               {tab.isLocal && <AvailableOfflineBadge />}
-              <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              {tab.key === 'byline' && byLineSections.length > 0 ? (
+                byLineSections.map((section, index) => (
+                  <View
+                    // biome-ignore lint/suspicious/noArrayIndexKey: stable within a single parsed render
+                    key={`byline-section-${section.verseNumber}-${index}`}
+                    ref={(node) => {
+                      if (node === null) {
+                        delete byLineSectionRefs.current[section.verseNumber];
+                      } else {
+                        byLineSectionRefs.current[section.verseNumber] = node;
+                      }
+                    }}
+                    testID={`byline-verse-section-${section.verseNumber}`}
+                    collapsable={false}
+                  >
+                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                  </View>
+                ))
+              ) : (
+                <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              )}
             </>
           ) : isOffline ? (
             <OfflineContentUnavailable contentType="explanation" />
@@ -407,6 +505,17 @@ export function BibleExplanationsPanel({
           )}
         </ScrollView>
       ))}
+
+      {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
+          beneath this ScrollView in split / desktop right panel, so use a
+          tighter bottom offset than the phone-portrait default. */}
+      <VerseJumpButton
+        verses={byLineVerses}
+        onSelect={handleByLineVerseJump}
+        visible={activeTab === 'byline'}
+        bottomOffset={spacing.lg}
+        testID={`${testID}-verse-jump`}
+      />
     </View>
   );
 }

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -20,7 +20,7 @@
 import { router } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { findNodeHandle, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { findNodeHandle, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
 import { AudioInlineEntry } from '@/components/bible/AudioInlineEntry';
 import { DeleteConfirmationModal } from '@/components/bible/DeleteConfirmationModal';
@@ -43,6 +43,7 @@ import { animations, type getColors, spacing } from '@/theme/tokens';
 import type { AutoHighlight } from '@/types/auto-highlights';
 import type { ChapterContent, ContentTabType, ExplanationContent } from '@/types/bible';
 import type { Note } from '@/types/notes';
+import { computeByLineJumpY } from '@/utils/bible/byLineJump';
 import { groupConsecutiveHighlights } from '@/utils/bible/groupConsecutiveHighlights';
 import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { BottomLogo } from './BottomLogo';
@@ -792,6 +793,29 @@ export function ChapterPage({
     const node = byLineSectionRefs.current[verseNumber];
     const scrollView = byLineScrollRef.current;
     if (!node || !scrollView) return;
+
+    // react-native-web ships `View.measureLayout` as a stub that never invokes
+    // either callback, so the native path silently no-ops on web. On web, read
+    // positions from the DOM via getBoundingClientRect + the ScrollView's
+    // current scrollTop. See verse-mate-mobile #77 / VERA-35 QA round 2.
+    if (Platform.OS === 'web') {
+      const scrollNode = (
+        scrollView as unknown as { getScrollableNode?: () => HTMLElement | null }
+      ).getScrollableNode?.();
+      const sectionEl = node as unknown as HTMLElement;
+      if (scrollNode && typeof sectionEl.getBoundingClientRect === 'function') {
+        const sRect = scrollNode.getBoundingClientRect();
+        const nRect = sectionEl.getBoundingClientRect();
+        const y = computeByLineJumpY(
+          { top: sRect.top, scrollTop: scrollNode.scrollTop },
+          { top: nRect.top },
+          spacing.md
+        );
+        scrollView.scrollTo({ y, animated: true });
+      }
+      return;
+    }
+
     const scrollHandle = findNodeHandle(scrollView);
     if (scrollHandle == null) return;
     // measureLayout reports the section's offset relative to the ScrollView

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -18,9 +18,9 @@
  */
 
 import { router } from 'expo-router';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { findNodeHandle, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
 import { AudioInlineEntry } from '@/components/bible/AudioInlineEntry';
 import { DeleteConfirmationModal } from '@/components/bible/DeleteConfirmationModal';
@@ -44,9 +44,11 @@ import type { AutoHighlight } from '@/types/auto-highlights';
 import type { ChapterContent, ContentTabType, ExplanationContent } from '@/types/bible';
 import type { Note } from '@/types/notes';
 import { groupConsecutiveHighlights } from '@/utils/bible/groupConsecutiveHighlights';
+import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { BottomLogo } from './BottomLogo';
 import { ChapterReader } from './ChapterReader';
 import { SkeletonLoader } from './SkeletonLoader';
+import { VerseJumpButton } from './VerseJumpButton';
 
 // Styles for the overall ChapterPage component
 const createStyles = (colors: ReturnType<typeof getColors>) =>
@@ -104,6 +106,7 @@ function TabContent({
   scrollRef,
   onTabContentSizeChange,
   isAvailableOffline,
+  onByLineSectionRegister,
 }: {
   chapter: ChapterContent | null | undefined;
   activeTab: ContentTabType;
@@ -121,6 +124,7 @@ function TabContent({
   scrollRef?: React.RefObject<ScrollView | null>;
   onTabContentSizeChange?: (contentWidth: number, contentHeight: number) => void;
   isAvailableOffline?: boolean;
+  onByLineSectionRegister?: (verseNumber: number, node: View | null) => void;
 }) {
   const { colors } = useTheme();
   const styles = createStyles(colors); // Use local createStyles for TabContent
@@ -214,6 +218,7 @@ function TabContent({
               explanation={explanationContent}
               filteredHighlights={filteredHighlights}
               filteredAutoHighlights={filteredAutoHighlights}
+              onByLineSectionRegister={activeTab === 'byline' ? onByLineSectionRegister : undefined}
             />
           )}
         </View>
@@ -307,6 +312,10 @@ export function ChapterPage({
   const byLineScrollRef = useRef<ScrollView>(null);
   const summaryScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
+
+  // Quick-verse-jump: refs to the rendered View for each By Line verse section.
+  // Used with measureLayout(byLineScrollRef) to compute the scroll-to Y on tap.
+  const byLineSectionRefs = useRef<Record<number, View | null>>({});
 
   // Note Modals State
   const [notesModalVisible, setNotesModalVisible] = useState(false);
@@ -754,6 +763,58 @@ export function ChapterPage({
   // Memoize context value to avoid unnecessary re-renders
   const textVisibilityContextValue = useMemo(() => ({ visibleYRange }), [visibleYRange]);
 
+  // Quick-verse-jump for the By Line tab (issue verse-mate-mobile#77).
+  // Parse the byline markdown once per content change to know which verse
+  // numbers are jumpable. Skip the parse when the tab is hidden.
+  const byLineVerses = useMemo(() => {
+    const content = byLineData && 'content' in byLineData ? byLineData.content : undefined;
+    if (!content) return [] as number[];
+    return parseByLineSections(content, chapterNumber)
+      .map((section) => section.verseNumber)
+      .filter((verseNumber) => verseNumber > 0);
+  }, [byLineData, chapterNumber]);
+
+  // Reset section refs when chapter changes.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refs reset on chapter swap
+  useEffect(() => {
+    byLineSectionRefs.current = {};
+  }, [bookId, chapterNumber]);
+
+  const handleByLineSectionRegister = useCallback((verseNumber: number, node: View | null) => {
+    if (node === null) {
+      delete byLineSectionRefs.current[verseNumber];
+      return;
+    }
+    byLineSectionRefs.current[verseNumber] = node;
+  }, []);
+
+  const handleByLineVerseJump = useCallback((verseNumber: number) => {
+    const node = byLineSectionRefs.current[verseNumber];
+    const scrollView = byLineScrollRef.current;
+    if (!node || !scrollView) return;
+    const scrollHandle = findNodeHandle(scrollView);
+    if (scrollHandle == null) return;
+    // measureLayout reports the section's offset relative to the ScrollView
+    // content, which is exactly what scrollTo expects on the y-axis.
+    (
+      node as unknown as {
+        measureLayout: (
+          node: number,
+          onSuccess: (x: number, y: number, w: number, h: number) => void,
+          onFail: () => void
+        ) => void;
+      }
+    ).measureLayout(
+      scrollHandle,
+      (_x, y) => {
+        // Bias by a small offset so the verse heading isn't flush with the
+        // viewport top.
+        scrollView.scrollTo({ y: Math.max(0, y - spacing.md), animated: true });
+      },
+      () => {}
+    );
+  }, []);
+
   return (
     <View style={styles.container} collapsable={false}>
       {/* Explanations View - Always render when user is in explanations view (even on buffer pages
@@ -814,6 +875,14 @@ export function ChapterPage({
             onTabContentSizeChange={(_w, h) =>
               handleTabContentSizeChange('byline', h, viewportHeightRef.current)
             }
+            onByLineSectionRegister={handleByLineSectionRegister}
+          />
+          {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77) */}
+          <VerseJumpButton
+            verses={byLineVerses}
+            onSelect={handleByLineVerseJump}
+            visible={activeView === 'explanations' && activeTab === 'byline'}
+            testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
           />
           <TabContent
             chapter={displayChapter}

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -257,6 +257,17 @@ export interface ChapterPageProps {
   onTap?: () => void;
   /** Hide the chapter title text (used in split view where parent has a header) */
   hideChapterTitle?: boolean;
+  /**
+   * Drives the verse-jump pill fade. Pass the same `fabVisible` state used by
+   * the chapter-nav scroll arrows so the pill auto-hides on the same trigger
+   * (VERA-39). Defaults to `true` for callers that don't track FAB visibility.
+   */
+  fabVisible?: boolean;
+  /**
+   * Called when the user taps the verse-jump pill. Wire to `showButtons` from
+   * `useFABVisibility` so the arrows and the pill re-show together.
+   */
+  onFABInteraction?: () => void;
 }
 
 /**
@@ -294,6 +305,8 @@ export function ChapterPage({
   onScroll,
   onTap,
   hideChapterTitle = false,
+  fabVisible = true,
+  onFABInteraction,
 }: ChapterPageProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors); // Use local createStyles for ChapterPage
@@ -901,13 +914,17 @@ export function ChapterPage({
             }
             onByLineSectionRegister={handleByLineSectionRegister}
           />
-          {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77) */}
-          <VerseJumpButton
-            verses={byLineVerses}
-            onSelect={handleByLineVerseJump}
-            visible={activeView === 'explanations' && activeTab === 'byline'}
-            testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
-          />
+          {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77).
+              Mount on the byline tab; fade with the scroll-arrow auto-hide (VERA-39). */}
+          {activeView === 'explanations' && activeTab === 'byline' && (
+            <VerseJumpButton
+              verses={byLineVerses}
+              onSelect={handleByLineVerseJump}
+              visible={fabVisible}
+              onInteraction={onFABInteraction}
+              testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
+            />
+          )}
           <TabContent
             chapter={displayChapter}
             activeTab="detailed"

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -58,6 +58,7 @@ import {
   findGroupByHighlightId,
   groupConsecutiveHighlights,
 } from '@/utils/bible/groupConsecutiveHighlights';
+import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 
 // TODO: This will be replaced by a user setting
 const PARAGRAPH_VIEW_ENABLED = true;
@@ -162,6 +163,14 @@ interface ChapterReaderProps {
   hideChapterTitle?: boolean;
   /** Callback to report Y-position of verse sections for scrolling */
   onContentLayout?: (sectionPositions: Record<number, number>) => void;
+  /**
+   * Register the rendered React Native View for a verse section in the By Line
+   * explanation tab. The parent uses `measureLayout` against its ScrollView ref
+   * to compute the absolute scroll offset for that verse.
+   *
+   * Receives `null` for verse sections that no longer exist (cleanup).
+   */
+  onByLineSectionRegister?: (verseNumber: number, node: View | null) => void;
   /** Callback to open notes modal */
   onOpenNotes?: () => void;
   /** Optional filtered highlights (overrides context highlights) */
@@ -258,6 +267,7 @@ export function ChapterReader({
   explanationsOnly = false,
   hideChapterTitle = false,
   onContentLayout,
+  onByLineSectionRegister,
   onOpenNotes,
   filteredHighlights,
   filteredAutoHighlights,
@@ -744,7 +754,26 @@ export function ChapterReader({
               )}
 
               {/* Markdown content */}
-              <Markdown style={markdownStyles}>{contentWithoutTitle}</Markdown>
+              {activeTab === 'byline' && onByLineSectionRegister ? (
+                (() => {
+                  const sections = parseByLineSections(contentWithoutTitle, chapter.chapterNumber);
+                  if (sections.length === 0) {
+                    return <Markdown style={markdownStyles}>{contentWithoutTitle}</Markdown>;
+                  }
+                  return sections.map((section, index) => (
+                    <View
+                      key={`byline-section-${section.verseNumber}-${index}`}
+                      ref={(node) => onByLineSectionRegister(section.verseNumber, node)}
+                      testID={`byline-verse-section-${section.verseNumber}`}
+                      collapsable={false}
+                    >
+                      <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                    </View>
+                  ));
+                })()
+              ) : (
+                <Markdown style={markdownStyles}>{contentWithoutTitle}</Markdown>
+              )}
             </View>
           );
         })()}

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -10,17 +10,30 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
-import { fontSizes, fontWeights, type getColors, spacing, type ThemeMode } from '@/theme/tokens';
+import {
+  animationDurations,
+  fontSizes,
+  fontWeights,
+  type getColors,
+  spacing,
+  type ThemeMode,
+} from '@/theme/tokens';
 
 export interface VerseJumpButtonProps {
   /** Ordered list of verse numbers available in the By Line view */
   verses: number[];
   /** Called with the chosen verse number after the modal closes */
   onSelect: (verseNumber: number) => void;
-  /** Hide the button entirely (e.g. when the tab is not active) */
+  /**
+   * Drives the fade-in/out animation. Mirrors the scroll-arrow auto-hide so
+   * the pill disappears on idle and reappears on scroll/tap (VERA-39). The
+   * pill stays mounted at opacity 0 — tapping the faded pill still opens the
+   * verse picker, matching the no-dead-zone arrow behavior.
+   */
   visible?: boolean;
   /**
    * Distance from the parent's bottom edge in dp. Defaults to mobile portrait
@@ -29,6 +42,11 @@ export interface VerseJumpButtonProps {
    * the host passes a tighter value (typically `spacing.lg`).
    */
   bottomOffset?: number;
+  /**
+   * Called when the user taps the pill. Lets the host reset its auto-hide
+   * timer so the verse-jump pill and scroll arrows re-show together.
+   */
+  onInteraction?: () => void;
   /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
   testID?: string;
 }
@@ -46,16 +64,28 @@ export function VerseJumpButton({
   onSelect,
   visible = true,
   bottomOffset,
+  onInteraction,
   testID = 'verse-jump-button',
 }: VerseJumpButtonProps) {
   const { mode, colors } = useTheme();
   const [open, setOpen] = useState(false);
   const styles = createStyles(mode, colors, bottomOffset);
 
-  if (!visible || verses.length === 0) return null;
+  // Mirror FloatingActionButtons fade — pill stays mounted at opacity 0 so
+  // tapping the faded pill area still opens the picker (VERA-39).
+  const opacity = useSharedValue(visible ? 1 : 0);
+  useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, {
+      duration: animationDurations.normal,
+    });
+  }, [visible, opacity]);
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  if (verses.length === 0) return null;
 
   const handleOpen = () => {
     triggerHaptic();
+    onInteraction?.();
     setOpen(true);
   };
 
@@ -71,19 +101,21 @@ export function VerseJumpButton({
 
   return (
     <>
-      <Pressable
-        onPress={handleOpen}
-        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-        accessibilityLabel="Jump to verse"
-        accessibilityRole="button"
-        accessibilityHint="Open the list of verses to jump to one in the By Line view"
-        testID={testID}
-      >
-        <Ionicons name="list" size={22} color="#ffffff" />
-        <Text style={styles.fabLabel} accessibilityElementsHidden>
-          Verse
-        </Text>
-      </Pressable>
+      <Animated.View style={[styles.fabContainer, animatedStyle]}>
+        <Pressable
+          onPress={handleOpen}
+          style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+          accessibilityLabel="Jump to verse"
+          accessibilityRole="button"
+          accessibilityHint="Open the list of verses to jump to one in the By Line view"
+          testID={testID}
+        >
+          <Ionicons name="list" size={22} color="#ffffff" />
+          <Text style={styles.fabLabel} accessibilityElementsHidden>
+            Verse
+          </Text>
+        </Pressable>
+      </Animated.View>
       <Modal
         visible={open}
         animationType="fade"
@@ -134,13 +166,20 @@ const createStyles = (
   bottomOffset?: number
 ) =>
   StyleSheet.create({
-    fab: {
+    // Animated wrapper drives fade-in/out (VERA-39). The Pressable inside
+    // retains its hit-target even at opacity 0, so taps on the faded pill
+    // still open the verse picker — mirrors FloatingActionButtons.
+    fabContainer: {
       position: 'absolute',
       right: spacing.lg,
       // Stack the pill ABOVE the chapter-nav FAB row by default (phone portrait
       // path through ChapterPage). Hosts without a chapter-nav row beneath the
       // ScrollView (split-view / desktop right panel) override via bottomOffset.
       bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+    },
+    fab: {
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -22,6 +22,13 @@ export interface VerseJumpButtonProps {
   onSelect: (verseNumber: number) => void;
   /** Hide the button entirely (e.g. when the tab is not active) */
   visible?: boolean;
+  /**
+   * Distance from the parent's bottom edge in dp. Defaults to mobile portrait
+   * stacking (above the chapter-nav FAB row + progress bar). Split-view /
+   * desktop panels have no chapter-nav row below the byline ScrollView, so
+   * the host passes a tighter value (typically `spacing.lg`).
+   */
+  bottomOffset?: number;
   /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
   testID?: string;
 }
@@ -38,11 +45,12 @@ export function VerseJumpButton({
   verses,
   onSelect,
   visible = true,
+  bottomOffset,
   testID = 'verse-jump-button',
 }: VerseJumpButtonProps) {
   const { mode, colors } = useTheme();
   const [open, setOpen] = useState(false);
-  const styles = createStyles(mode, colors);
+  const styles = createStyles(mode, colors, bottomOffset);
 
   if (!visible || verses.length === 0) return null;
 
@@ -120,16 +128,19 @@ export function VerseJumpButton({
 const FAB_SIZE = 52;
 const CELL_SIZE = 48;
 
-const createStyles = (mode: ThemeMode, colors: ReturnType<typeof getColors>) =>
+const createStyles = (
+  mode: ThemeMode,
+  colors: ReturnType<typeof getColors>,
+  bottomOffset?: number
+) =>
   StyleSheet.create({
     fab: {
       position: 'absolute',
       right: spacing.lg,
-      // Stack the pill ABOVE the chapter-nav FAB row instead of co-locating
-      // (chapter-nav row: bottom 60 + size 56 = top edge 116 from screen bottom).
-      // 60 (chapter-nav bottomOffset) + 56 (chapter-nav FAB size) + spacing.md
-      // gap, then spacing.lg breathing room above the progress bar.
-      bottom: spacing.lg + 60 + 56 + spacing.md,
+      // Stack the pill ABOVE the chapter-nav FAB row by default (phone portrait
+      // path through ChapterPage). Hosts without a chapter-nav row beneath the
+      // ScrollView (split-view / desktop right panel) override via bottomOffset.
+      bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -1,0 +1,205 @@
+/**
+ * VerseJumpButton
+ *
+ * Floating action button + verse-number grid modal. Used by the By Line
+ * explanation tab so readers can jump to a specific verse instead of scrolling
+ * through long chapters (e.g. Psalm 119, 176 verses).
+ *
+ * @see verse-mate-mobile issue #77
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import * as Haptics from 'expo-haptics';
+import { useState } from 'react';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { fontSizes, fontWeights, type getColors, spacing, type ThemeMode } from '@/theme/tokens';
+
+export interface VerseJumpButtonProps {
+  /** Ordered list of verse numbers available in the By Line view */
+  verses: number[];
+  /** Called with the chosen verse number after the modal closes */
+  onSelect: (verseNumber: number) => void;
+  /** Hide the button entirely (e.g. when the tab is not active) */
+  visible?: boolean;
+  /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
+  testID?: string;
+}
+
+const HAPTICS_ENABLED = Platform.OS !== 'web';
+
+function triggerHaptic() {
+  if (!HAPTICS_ENABLED) return;
+  // Fire-and-forget; failures are non-fatal in tests.
+  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light).catch(() => {});
+}
+
+export function VerseJumpButton({
+  verses,
+  onSelect,
+  visible = true,
+  testID = 'verse-jump-button',
+}: VerseJumpButtonProps) {
+  const { mode, colors } = useTheme();
+  const [open, setOpen] = useState(false);
+  const styles = createStyles(mode, colors);
+
+  if (!visible || verses.length === 0) return null;
+
+  const handleOpen = () => {
+    triggerHaptic();
+    setOpen(true);
+  };
+
+  const handleClose = () => setOpen(false);
+
+  const handleSelect = (verseNumber: number) => {
+    triggerHaptic();
+    setOpen(false);
+    // Defer to the next tick so the modal can dismiss before the scroll
+    // animation begins — feels smoother on iOS.
+    setTimeout(() => onSelect(verseNumber), 0);
+  };
+
+  return (
+    <>
+      <Pressable
+        onPress={handleOpen}
+        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+        accessibilityLabel="Jump to verse"
+        accessibilityRole="button"
+        accessibilityHint="Open the list of verses to jump to one in the By Line view"
+        testID={testID}
+      >
+        <Ionicons name="list" size={22} color="#ffffff" />
+        <Text style={styles.fabLabel} accessibilityElementsHidden>
+          Verse
+        </Text>
+      </Pressable>
+      <Modal
+        visible={open}
+        animationType="fade"
+        transparent
+        onRequestClose={handleClose}
+        testID={`${testID}-modal`}
+      >
+        <Pressable
+          style={styles.backdrop}
+          onPress={handleClose}
+          accessibilityLabel="Close verse list"
+          testID={`${testID}-backdrop`}
+        >
+          {/* Inner pressable swallows taps so the sheet doesn't close. */}
+          <Pressable style={styles.sheet} onPress={() => {}}>
+            <Text style={styles.title}>Jump to verse</Text>
+            <ScrollView
+              style={styles.gridScroll}
+              contentContainerStyle={styles.grid}
+              showsVerticalScrollIndicator={false}
+            >
+              {verses.map((verseNumber) => (
+                <Pressable
+                  key={verseNumber}
+                  onPress={() => handleSelect(verseNumber)}
+                  style={({ pressed }) => [styles.cell, pressed && styles.cellPressed]}
+                  accessibilityLabel={`Jump to verse ${verseNumber}`}
+                  accessibilityRole="button"
+                  testID={`${testID}-verse-${verseNumber}`}
+                >
+                  <Text style={styles.cellText}>{verseNumber}</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </Pressable>
+        </Pressable>
+      </Modal>
+    </>
+  );
+}
+
+const FAB_SIZE = 52;
+const CELL_SIZE = 48;
+
+const createStyles = (mode: ThemeMode, colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    fab: {
+      position: 'absolute',
+      right: spacing.lg,
+      bottom: spacing.lg + 60, // sit above the progress bar / FAB row
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+      borderRadius: FAB_SIZE / 2,
+      backgroundColor: colors.gold,
+      justifyContent: 'center',
+      alignItems: 'center',
+      ...Platform.select({
+        ios: {
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: mode === 'dark' ? 0.4 : 0.2,
+          shadowRadius: 6,
+        },
+        android: {
+          elevation: 6,
+        },
+        default: {},
+      }),
+    },
+    fabPressed: {
+      opacity: 0.85,
+    },
+    fabLabel: {
+      position: 'absolute',
+      bottom: 4,
+      fontSize: 9,
+      color: '#ffffff',
+      fontWeight: fontWeights.semibold,
+    },
+    backdrop: {
+      flex: 1,
+      backgroundColor: colors.backdrop,
+      justifyContent: 'flex-end',
+    },
+    sheet: {
+      backgroundColor: colors.backgroundElevated,
+      borderTopLeftRadius: spacing.lg,
+      borderTopRightRadius: spacing.lg,
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.xxl,
+      maxHeight: '70%',
+    },
+    title: {
+      fontSize: fontSizes.heading2,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      marginBottom: spacing.md,
+    },
+    gridScroll: {
+      flexGrow: 0,
+    },
+    grid: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing.xs,
+    },
+    cell: {
+      width: CELL_SIZE,
+      height: CELL_SIZE,
+      borderRadius: spacing.sm,
+      backgroundColor: colors.backgroundSecondary,
+      borderWidth: 1,
+      borderColor: colors.borderSecondary,
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+    cellPressed: {
+      backgroundColor: colors.gold,
+      borderColor: colors.gold,
+    },
+    cellText: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+    },
+  });

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -125,7 +125,11 @@ const createStyles = (mode: ThemeMode, colors: ReturnType<typeof getColors>) =>
     fab: {
       position: 'absolute',
       right: spacing.lg,
-      bottom: spacing.lg + 60, // sit above the progress bar / FAB row
+      // Stack the pill ABOVE the chapter-nav FAB row instead of co-locating
+      // (chapter-nav row: bottom 60 + size 56 = top edge 116 from screen bottom).
+      // 60 (chapter-nav bottomOffset) + 56 (chapter-nav FAB size) + spacing.md
+      // gap, then spacing.lg breathing room above the progress bar.
+      bottom: spacing.lg + 60 + 56 + spacing.md,
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,

--- a/utils/bible/byLineJump.ts
+++ b/utils/bible/byLineJump.ts
@@ -1,0 +1,20 @@
+/**
+ * Quick-verse-jump scroll-target math (verse-mate-mobile #77 / VERA-35).
+ *
+ * react-native-web ships `View.measureLayout` as a stub that never invokes its
+ * callbacks, so the native scroll path silently no-ops on web. The web fallback
+ * reads positions from the DOM via `getBoundingClientRect` + the ScrollView's
+ * current `scrollTop`. Native uses `measureLayout` directly in ChapterPage.
+ */
+
+type RectLike = { top: number };
+type ScrollableLike = RectLike & { scrollTop: number };
+
+export function computeByLineJumpY(
+  scrollRect: ScrollableLike,
+  sectionRect: RectLike,
+  biasPx: number
+): number {
+  const y = sectionRect.top - scrollRect.top + scrollRect.scrollTop - biasPx;
+  return Math.max(0, y);
+}

--- a/utils/bible/parseByLineExplanation.ts
+++ b/utils/bible/parseByLineExplanation.ts
@@ -211,3 +211,59 @@ export function extractVerseTextFromByLine(
 
   return verseTexts.join(' ');
 }
+
+export interface ByLineSection {
+  verseNumber: number;
+  markdown: string;
+}
+
+/**
+ * Splits byline markdown into per-verse sections.
+ * Anything before the first `## <Chapter>:<Verse>` header is returned as a
+ * leading prelude with verseNumber = 0 (preserves intro text from the model).
+ *
+ * Used by the quick-verse-jump control to anchor each verse section in the
+ * ScrollView so taps on a verse number can scrollTo the right Y position.
+ */
+export function parseByLineSections(
+  markdownContent: string,
+  chapterNumber: number
+): ByLineSection[] {
+  if (!markdownContent) return [];
+
+  const content = markdownContent.replace(/\r\n/g, '\n');
+  const lines = content.split('\n');
+
+  const sections: ByLineSection[] = [];
+  let currentVerse = 0;
+  let buffer: string[] = [];
+
+  const flush = () => {
+    const body = buffer.join('\n').trim();
+    if (body.length > 0) {
+      sections.push({ verseNumber: currentVerse, markdown: body });
+    }
+    buffer = [];
+  };
+
+  for (const line of lines) {
+    if (line.startsWith('## ')) {
+      const match = line.match(/(\d+):(\d+)/);
+      if (match) {
+        const foundChapter = parseInt(match[1], 10);
+        const foundVerse = parseInt(match[2], 10);
+        if (foundChapter === chapterNumber) {
+          flush();
+          currentVerse = foundVerse;
+          buffer.push(line);
+          continue;
+        }
+      }
+    }
+    buffer.push(line);
+  }
+
+  flush();
+
+  return sections;
+}


### PR DESCRIPTION
## Summary

Adds a quick-verse-jump control to the **By Line** explanation tab so readers can skip straight to any verse instead of scrolling through long chapters. Resolves the Psalm 119 (176 verses) pain point quoted in the upstream issue.

- New `VerseJumpButton` — gold floating pill bottom-right of the By Line tab, opens a verse-number grid sheet.
- `parseByLineSections` util splits the byline markdown on each `## <Chapter>:<Verse>` heading.
- `ChapterReader` registers a per-verse View on the byline path; `ChapterPage` resolves the section with `measureLayout(byLineScrollRef)` on tap and animates the scroll (biased so the heading isn't flush with the viewport top).
- No change to summary/detailed tabs — they still render a single markdown blob.

Closes #77

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun jest __tests__/utils/bible/parseByLineExplanation.test.ts` — 10/10 (new cases for `parseByLineSections`, incl. 176-verse synthetic Psalm 119)
- [x] `bun jest __tests__/components/bible/VerseJumpButton.test.tsx` — 5/5 (empty list, hidden, modal grid, select-and-close, backdrop dismiss)
- [x] `bun jest __tests__/components/bible/ChapterPage.test.tsx __tests__/components/bible/ChapterReader.test.tsx app/bible/__tests__/by-line-view.test.tsx` — 17/17 (regressions clean)
- [x] `biome check` clean on the changed files
- [ ] **QA**: manual verify on iOS + Android — open the By Line tab on Psalm 119, tap the gold pill, jump to verse 100 + verse 176, confirm the heading lands near the viewport top. Verify the FAB is hidden in Bible view and on the Summary / Detailed tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
