### PR TITLE
fix(dictionary/ios): anchor UIReferenceLibraryViewController as popover on iPad (VER-48)

### DIFF
--- a/modules/dictionary/ios/DictionaryModule.swift
+++ b/modules/dictionary/ios/DictionaryModule.swift
@@ -35,6 +35,22 @@ public class DictionaryModule: Module {
           topController = presentedVC
         }
 
+        // iPad requires a popover anchor for UIReferenceLibraryViewController.
+        // Without one, the sheet renders unsized/misformatted (VER-48). The JS
+        // bridge does not pass source coordinates, so anchor to the top view's
+        // center with no arrow direction.
+        if UIDevice.current.userInterfaceIdiom == .pad {
+          referenceVC.modalPresentationStyle = .popover
+          if let popover = referenceVC.popoverPresentationController {
+            let anchorView = topController.view ?? rootViewController.view
+            popover.sourceView = anchorView
+            if let bounds = anchorView?.bounds {
+              popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            }
+            popover.permittedArrowDirections = []
+          }
+        }
+
         topController.present(referenceVC, animated: true)
         return true
       }


### PR DESCRIPTION
## Summary

- Fixes iPad formatting issue with the iOS native dictionary lookup popover ([VER-48](/VER/issues/VER-48)).
- `UIReferenceLibraryViewController` on iPad requires popover presentation with a source anchor; presenting it bare worked on iPhone but rendered unsized/misformatted on iPad (Andy Tryba, Slack #bugs-mobile, multiple screenshots).
- The JS bridge does not pass source coordinates, so iPad fallback anchors to the top view controller's center with no arrow direction. iPhone behavior is unchanged.

## Change

In `modules/dictionary/ios/DictionaryModule.swift`, when `UIDevice.current.userInterfaceIdiom == .pad`:
- Set `modalPresentationStyle = .popover`
- Set `popoverPresentationController.sourceView` to the top controller's view
- Anchor `sourceRect` at the view's center with zero size
- Set `permittedArrowDirections = []` (no arrow when centered)

## Test plan

- [ ] Build and launch on iPad simulator (e.g. iPad Pro 11").
- [ ] Long-press a word in a verse to trigger native dictionary lookup.
- [ ] Confirm the dictionary card renders cleanly as a centered popover (not the unsized/misformatted sheet from the Slack screenshots).
- [ ] Spot-check on iPhone simulator that lookup behavior is unchanged.
- [ ] (Optional) Verify on a physical iPad if available.

> Swift-only change in an iOS-only Expo native module. No JS signature/behavior change. JS tests mock the native module so they don't exercise this code path; runtime verification must be done in iOS simulator/device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)