### PR TITLE
feat(byline): auto-hide verse-jump pill with scroll arrows (VERA-39)

### DIFF
--- a/__tests__/components/bible/VerseJumpButton.test.tsx
+++ b/__tests__/components/bible/VerseJumpButton.test.tsx
@@ -3,6 +3,9 @@
  *
  * Verifies the quick-verse-jump control rendered above the By Line tab:
  * - hides itself when there are no verses to jump to
+ * - fades (rather than unmounts) when visible=false so the pill auto-hides
+ *   on the same trigger as the chapter-nav scroll arrows (VERA-39)
+ * - keeps the hit-target during fade-out and reveals the picker on tap
  * - opens a modal listing every verse on tap
  * - emits the chosen verse number on cell tap and dismisses the modal
  * - dismisses on backdrop tap without emitting
@@ -26,10 +29,30 @@ describe('VerseJumpButton', () => {
     expect(screen.queryByTestId('verse-jump-button')).toBeNull();
   });
 
-  it('renders nothing when visible=false', () => {
+  it('stays mounted but fades out when visible=false (mirrors scroll-arrow auto-hide)', () => {
     const onSelect = jest.fn();
     renderWithProviders(<VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} visible={false} />);
-    expect(screen.queryByTestId('verse-jump-button')).toBeNull();
+    // Pill stays in the tree so the hit-target survives the fade — no dead-zone
+    // regression vs. the previous always-visible pill.
+    expect(screen.getByTestId('verse-jump-button')).toBeTruthy();
+  });
+
+  it('still opens the picker when tapped while faded out', () => {
+    const onSelect = jest.fn();
+    const onInteraction = jest.fn();
+    renderWithProviders(
+      <VerseJumpButton
+        verses={[1, 2, 3]}
+        onSelect={onSelect}
+        visible={false}
+        onInteraction={onInteraction}
+      />
+    );
+    fireEvent.press(screen.getByTestId('verse-jump-button'));
+    expect(screen.getByTestId('verse-jump-button-verse-2')).toBeTruthy();
+    // Tap also signals interaction so the host can reset the auto-hide timer
+    // and re-show the pill alongside the scroll arrows.
+    expect(onInteraction).toHaveBeenCalledTimes(1);
   });
 
   it('opens the modal and lists every supplied verse on tap', () => {

--- a/__tests__/utils/bible/byLineJump.test.ts
+++ b/__tests__/utils/bible/byLineJump.test.ts
@@ -34,4 +34,28 @@ describe('computeByLineJumpY', () => {
     const y = computeByLineJumpY({ top: 0, scrollTop: 0 }, { top: 127425 }, 12);
     expect(y).toBe(127413);
   });
+
+  // VERA-36: desktop viewport regression. At width >= 900dp the app renders
+  // the explanations panel as a split-view right panel, so the byline
+  // ScrollView's rect.top is offset by the panel header + tab bar (~120dp).
+  // The math must produce the correct target when scrollTop is mid-chapter.
+  it('computes desktop-viewport target when ScrollView sits below the split-panel header', () => {
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 800 }, 12);
+    expect(y).toBe(668); // 800 - 120 + 0 - 12
+  });
+
+  it('preserves desktop forward-jump magnitude when user has scrolled mid-chapter', () => {
+    // Right panel scrolled 1200px; the section's viewport-relative top is just
+    // below the visible area. Result must equal the absolute scroll target,
+    // unaffected by the panel's chrome offset.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 1200 }, { top: 400 }, 12);
+    expect(y).toBe(1468); // 400 - 120 + 1200 - 12
+  });
+
+  it('handles Psalm 119 v176 magnitude inside a split-view right panel', () => {
+    // Same offsetTop magnitude as the phone case above (~127425), but with the
+    // ScrollView mounted inside a 120dp-tall chrome stack.
+    const y = computeByLineJumpY({ top: 120, scrollTop: 0 }, { top: 127425 }, 12);
+    expect(y).toBe(127293);
+  });
 });

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -393,6 +393,8 @@ export default function ChapterScreen() {
           isPreloading={!isCurrent}
           targetVerse={isCurrent ? targetVerse : undefined}
           targetEndVerse={isCurrent ? targetEndVerse : undefined}
+          fabVisible={fabVisible}
+          onFABInteraction={showButtons}
         />
       );
     },
@@ -405,6 +407,8 @@ export default function ChapterScreen() {
       chapterNumber,
       targetVerse,
       targetEndVerse,
+      fabVisible,
+      showButtons,
     ]
   );
 
@@ -535,6 +539,8 @@ export default function ChapterScreen() {
                   onMenuPress={() => setIsMenuOpen(true)}
                   onScroll={handleScroll}
                   onTap={handleTap}
+                  fabVisible={fabVisible}
+                  onFABInteraction={showButtons}
                 />
               }
             />

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -88,6 +88,20 @@ export interface BibleExplanationsPanelProps {
   /** Callback for tap events (for FAB visibility control) */
   onTap?: () => void;
 
+  /**
+   * Drives the verse-jump pill fade. Pass the same `fabVisible` state used
+   * by the chapter-nav scroll arrows so the pill auto-hides on the same
+   * trigger (VERA-39 / VERA-36). Defaults to `true` for callers that don't
+   * track FAB visibility.
+   */
+  fabVisible?: boolean;
+
+  /**
+   * Called when the user taps the verse-jump pill. Wire to `showButtons`
+   * from `useFABVisibility` so the arrows and the pill re-show together.
+   */
+  onFABInteraction?: () => void;
+
   /** Test ID for testing */
   testID?: string;
 }
@@ -106,6 +120,8 @@ export function BibleExplanationsPanel({
   onMenuPress,
   onScroll,
   onTap,
+  fabVisible = true,
+  onFABInteraction,
   testID = 'bible-explanations-panel',
 }: BibleExplanationsPanelProps) {
   const { mode, colors } = useTheme();
@@ -508,14 +524,18 @@ export function BibleExplanationsPanel({
 
       {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
           beneath this ScrollView in split / desktop right panel, so use a
-          tighter bottom offset than the phone-portrait default. */}
-      <VerseJumpButton
-        verses={byLineVerses}
-        onSelect={handleByLineVerseJump}
-        visible={activeTab === 'byline'}
-        bottomOffset={spacing.lg}
-        testID={`${testID}-verse-jump`}
-      />
+          tighter bottom offset than the phone-portrait default.
+          Fades with the scroll-arrow auto-hide (VERA-39 / VERA-36 parity). */}
+      {activeTab === 'byline' && (
+        <VerseJumpButton
+          verses={byLineVerses}
+          onSelect={handleByLineVerseJump}
+          visible={fabVisible}
+          onInteraction={onFABInteraction}
+          bottomOffset={spacing.lg}
+          testID={`${testID}-verse-jump`}
+        />
+      )}
     </View>
   );
 }

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -14,9 +14,18 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  Animated,
+  findNodeHandle,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
@@ -36,8 +45,11 @@ import {
   spacing,
 } from '@/theme/tokens';
 import type { ContentTabType } from '@/types/bible';
+import { computeByLineJumpY } from '@/utils/bible/byLineJump';
+import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { AudioInlineEntry } from './AudioInlineEntry';
 import { ShareButton } from './ShareButton';
+import { VerseJumpButton } from './VerseJumpButton';
 
 /**
  * Tab configuration for explanation types
@@ -128,12 +140,18 @@ export function BibleExplanationsPanel({
   const byLineScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
 
+  // Quick-verse-jump (VERA-35 / VERA-36): refs to each rendered By Line
+  // verse-section View. Populated when byline content is split into per-verse
+  // sections below. Reset on chapter swap so stale nodes can't be reached.
+  const byLineSectionRefs = useRef<Record<number, View | null>>({});
+
   // Reset all scroll positions only when chapter changes (not on tab switch)
   // biome-ignore lint/correctness/useExhaustiveDependencies: deps are intentional triggers for scroll reset
   useEffect(() => {
     summaryScrollRef.current?.scrollTo({ y: 0, animated: false });
     byLineScrollRef.current?.scrollTo({ y: 0, animated: false });
     detailedScrollRef.current?.scrollTo({ y: 0, animated: false });
+    byLineSectionRefs.current = {};
   }, [bookId, chapterNumber]);
 
   // Animate indicator when active tab changes
@@ -194,6 +212,66 @@ export function BibleExplanationsPanel({
   const summaryContent = extractContent(summaryData);
   const byLineContent = extractContent(byLineData);
   const detailedContent = extractContent(detailedData);
+
+  // Quick-verse-jump for the By Line tab (VERA-36): desktop / split-view path.
+  // ChapterPage handles the phone-portrait path; this panel covers
+  // landscape-tablet and web desktop (width >= 900dp, see
+  // utils/device-detection.ts -> shouldUseSplitView).
+  const byLineSections = useMemo(() => {
+    if (!byLineContent) return [] as ReturnType<typeof parseByLineSections>;
+    return parseByLineSections(byLineContent, chapterNumber);
+  }, [byLineContent, chapterNumber]);
+
+  const byLineVerses = useMemo(
+    () => byLineSections.map((section) => section.verseNumber).filter((v) => v > 0),
+    [byLineSections]
+  );
+
+  const handleByLineVerseJump = useCallback((verseNumber: number) => {
+    const node = byLineSectionRefs.current[verseNumber];
+    const scrollView = byLineScrollRef.current;
+    if (!node || !scrollView) return;
+
+    // react-native-web's `View.measureLayout` is a no-op stub, so the native
+    // path silently fails on web. On web, read positions from the DOM via
+    // getBoundingClientRect + the ScrollView's scrollTop. Mirrors the logic in
+    // ChapterPage.tsx (VERA-35 QA round 2 / verse-mate-mobile #77).
+    if (Platform.OS === 'web') {
+      const scrollNode = (
+        scrollView as unknown as { getScrollableNode?: () => HTMLElement | null }
+      ).getScrollableNode?.();
+      const sectionEl = node as unknown as HTMLElement;
+      if (scrollNode && typeof sectionEl.getBoundingClientRect === 'function') {
+        const sRect = scrollNode.getBoundingClientRect();
+        const nRect = sectionEl.getBoundingClientRect();
+        const y = computeByLineJumpY(
+          { top: sRect.top, scrollTop: scrollNode.scrollTop },
+          { top: nRect.top },
+          spacing.md
+        );
+        scrollView.scrollTo({ y, animated: true });
+      }
+      return;
+    }
+
+    const scrollHandle = findNodeHandle(scrollView);
+    if (scrollHandle == null) return;
+    (
+      node as unknown as {
+        measureLayout: (
+          node: number,
+          onSuccess: (x: number, y: number, w: number, h: number) => void,
+          onFail: () => void
+        ) => void;
+      }
+    ).measureLayout(
+      scrollHandle,
+      (_x, y) => {
+        scrollView.scrollTo({ y: Math.max(0, y - spacing.md), animated: true });
+      },
+      () => {}
+    );
+  }, []);
 
   /**
    * Handle touch start - record time and position
@@ -396,7 +474,27 @@ export function BibleExplanationsPanel({
                 />
               ) : null}
               {tab.isLocal && <AvailableOfflineBadge />}
-              <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              {tab.key === 'byline' && byLineSections.length > 0 ? (
+                byLineSections.map((section, index) => (
+                  <View
+                    // biome-ignore lint/suspicious/noArrayIndexKey: stable within a single parsed render
+                    key={`byline-section-${section.verseNumber}-${index}`}
+                    ref={(node) => {
+                      if (node === null) {
+                        delete byLineSectionRefs.current[section.verseNumber];
+                      } else {
+                        byLineSectionRefs.current[section.verseNumber] = node;
+                      }
+                    }}
+                    testID={`byline-verse-section-${section.verseNumber}`}
+                    collapsable={false}
+                  >
+                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                  </View>
+                ))
+              ) : (
+                <Markdown style={markdownStyles}>{tab.data}</Markdown>
+              )}
             </>
           ) : isOffline ? (
             <OfflineContentUnavailable contentType="explanation" />
@@ -407,6 +505,17 @@ export function BibleExplanationsPanel({
           )}
         </ScrollView>
       ))}
+
+      {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
+          beneath this ScrollView in split / desktop right panel, so use a
+          tighter bottom offset than the phone-portrait default. */}
+      <VerseJumpButton
+        verses={byLineVerses}
+        onSelect={handleByLineVerseJump}
+        visible={activeTab === 'byline'}
+        bottomOffset={spacing.lg}
+        testID={`${testID}-verse-jump`}
+      />
     </View>
   );
 }

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -257,6 +257,17 @@ export interface ChapterPageProps {
   onTap?: () => void;
   /** Hide the chapter title text (used in split view where parent has a header) */
   hideChapterTitle?: boolean;
+  /**
+   * Drives the verse-jump pill fade. Pass the same `fabVisible` state used by
+   * the chapter-nav scroll arrows so the pill auto-hides on the same trigger
+   * (VERA-39). Defaults to `true` for callers that don't track FAB visibility.
+   */
+  fabVisible?: boolean;
+  /**
+   * Called when the user taps the verse-jump pill. Wire to `showButtons` from
+   * `useFABVisibility` so the arrows and the pill re-show together.
+   */
+  onFABInteraction?: () => void;
 }
 
 /**
@@ -294,6 +305,8 @@ export function ChapterPage({
   onScroll,
   onTap,
   hideChapterTitle = false,
+  fabVisible = true,
+  onFABInteraction,
 }: ChapterPageProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors); // Use local createStyles for ChapterPage
@@ -901,13 +914,17 @@ export function ChapterPage({
             }
             onByLineSectionRegister={handleByLineSectionRegister}
           />
-          {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77) */}
-          <VerseJumpButton
-            verses={byLineVerses}
-            onSelect={handleByLineVerseJump}
-            visible={activeView === 'explanations' && activeTab === 'byline'}
-            testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
-          />
+          {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77).
+              Mount on the byline tab; fade with the scroll-arrow auto-hide (VERA-39). */}
+          {activeView === 'explanations' && activeTab === 'byline' && (
+            <VerseJumpButton
+              verses={byLineVerses}
+              onSelect={handleByLineVerseJump}
+              visible={fabVisible}
+              onInteraction={onFABInteraction}
+              testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
+            />
+          )}
           <TabContent
             chapter={displayChapter}
             activeTab="detailed"

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -10,17 +10,30 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
-import { fontSizes, fontWeights, type getColors, spacing, type ThemeMode } from '@/theme/tokens';
+import {
+  animationDurations,
+  fontSizes,
+  fontWeights,
+  type getColors,
+  spacing,
+  type ThemeMode,
+} from '@/theme/tokens';
 
 export interface VerseJumpButtonProps {
   /** Ordered list of verse numbers available in the By Line view */
   verses: number[];
   /** Called with the chosen verse number after the modal closes */
   onSelect: (verseNumber: number) => void;
-  /** Hide the button entirely (e.g. when the tab is not active) */
+  /**
+   * Drives the fade-in/out animation. Mirrors the scroll-arrow auto-hide so
+   * the pill disappears on idle and reappears on scroll/tap (VERA-39). The
+   * pill stays mounted at opacity 0 — tapping the faded pill still opens the
+   * verse picker, matching the no-dead-zone arrow behavior.
+   */
   visible?: boolean;
   /**
    * Distance from the parent's bottom edge in dp. Defaults to mobile portrait
@@ -29,6 +42,11 @@ export interface VerseJumpButtonProps {
    * the host passes a tighter value (typically `spacing.lg`).
    */
   bottomOffset?: number;
+  /**
+   * Called when the user taps the pill. Lets the host reset its auto-hide
+   * timer so the verse-jump pill and scroll arrows re-show together.
+   */
+  onInteraction?: () => void;
   /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
   testID?: string;
 }
@@ -46,16 +64,28 @@ export function VerseJumpButton({
   onSelect,
   visible = true,
   bottomOffset,
+  onInteraction,
   testID = 'verse-jump-button',
 }: VerseJumpButtonProps) {
   const { mode, colors } = useTheme();
   const [open, setOpen] = useState(false);
   const styles = createStyles(mode, colors, bottomOffset);
 
-  if (!visible || verses.length === 0) return null;
+  // Mirror FloatingActionButtons fade — pill stays mounted at opacity 0 so
+  // tapping the faded pill area still opens the picker (VERA-39).
+  const opacity = useSharedValue(visible ? 1 : 0);
+  useEffect(() => {
+    opacity.value = withTiming(visible ? 1 : 0, {
+      duration: animationDurations.normal,
+    });
+  }, [visible, opacity]);
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+
+  if (verses.length === 0) return null;
 
   const handleOpen = () => {
     triggerHaptic();
+    onInteraction?.();
     setOpen(true);
   };
 
@@ -71,19 +101,21 @@ export function VerseJumpButton({
 
   return (
     <>
-      <Pressable
-        onPress={handleOpen}
-        style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
-        accessibilityLabel="Jump to verse"
-        accessibilityRole="button"
-        accessibilityHint="Open the list of verses to jump to one in the By Line view"
-        testID={testID}
-      >
-        <Ionicons name="list" size={22} color="#ffffff" />
-        <Text style={styles.fabLabel} accessibilityElementsHidden>
-          Verse
-        </Text>
-      </Pressable>
+      <Animated.View style={[styles.fabContainer, animatedStyle]}>
+        <Pressable
+          onPress={handleOpen}
+          style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+          accessibilityLabel="Jump to verse"
+          accessibilityRole="button"
+          accessibilityHint="Open the list of verses to jump to one in the By Line view"
+          testID={testID}
+        >
+          <Ionicons name="list" size={22} color="#ffffff" />
+          <Text style={styles.fabLabel} accessibilityElementsHidden>
+            Verse
+          </Text>
+        </Pressable>
+      </Animated.View>
       <Modal
         visible={open}
         animationType="fade"
@@ -134,13 +166,20 @@ const createStyles = (
   bottomOffset?: number
 ) =>
   StyleSheet.create({
-    fab: {
+    // Animated wrapper drives fade-in/out (VERA-39). The Pressable inside
+    // retains its hit-target even at opacity 0, so taps on the faded pill
+    // still open the verse picker — mirrors FloatingActionButtons.
+    fabContainer: {
       position: 'absolute',
       right: spacing.lg,
       // Stack the pill ABOVE the chapter-nav FAB row by default (phone portrait
       // path through ChapterPage). Hosts without a chapter-nav row beneath the
       // ScrollView (split-view / desktop right panel) override via bottomOffset.
       bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+    },
+    fab: {
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -22,6 +22,13 @@ export interface VerseJumpButtonProps {
   onSelect: (verseNumber: number) => void;
   /** Hide the button entirely (e.g. when the tab is not active) */
   visible?: boolean;
+  /**
+   * Distance from the parent's bottom edge in dp. Defaults to mobile portrait
+   * stacking (above the chapter-nav FAB row + progress bar). Split-view /
+   * desktop panels have no chapter-nav row below the byline ScrollView, so
+   * the host passes a tighter value (typically `spacing.lg`).
+   */
+  bottomOffset?: number;
   /** Test id prefix; sub-elements append a suffix (verse cells, backdrop, modal) */
   testID?: string;
 }
@@ -38,11 +45,12 @@ export function VerseJumpButton({
   verses,
   onSelect,
   visible = true,
+  bottomOffset,
   testID = 'verse-jump-button',
 }: VerseJumpButtonProps) {
   const { mode, colors } = useTheme();
   const [open, setOpen] = useState(false);
-  const styles = createStyles(mode, colors);
+  const styles = createStyles(mode, colors, bottomOffset);
 
   if (!visible || verses.length === 0) return null;
 
@@ -120,16 +128,19 @@ export function VerseJumpButton({
 const FAB_SIZE = 52;
 const CELL_SIZE = 48;
 
-const createStyles = (mode: ThemeMode, colors: ReturnType<typeof getColors>) =>
+const createStyles = (
+  mode: ThemeMode,
+  colors: ReturnType<typeof getColors>,
+  bottomOffset?: number
+) =>
   StyleSheet.create({
     fab: {
       position: 'absolute',
       right: spacing.lg,
-      // Stack the pill ABOVE the chapter-nav FAB row instead of co-locating
-      // (chapter-nav row: bottom 60 + size 56 = top edge 116 from screen bottom).
-      // 60 (chapter-nav bottomOffset) + 56 (chapter-nav FAB size) + spacing.md
-      // gap, then spacing.lg breathing room above the progress bar.
-      bottom: spacing.lg + 60 + 56 + spacing.md,
+      // Stack the pill ABOVE the chapter-nav FAB row by default (phone portrait
+      // path through ChapterPage). Hosts without a chapter-nav row beneath the
+      // ScrollView (split-view / desktop right panel) override via bottomOffset.
+      bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
       width: FAB_SIZE,
       height: FAB_SIZE,
       borderRadius: FAB_SIZE / 2,


### PR DESCRIPTION
Stacks on top of PR #299 (verse-jump pill) and matches the scroll-arrow auto-hide so the pill disappears on idle and reappears on scroll/tap. Andy's board feedback: *"Prob best if the circle disappears like the arrows"*.

Tracks [VERA-39](https://verse-mate.paperclip.app/VERA/issues/VERA-39). Desktop sibling [VERA-36](https://verse-mate.paperclip.app/VERA/issues/VERA-36) inherits the same behavior through `BibleExplanationsPanel`.

## Approach

- `VerseJumpButton`: `visible` now drives a Reanimated opacity fade instead of unmounting. The pill stays in the tree so the tap target survives during fade-out — no dead-zone vs. the previous always-visible pill. New `onInteraction` prop fires on press so the host can reset its auto-hide timer alongside the scroll arrows.
- `ChapterPage` (phone portrait) and `BibleExplanationsPanel` (split-view / desktop) forward the existing `fabVisible` state + `showButtons` callback from `useFABVisibility` to the pill. Mount-guard moves to the parent so empty-tab states fully unmount.
- `ChapterScreen` wires `fabVisible` + `showButtons` through `renderChapterPage` and the split-view right panel.

## Test plan

- [x] `npm test -- __tests__/components/bible/VerseJumpButton.test.tsx` — covers fade-out without unmount + tap-while-faded reveal
- [x] `npm test -- __tests__/components/bible` (251 tests pass)
- [x] `bun run type-check`
- [ ] Live verify on device: Genesis 1, Psalm 119, Matthew 5 — pill fades after 3s idle, reappears on scroll/tap, no regression on tap-to-jump

## Notes

This branch includes one prior unmerged commit (`edb899a` — wire VerseJumpButton into the split-view panel for VERA-36) since the auto-hide change extends that wiring. If PR #299 is re-scoped to include the split-view wiring, this PR will rebase cleanly to just the auto-hide commit.