### PR TITLE
fix(insights): center landscape tabs + strip duplicate topic title (VER-73)

### DIFF
--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -596,7 +596,7 @@ function createStyles(
       gap: 4,
       position: 'relative',
       minHeight: 36,
-      alignSelf: 'flex-start',
+      alignSelf: 'center',
     },
     slidingIndicator: {
       position: 'absolute',
@@ -646,25 +646,6 @@ function createStyles(
       fontSize: fontSizes.body,
       color: colors.textSecondary,
       textAlign: 'center',
-    },
-    contentTitleRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'space-between',
-      marginBottom: spacing.lg,
-    },
-    contentTitle: {
-      flex: 1,
-      fontSize: fontSizes.heading1,
-      fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
-      color: colors.textPrimary,
-      marginRight: spacing.md,
-    },
-    contentActions: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: spacing.xs,
     },
   });
 

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -60,6 +60,17 @@ function cleanupBylineReferences(content: string): string {
 }
 
 /**
+ * Strip the leading H1–H6 heading line from AI-generated markdown.
+ *
+ * The header bar already renders "{topicName} Insights"; AI bodies usually
+ * begin with a duplicate `# {topicName}` heading. Mirrors the strip pattern
+ * in `ChapterReader` (VER-73 / GH-186).
+ */
+function stripLeadingHeading(content: string): string {
+  return content.replace(/^#{1,6}\s+.+?(?:\r?\n|$)/, '');
+}
+
+/**
  * Tab option for the header
  */
 interface TabOption {
@@ -168,11 +179,16 @@ export function TopicExplanationsPanel({
   };
 
   const rawExplanationContent = getExplanationContent();
-  // Clean up byline content to remove redundant verse references
-  const explanationContent =
+  // Clean up byline content to remove redundant verse references, then strip
+  // the duplicate leading `# {topicName}` heading the header bar already shows.
+  const cleanedExplanationContent =
     activeTab === 'byline' && rawExplanationContent
       ? cleanupBylineReferences(rawExplanationContent)
       : rawExplanationContent;
+  const explanationContent =
+    typeof cleanedExplanationContent === 'string'
+      ? stripLeadingHeading(cleanedExplanationContent)
+      : cleanedExplanationContent;
   const hasContent = explanationContent && typeof explanationContent === 'string';
 
   // Custom share handler for topics
@@ -372,7 +388,7 @@ function createStyles(
       gap: 4,
       position: 'relative',
       minHeight: 36,
-      alignSelf: 'flex-start',
+      alignSelf: 'center',
     },
     slidingIndicator: {
       position: 'absolute',


### PR DESCRIPTION
## Summary

- `BibleExplanationsPanel` + `TopicExplanationsPanel`: `tabsRow.alignSelf` changes from `flex-start` → `center` so the Summary / By Line / Detailed pill sits in the middle of the wide right panel in landscape split view.
- `TopicExplanationsPanel`: strip the leading H1–H6 heading from AI-generated explanation markdown so the header bar's `"{topicName} Insights"` is no longer doubled by a `# {topicName}` heading in the body. Mirrors the existing strip pattern in `ChapterReader.tsx:702-711` (introduced in GH-186 / `bc3d784`).
- `BibleExplanationsPanel`: drop the dead `contentTitleRow` / `contentTitle` / `contentActions` style entries that `bc3d784` left behind unused.

Closes VER-73. Source: QA confirmation on VER-59 (Andy Tryba, Slack #bugs-mobile).

## Why

The original GH-186 / `bc3d784` fix only patched the Bible side of the duplicate-title bug. The Topic side and the tab-row alignment were never patched — the latter regressed when the landscape-mode commit (`9d8be71`, Feature/landscape mode #43) introduced `alignSelf: 'flex-start'` on the tab pill.

The `tabContainer` parent already has horizontal padding, so flipping `alignSelf` to `center` is the only change needed. The heading-strip helper is a pure function that mirrors the working pattern in `ChapterReader`.

## Test plan

- [ ] iOS simulator, landscape: open a Bible chapter → Summary / By Line / Detailed pill is horizontally centered in the right panel.
- [ ] iOS simulator, landscape: open a Topic → tab pill is centered AND the right panel shows the header `"{topicName} Insights"` only once (no duplicate `# {topicName}` heading above the markdown body).
- [ ] Android simulator: same two checks.
- [ ] Phone portrait: confirm Bible + Topic explanations panels still render correctly (no centering regression on narrow widths).
- [ ] Follow-up (separate ticket): add a Maestro regression case for landscape Insights tab alignment so this doesn't re-emerge a third time.

## Out of scope

- `TopicContentPanel` (left panel) has a related double-render of `{topicName}` between its header and `TopicText.tsx:126`. The issue flagged this as engineering judgement once Andy's screenshot is reviewed — leaving for a follow-up if QA confirms it's the same visual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)