### PR TITLE
docs(eas): document v0 EAS / dev-build flow (VER-20)

### DIFF
--- a/docs/EAS_DEV_BUILD.md
+++ b/docs/EAS_DEV_BUILD.md
@@ -1,92 +1,87 @@
-# EAS / dev-build flow (v0)
+# EAS / dev-build flow — v0 notes
 
-Operational reference for how VerseMate Mobile is built and iterated on for v0.
-Decision background: [VER-17](https://github.com/verse-mate/verse-mate-meta) /
-VER-20 — use EAS Build free tier + Expo Go, no local iOS sim / Android emulator
-provisioning.
+Thin pointer doc that records the v0 mobile dev-build decision from VER-17 /
+VER-20 and indexes the existing automation. **Canonical deployment doc is
+[`.deployment/README.md`](../.deployment/README.md)** — read that first for
+build profiles, scripts, credentials, App Store submission, and
+troubleshooting. This file only adds what the canonical doc doesn't already
+cover: the v0 decision context and how the engineering agent fits in.
 
-## Account
+## v0 decision (from VER-17 triage)
 
-- Expo organization (`owner` in `app.config.js`): **versemate**
-- EAS project id (`extra.eas.projectId`): `3178e762-1329-4504-9541-0f6a489a760b`
-- Tier: **free**. Paid tier is not requested. Re-open the cost question only if
-  free-tier concurrency / build minutes become a real bottleneck.
+- **Stack**: EAS Build (free tier) + Expo Go.
+- **Out of scope**: local iOS Simulator / Android Emulator provisioning in
+  the agent sandbox, paid EAS tier.
+- **Iteration loop**:
+  - JS-only changes → `bun start` + Expo Go on a real device.
+  - Native module changes → custom dev client via
+    `eas build --profile development` (profile already defined in `eas.json`).
+- **Account**: `owner: versemate` in `app.config.js`, EAS projectId
+  `3178e762-1329-4504-9541-0f6a489a760b`.
+- Re-open the paid-tier question only if free-tier concurrency / build
+  minutes actually bottleneck us.
 
-## Day-to-day iteration: Expo Go
+## Existing gitflow automations (already in place)
 
-For JS-only changes (most product work), use Expo Go on a real device — no
-build needed.
+These are wired up today — the agent does not need to recreate any of this:
 
-```bash
-bun start            # start the Metro dev server
-# scan the QR code with Expo Go on iOS/Android
-```
+- **`expo-preview-build.yml`** — triggered by `workflow_dispatch` *or* by a
+  push whose commit-title contains `[preview:ios]`, `[preview:android]`, or
+  `[preview:all]`. Runs typecheck + lint + tests, runs
+  `.deployment/build-preview.sh`, then auto-submits via
+  `.deployment/submit-testflight.sh` (iOS) and
+  `.deployment/submit-play-store.sh` (Android). Optional `version_bump`
+  input drives `scripts/bump-version.js`.
+- **`expo-production-build.yml`** — `workflow_dispatch` only, takes a
+  `version_tag` input, runs `.deployment/build-production.sh`. No
+  auto-submission to stores — submission stays manual per
+  `.deployment/PRODUCTION_SUBMISSION.md`.
+- **`maestro-e2e.yml`** — downloads the latest `e2e-test` APK from EAS,
+  pushes a JS-only OTA update via `eas update --branch e2e-test`, then runs
+  Maestro on Android emulators (Pixel 6 + Nexus 10, API 34). `force-rebuild`
+  input only when native code changes.
+- **`ci.yml` / `test.yml`** — typecheck, lint, Jest, Chromatic on PRs.
+- **`deploy-web.yml`** — Expo web bundle deploy (out of scope here, see
+  VER-19 / VER-18 history).
 
-When to stay in Expo Go:
+CI auth: `EXPO_TOKEN` is already configured as a GitHub Actions secret. All
+EAS workflows above run non-interactively against the `versemate` account
+through that secret.
 
-- UI / screen / hook / route changes
-- API integration changes (no new native SDKs)
-- Theme / locale / copy
+## How the engineering agent uses this
 
-## Native module changes: custom dev client via EAS
+For day-to-day Paperclip work, the agent does **not** need a local
+`EXPO_TOKEN`:
 
-When you add or upgrade a native module (anything that touches `ios/` /
-`android/` projects, new `expo-*` modules with native code, new permissions,
-etc.) Expo Go can't load it. Build a custom dev client on EAS:
+- JS/native code changes ship as normal PRs and go through the existing
+  `ci.yml` / `test.yml` checks.
+- A preview build to TestFlight / Play Store is triggered by adding
+  `[preview:ios|android|all]` to a commit-title on the working branch (or
+  by `gh workflow run "Expo Preview Build"`), no agent-side credentials
+  needed.
+- Maestro E2E runs via `gh workflow run "Maestro E2E Tests"`; the workflow
+  pulls the existing `e2e-test` APK and OTA-updates it, again using the
+  CI `EXPO_TOKEN`.
 
-```bash
-# install latest eas-cli on demand (no devDependency required)
-npx --yes eas-cli@latest build --profile development --platform ios
-npx --yes eas-cli@latest build --profile development --platform android
-```
+The only times an agent-local `EXPO_TOKEN` would help are ad-hoc commands
+like `eas build:list`, `eas update`, or `eas credentials` from inside the
+sandbox. None of those are blocking v0.
 
-The `development` profile is already defined in `eas.json` with
-`developmentClient: true` and `distribution: internal`. After the build
-finishes, install the resulting `.ipa` / `.apk` on a real device (or
-TestFlight internal group) and keep using `bun start` for JS reloads against
-that dev client.
+### Sandbox EAS auth status (2026-05-15)
 
-Other useful profiles already wired in `eas.json`:
+`npx --yes eas-cli@latest whoami` from the agent sandbox returns
+`Not logged in`. Documenting this as the decision per VER-20's acceptance
+criteria — provisioning an `EXPO_TOKEN` into the agent sandbox is tracked
+as low-priority follow-up [VER-23](https://github.com/verse-mate/verse-mate-meta)
+and is **not blocking** because CI already holds the token. Re-prioritize
+VER-23 if/when an agent run needs ad-hoc `eas` invocations the gitflow
+doesn't cover.
 
-- `e2e-test` — APK + iOS build for Maestro E2E.
-- `preview` — store-distribution preview channel (autoIncrement).
-- `production` — store-distribution production channel.
-
-## Authentication
-
-`eas-cli` needs to be authenticated to the `versemate` account.
-
-Interactive (human laptop): `npx eas-cli login`. Browser flow.
-
-Non-interactive (engineering agent sandbox, CI): set `EXPO_TOKEN` to a
-personal access token generated at https://expo.dev/settings/access-tokens
-under the versemate account. With that env var present, `eas` commands run
-without an interactive login.
-
-Verify with:
-
-```bash
-EXPO_TOKEN=... npx --yes eas-cli@latest whoami
-# expected: versemate
-```
-
-### Current sandbox status (2026-05-15)
-
-`npx eas-cli whoami` from the engineering agent sandbox currently returns
-`Not logged in`. EAS credentials have not been provisioned into the agent
-environment yet. Provisioning an `EXPO_TOKEN` for the agent is a CEO action
-(same pattern as the `verse-mate-agent` GitHub PAT). Until that token is
-present, mobile-side EAS builds must be triggered from a developer laptop
-that has run `eas login`.
-
-This is **not blocking v0 product work**: Expo Go covers JS iteration, and
-the existing native binaries on the App Store / Play Store cover any
-"need a real native build" scenario for the moment.
-
-## Anti-checklist (what we are *not* doing for v0)
+## Anti-checklist (what we are *not* changing for v0)
 
 - No local iOS Simulator / Android Emulator setup in the agent sandbox.
 - No paid EAS subscription.
-- No EAS Submit automation in CI yet — store submissions stay manual.
-- No EAS Update channel rollout policy beyond the channels already declared
-  in `eas.json`.
+- No new build profiles — `development`, `e2e-test`, `preview`, `production`
+  already cover the spectrum.
+- No new CI workflows — existing ones cover preview, production, E2E,
+  unit/integration, and web deploy.

--- a/docs/EAS_DEV_BUILD.md
+++ b/docs/EAS_DEV_BUILD.md
@@ -1,0 +1,92 @@
+# EAS / dev-build flow (v0)
+
+Operational reference for how VerseMate Mobile is built and iterated on for v0.
+Decision background: [VER-17](https://github.com/verse-mate/verse-mate-meta) /
+VER-20 — use EAS Build free tier + Expo Go, no local iOS sim / Android emulator
+provisioning.
+
+## Account
+
+- Expo organization (`owner` in `app.config.js`): **versemate**
+- EAS project id (`extra.eas.projectId`): `3178e762-1329-4504-9541-0f6a489a760b`
+- Tier: **free**. Paid tier is not requested. Re-open the cost question only if
+  free-tier concurrency / build minutes become a real bottleneck.
+
+## Day-to-day iteration: Expo Go
+
+For JS-only changes (most product work), use Expo Go on a real device — no
+build needed.
+
+```bash
+bun start            # start the Metro dev server
+# scan the QR code with Expo Go on iOS/Android
+```
+
+When to stay in Expo Go:
+
+- UI / screen / hook / route changes
+- API integration changes (no new native SDKs)
+- Theme / locale / copy
+
+## Native module changes: custom dev client via EAS
+
+When you add or upgrade a native module (anything that touches `ios/` /
+`android/` projects, new `expo-*` modules with native code, new permissions,
+etc.) Expo Go can't load it. Build a custom dev client on EAS:
+
+```bash
+# install latest eas-cli on demand (no devDependency required)
+npx --yes eas-cli@latest build --profile development --platform ios
+npx --yes eas-cli@latest build --profile development --platform android
+```
+
+The `development` profile is already defined in `eas.json` with
+`developmentClient: true` and `distribution: internal`. After the build
+finishes, install the resulting `.ipa` / `.apk` on a real device (or
+TestFlight internal group) and keep using `bun start` for JS reloads against
+that dev client.
+
+Other useful profiles already wired in `eas.json`:
+
+- `e2e-test` — APK + iOS build for Maestro E2E.
+- `preview` — store-distribution preview channel (autoIncrement).
+- `production` — store-distribution production channel.
+
+## Authentication
+
+`eas-cli` needs to be authenticated to the `versemate` account.
+
+Interactive (human laptop): `npx eas-cli login`. Browser flow.
+
+Non-interactive (engineering agent sandbox, CI): set `EXPO_TOKEN` to a
+personal access token generated at https://expo.dev/settings/access-tokens
+under the versemate account. With that env var present, `eas` commands run
+without an interactive login.
+
+Verify with:
+
+```bash
+EXPO_TOKEN=... npx --yes eas-cli@latest whoami
+# expected: versemate
+```
+
+### Current sandbox status (2026-05-15)
+
+`npx eas-cli whoami` from the engineering agent sandbox currently returns
+`Not logged in`. EAS credentials have not been provisioned into the agent
+environment yet. Provisioning an `EXPO_TOKEN` for the agent is a CEO action
+(same pattern as the `verse-mate-agent` GitHub PAT). Until that token is
+present, mobile-side EAS builds must be triggered from a developer laptop
+that has run `eas login`.
+
+This is **not blocking v0 product work**: Expo Go covers JS iteration, and
+the existing native binaries on the App Store / Play Store cover any
+"need a real native build" scenario for the moment.
+
+## Anti-checklist (what we are *not* doing for v0)
+
+- No local iOS Simulator / Android Emulator setup in the agent sandbox.
+- No paid EAS subscription.
+- No EAS Submit automation in CI yet — store submissions stay manual.
+- No EAS Update channel rollout policy beyond the channels already declared
+  in `eas.json`.


### PR DESCRIPTION
## Summary
- Adds `docs/EAS_DEV_BUILD.md` — a **thin v0 pointer** to the existing canonical [`.deployment/README.md`](../.deployment/README.md) and gitflow automations.
- Captures only what isn't already documented: v0-decision context from VER-17 triage, an index of the existing CI workflows and their triggers, and how the engineering agent fits in (it doesn't need a local `EXPO_TOKEN` — CI already holds it).

## Why the rewrite
First pass duplicated material that already lives in `.deployment/README.md`. CEO flagged that the repo's gitflow has many existing mobile-deployment automations. This revision indexes them rather than re-explaining them, and corrects two earlier inaccuracies:
- CI **does** auto-submit preview builds to TestFlight + Play Store via `.deployment/submit-testflight.sh` / `.deployment/submit-play-store.sh`.
- An EAS Update channel is **already in active use** — `maestro-e2e.yml` pushes JS-only OTA updates to the `e2e-test` branch.

## Test plan
- [ ] Reviewer reads the rewritten doc and confirms it accurately points at the existing automations.
- [ ] Reviewer confirms the agent-needs-no-local-EXPO_TOKEN framing matches reality (it relies on CI's `EXPO_TOKEN` secret, not on the agent sandbox holding credentials).