### PR TITLE
fix(byline): wire quick-verse-jump FAB into split-view explanations panel

### DIFF
--- a/__tests__/utils/bible/byLineJump.test.ts
+++ b/__tests__/utils/bible/byLineJump.test.ts
@@ -34,4 +34,28 @@ describe('computeByLineJumpY', () => {
     const y = computeByLineJumpY({ top: 0, scrollTop: 0 }, { top: 127425 }, 12);
     expect(y).toBe(127413);
   });
+
+  // VERA-36: desktop viewport regression. At width >= 900dp the app renders
+  // the explanations panel as a split-view right panel, so the byline
+  // ScrollView's rect.top is offset by the panel header + tab bar (~120dp).
+  // The math must produce the correct target when scrollTop is mid-chapter.
+  it('computes desktop-viewport target when ScrollView sits below the split-panel header', () => {
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 800 }, 12);
+    expect(y).toBe(668); // 800 - 120 + 0 - 12
+  });
+
+  it('preserves desktop forward-jump magnitude when user has scrolled mid-chapter', () => {
+    // Right panel scrolled 1200px; the section's viewport-relative top is just
+    // below the visible area. Result must equal the absolute scroll target,
+    // unaffected by the panel's chrome offset.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 1200 }, { top: 400 }, 12);
+    expect(y).toBe(1468); // 400 - 120 + 1200 - 12
+  });
+
+  it('handles Psalm 119 v176 magnitude inside a split-view right panel', () => {
+    // Same offsetTop magnitude as the phone case above (~127425), but with the
+    // ScrollView mounted inside a 120dp-tall chrome stack.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 127425 }, 12);
+    expect(y).toBe(127293);
+  });
 });

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -14,9 +14,18 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Animated,
+  findNodeHandle,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
@@ -36,8 +45,11 @@ import {
   spacing,
 } from '@/theme/tokens';
 import type { ContentTabType } from '@/types/bible';
+import { computeByLineJumpY } from '@/utils/bible/byLineJump';
+import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { AudioInlineEntry } from './AudioInlineEntry';
 import { ShareButton } from './ShareButton';
+import { VerseJumpButton } from './VerseJumpButton';
 
 /**
  * Tab configuration for explanation types
@@ -128,12 +140,18 @@ export function BibleExplanationsPanel({
   const byLineScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
 
+  // Quick-verse-jump (VERA-35 / VERA-36): refs to each rendered By Line
+  // verse-section View. Populated when byline content is split into per-verse
+  // sections below. Reset on chapter swap so stale nodes can't be reached.
+  const byLineSectionRefs = useRef<Record<number, View | null>>({});
+
   // Reset all scroll positions only when chapter changes (not on tab switch)
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps are intentional triggers for scroll reset
   useEffect(() => {
     summaryScrollRef.current?.scrollTo({ y: 0, animated: false });
     byLineScrollRef.current?.scrollTo({ y: 0, animated: false });
     detailedScrollRef.current?.scrollTo({ y: 0, animated: false });
+    byLineSectionRefs.current = {};
   }, [bookId, chapterNumber]);
 
   // Animate indicator when active tab changes
@@ -194,6 +212,66 @@ export function BibleExplanationsPanel({
   const summaryContent = extractContent(summaryData);
   const byLineContent = extractContent(byLineData);
   const detailedContent = extractContent(detailedData);
+
+  // Quick-verse-jump for the By Line tab (VERA-36): desktop / split-view path.
+  // ChapterPage handles the phone-portrait path; this panel covers
+  // landscape-tablet and web desktop (width >= 900dp, see
+  // utils/device-detection.ts -> shouldUseSplitView).
+  const byLineSections = useMemo(() => {
+    if (!byLineContent) return [] as ReturnType<typeof parseByLineSections>;
+    return parseByLineSections(byLineContent, chapterNumber);
+  }, [byLineContent, chapterNumber]);
+
+  const byLineVerses = useMemo(
+    () => byLineSections.map((section) => section.verseNumber).filter((v) => v > 0),
+    [byLineSections]
+  );
+
+  const handleByLineVerseJump = useCallback((verseNumber: number) => {
+    const node = byLineSectionRefs.current[verseNumber];
+    const scrollView = byLineScrollRef.current;
+    if (!node || !scrollView) return;
+
+    // react-native-web's `View.measureLayout` is a no-op stub, so the native
+    // path silently fails on web. On web, read positions from the DOM via
+    // getBoundingClientRect + the ScrollView's scrollTop. Mirrors the logic in
+    // ChapterPage.tsx (VERA-35 QA round 2 / verse-mate-mobile #77).
+    if (Platform.OS === 'web') {
+      const scrollNode = (
+        scrollView as unknown as { getScrollableNode?: () => HTMLElement | null }
+      ).getScrollableNode?.();
+      const sectionEl = node as unknown as HTMLElement;
+      if (scrollNode && typeof sectionEl.getBoundingClientRect === 'function') {
+        const sRect = scrollNode.getBoundingClientRect();
+        const nRect = sectionEl.getBoundingClientRect();
+        const y = computeByLineJumpY(
+          { top: sRect.top, scrollTop: scrollNode.scrollTop },
+          { top: nRect.top },
+          spacing.md
+        );
+        scrollView.scrollTo({ y, animated: true });
+      }
+      return;
+    }
+
+    const scrollHandle = findNodeHandle(scrollView);
+    if (scrollHandle == null) return;
+    (
+      node as unknown as {
+        measureLayout: (
+          node: number,
+          onSuccess: (x: number, y: number, w: number, h: number) => void,
+          onFail: () => void
+        ) => void;
+      }
+    ).measureLayout(
+      scrollHandle,
+      (_x, y) => {
+        scrollView.scrollTo({ y: Math.max(0, y - spacing.md), animated: true });
+      },
+      () => {}
+    );
+  }, []);
 
   /**
    * Handle touch start - record time and position
@@ -396,7 +474,27 @@ export function BibleExplanationsPanel({
                 />
               ) : null}
               {tab.isLocal && <AvailableOfflineBadge />}
-              <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              {tab.key === 'byline' && byLineSections.length > 0 ? (
+                byLineSections.map((section, index) => (
+                  <View
+                    // biome-ignore lint/suspicious/noArrayIndexKey: stable within a single parsed render
+                    key={`byline-section-${section.verseNumber}-${index}`}
+                    ref={(node) => {
+                      if (node === null) {
+                        delete byLineSectionRefs.current[section.verseNumber];
+                      } else {
+                        byLineSectionRefs.current[section.verseNumber] = node;
+                      }
+                    }}
+                    testID={`byline-verse-section-${section.verseNumber}`}
+                    collapsable={false}
+                  >
+                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                  </View>
+                ))
+              ) : (
+                <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              )}
             </>
           ) : isOffline ? (
             <OfflineContentUnavailable contentType="explanation" />
@@ -407,6 +505,17 @@ export function BibleExplanationsPanel({
           )}
         </ScrollView>
       ))}
+
+      {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
+          beneath this ScrollView in split / desktop right panel, so use a
+          tighter bottom offset than the phone-portrait default. */}
+      <VerseJumpButton
+        verses={byLineVerses}
+        onSelect={handleByLineVerseJump}
+        visible={activeTab === 'byline'}
+        bottomOffset={spacing.lg}
+        testID={`${testID}-verse-jump`}
+      />
     </View>
   );
 }

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -22,6 +22,13 @@ export interface VerseJumpButtonProps {
   onSelect: (verseNumber: number) => void;
   /** Hide the button entirely (e.g. when the tab is not active) */
   visible?: boolean;
+  /**
+   * Distance from the parent's bottom edge in dp. Defaults to mobile portrait
+   * stacking (above the chapter-nav FAB row + progress bar). Split-view /
+   * desktop panels have no chapter-nav row below the byline ScrollView, so
+   * the host passes a tighter value (typically `spacing.lg`).
+   */
+  bottomOffset?: number;
   /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
   testID?: string;
 }
@@ -38,11 +45,12 @@ export function VerseJumpButton({
   verses,
   onSelect,
   visible = true,
+  bottomOffset,
   testID = 'verse-jump-button',
 }: VerseJumpButtonProps) {
   const { mode, colors } = useTheme();
   const [open, setOpen] = useState(false);
-  const styles = createStyles(mode, colors);
+  const styles = createStyles(mode, colors, bottomOffset);
 
   if (!visible || verses.length === 0) return null;
 
@@ -120,16 +128,19 @@ export function VerseJumpButton({
 const FAB_SIZE = 52;
 const CELL_SIZE = 48;
 
-const createStyles = (mode: ThemeMode, colors: ReturnType<typeof getColors>) =>
+const createStyles = (
+  mode: ThemeMode,
+  colors: ReturnType<typeof getColors>,
+  bottomOffset?: number
+) =>
   StyleSheet.create({
     fab: {
       position: 'absolute',
       right: spacing.lg,
-      // Stack the pill ABOVE the chapter-nav FAB row instead of co-locating
-      // (chapter-nav row: bottom 60 + size 56 = top edge 116 from screen bottom).
-      // 60 (chapter-nav bottomOffset) + 56 (chapter-nav FAB size) + spacing.md
-      // gap, then spacing.lg breathing room above the progress bar.
-      bottom: spacing.lg + 60 + 56 + spacing.md,
+      // Stack the pill ABOVE the chapter-nav FAB row by default (phone portrait
+      // path through ChapterPage). Hosts without a chapter-nav row beneath the
+      // ScrollView (split-view / desktop right panel) override via bottomOffset.
+      bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,


### PR DESCRIPTION
## Summary

VERA-36. Quick-verse-jump pill landed in [PR #299](https://github.com/verse-mate/verse-mate-mobile/pull/299) inside `ChapterPage`, the phone-portrait reader path. At desktop viewport (web width ≥ 900dp, see `shouldUseSplitView` in `utils/device-detection.ts`) the app renders the explanations tab through `BibleExplanationsPanel` instead, which had no FAB and no per-verse refs — so the pill was simply missing on desktop.

This wires the same control into `BibleExplanationsPanel`:

- Split parsed byline markdown into per-verse `<View>` sections and capture refs into `byLineSectionRefs` (mirrors `ChapterReader`).
- Reuse `computeByLineJumpY` + the RNW-vs-native branching from `ChapterPage.handleByLineVerseJump` — math stays in one place, exercised by `byLineJump.test.ts`.
- Render `VerseJumpButton` only when `activeTab === 'byline'`.

`VerseJumpButton` gains an optional `bottomOffset` prop. Phone-portrait default (above chapter-nav FAB row + progress bar) is unchanged. Split / desktop right panel has no chrome beneath its ScrollView so it passes `spacing.lg`, keeping the pill flush with the panel bottom-right.

Unit-test parity (per VERA-36 acceptance): three new cases in `byLineJump.test.ts` exercise the desktop-viewport offset magnitude where the ScrollView is mounted inside a 120dp panel-header chrome stack, including the Psalm 119 v176 magnitude.

## Layered on top of PR #299

This branches from `feat-verse-jump/byline`, not `main`. Merge order: #299 first, then this PR.

## Test plan

- [x] `npm test -- --testPathPattern=byLineJump` — 7/7 (3 new desktop cases).
- [x] `npm test -- --testPathPattern=VerseJumpButton` — 5/5 (existing snapshots unchanged by `bottomOffset` addition).
- [x] `npm test -- --testPathPattern="ChapterPage|bible-reading-integration"` — 27/27 (5 pre-existing skips), no regressions.
- [x] `bun run type-check` — clean.
- [ ] QA at desktop viewport (≥1024px) on `verse-mate-mobile-web-preview.verse-mate.workers.dev`:
  - [ ] Psalm 119 (176 verses): pill visible, opens grid, tapping a verse scrolls to it, no overlap with any chrome.
  - [ ] Matthew 5 (48 verses).
  - [ ] Genesis 1.

Refs: VERA-36, verse-mate-mobile #77, [PR #299](https://github.com/verse-mate/verse-mate-mobile/pull/299).
