### PR TITLE
fix(dictionary): expand KJV ligatures in normalizeWord (VER-43)

### DIFF
--- a/__tests__/services/word-mapping-service.test.ts
+++ b/__tests__/services/word-mapping-service.test.ts
@@ -1,0 +1,30 @@
+import { normalizeWord } from '@/services/word-mapping-service';
+
+describe('normalizeWord', () => {
+  it('lowercases and strips punctuation', () => {
+    expect(normalizeWord('Jesus,')).toBe('jesus');
+    expect(normalizeWord("Christ's")).toBe('christs');
+  });
+
+  // VER-43: KJV typography uses æ/Æ/œ/Œ ligatures (e.g., "Zacchæus"), which Unicode
+  // does not treat as compatibility decompositions. Without explicit mapping, dictionary
+  // keys like "zacchaeus" never matched and the lookup returned "no definition found".
+  it('expands KJV ligatures so dictionary keys match (VER-43)', () => {
+    expect(normalizeWord('Zacchæus')).toBe('zacchaeus');
+    expect(normalizeWord('Cæsar')).toBe('caesar');
+    expect(normalizeWord('Phœnicia')).toBe('phoenicia');
+    expect(normalizeWord('Æneas')).toBe('aeneas');
+    expect(normalizeWord('Judæa')).toBe('judaea');
+    expect(normalizeWord('Galilæan')).toBe('galilaean');
+  });
+
+  it('strips combining diacritics', () => {
+    expect(normalizeWord('résumé')).toBe('resume');
+    expect(normalizeWord('naïve')).toBe('naive');
+  });
+
+  it('leaves plain ASCII words unchanged apart from case', () => {
+    expect(normalizeWord('LOVE')).toBe('love');
+    expect(normalizeWord('Heaven')).toBe('heaven');
+  });
+});

--- a/services/word-mapping-service.ts
+++ b/services/word-mapping-service.ts
@@ -111,11 +111,26 @@ const wordToStrongs: Record<string, string> = {
   ...greekWordMappings,
 };
 
+// Latin ligatures used in KJV typography (e.g., "Zacchæus", "Cæsar", "Phœnicia").
+// Unicode treats these as independent letters, so NFKD does not decompose them — we map explicitly.
+const LIGATURE_MAP: Record<string, string> = {
+  æ: 'ae',
+  Æ: 'AE',
+  œ: 'oe',
+  Œ: 'OE',
+};
+
 /**
- * Normalizes a word for lookup by converting to lowercase and removing punctuation
+ * Normalizes a word for lookup by expanding KJV ligatures, stripping diacritics,
+ * lowercasing, and removing punctuation.
  */
 export function normalizeWord(word: string): string {
-  return word.toLowerCase().replace(/[.,;:!?'"()]/g, '');
+  return word
+    .replace(/[æÆœŒ]/g, (c) => LIGATURE_MAP[c])
+    .normalize('NFKD')
+    .replace(/\p{M}/gu, '')
+    .toLowerCase()
+    .replace(/[.,;:!?'"()]/g, '');
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Bug:** Looking up words with KJV Latin ligatures (æ, œ) always returned "no definition found"
- **Root cause:** `normalizeWord()` did not expand ligatures, so `"zacchæus"` never matched Easton key `"zacchaeus"` (Levenshtein distance exceeded fuzzy threshold)
- **Fix:** Explicit `LIGATURE_MAP` in `word-mapping-service.ts` expands æ→ae, Æ→AE, œ→oe, Œ→OE before the NFKD + diacritic-strip pass

**Correction to QA's proposal:** `.normalize('NFKD')` does NOT decompose æ/œ — Unicode treats them as independent Latin letters, not compatibility forms. The explicit map is required.

**Verified working:**
| Input | Output | Easton hit |
|---|---|---|
| Zacchæus | zacchaeus | EXACT |
| Cæsar | caesar | EXACT |
| Phœnicia | phoenicia | EXACT |
| Judæa | judaea | fuzzy (→ judea, dist=1) |
| Galilæan | galilaean | fuzzy (→ galilean, dist=1) |

## Files changed

- `services/word-mapping-service.ts` — fix in `normalizeWord()`
- `__tests__/services/word-mapping-service.test.ts` — new unit tests covering ligature cases

## Test plan

- [ ] New unit tests in `word-mapping-service.test.ts` pass (blocked by pre-existing MSW/ESM infra issue in test runner — tracked separately)
- [ ] Type-check passes
- [ ] Live test: tap "Zacchæus" in Luke 19:2 on KJV build, confirm definition appears

## Related

Fixes [VER-43](/VER/issues/VER-43). Follow-up content gap (short names < 4 chars: Ham, Lot, Ur) to be filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)