### PR TITLE
fix(bible): safe-area insets in portrait and landscape (VER-70)

### DIFF
--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -22,6 +22,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { findNodeHandle, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AudioInlineEntry } from '@/components/bible/AudioInlineEntry';
 import { DeleteConfirmationModal } from '@/components/bible/DeleteConfirmationModal';
 import { NoteEditModal } from '@/components/bible/NoteEditModal';
@@ -52,7 +53,7 @@ import { SkeletonLoader } from './SkeletonLoader';
 import { VerseJumpButton } from './VerseJumpButton';
 
 // Styles for the overall ChapterPage component
-const createStyles = (colors: ReturnType<typeof getColors>) =>
+const createStyles = (colors: ReturnType<typeof getColors>, bottomInset: number) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -62,8 +63,10 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
       flexGrow: 1,
       paddingHorizontal: spacing.lg,
       paddingVertical: spacing.xxl,
-      // Add bottom padding to account for floating action buttons AND progress bar
-      paddingBottom: 60, // FAB height + bottom offset + progress bar + extra spacing
+      // FAB height + bottom offset + progress bar + extra spacing, plus the
+      // device's bottom safe-area inset so the last verse clears the home
+      // indicator on notched iPhones (VER-70).
+      paddingBottom: 60 + bottomInset,
     },
     readerContainer: {
       flex: 1,
@@ -128,7 +131,8 @@ function TabContent({
   onByLineSectionRegister?: (verseNumber: number, node: View | null) => void;
 }) {
   const { colors } = useTheme();
-  const styles = createStyles(colors); // Use local createStyles for TabContent
+  const insets = useSafeAreaInsets();
+  const styles = createStyles(colors, insets.bottom); // Use local createStyles for TabContent
 
   const isHidden = !visible;
   if (isHidden && !shouldRenderHidden) return null;
@@ -309,7 +313,8 @@ export function ChapterPage({
   onFABInteraction,
 }: ChapterPageProps) {
   const { colors } = useTheme();
-  const styles = createStyles(colors); // Use local createStyles for ChapterPage
+  const insets = useSafeAreaInsets();
+  const styles = createStyles(colors, insets.bottom); // Use local createStyles for ChapterPage
 
   // Use Reanimated ref for the animated ScrollView
   const animatedScrollRef = useAnimatedRef<Animated.ScrollView>();

--- a/components/ui/SplitView.tsx
+++ b/components/ui/SplitView.tsx
@@ -134,20 +134,33 @@ export function SplitView({
   const handleLayout = useCallback(
     (event: LayoutChangeEvent) => {
       const { width, x } = event.nativeEvent.layout;
-      containerWidth.value = width;
-      containerX.value = x;
+      // onLayout reports the container's outer width, but the container has
+      // paddingLeft/paddingRight equal to the horizontal safe-area insets
+      // (notch on landscape). Panels must size against the inner width so the
+      // right panel doesn't overflow into the notch region. (VER-70)
+      const innerWidth = Math.max(0, width - insets.left - insets.right);
+      containerWidth.value = innerWidth;
+      containerX.value = x + insets.left;
 
       // Initialize split position if needed
-      if (!isLayoutReady || Math.abs(containerWidth.value - width) > 1) {
-        const { leftWidth } = calculatePanelWidths(width, splitRatio);
+      if (!isLayoutReady || Math.abs(containerWidth.value - innerWidth) > 1) {
+        const { leftWidth } = calculatePanelWidths(innerWidth, splitRatio);
         committedSplitPosition.value = leftWidth;
       }
 
-      if (!isLayoutReady && width > 0) {
+      if (!isLayoutReady && innerWidth > 0) {
         setIsLayoutReady(true);
       }
     },
-    [splitRatio, committedSplitPosition, containerWidth, containerX, isLayoutReady]
+    [
+      splitRatio,
+      committedSplitPosition,
+      containerWidth,
+      containerX,
+      isLayoutReady,
+      insets.left,
+      insets.right,
+    ]
   );
 
   // --- Sync Props to Internal State ---


### PR DESCRIPTION
## Summary

Two QA-confirmed safe-area bugs from [VER-54](/VER/issues/VER-54) (parent issue: [VER-70](/VER/issues/VER-70)).

### Bug 1 — Portrait: last verse hidden by FAB/progress bar
`components/bible/ChapterPage.tsx` used `paddingBottom: 60`, which doesn't account for the ~34pt bottom safe-area inset (home indicator) on notched iPhones. The last line of the last verse was hidden behind the FAB/progress bar overlay.

**Fix:** threaded `useSafeAreaInsets().bottom` through `createStyles` and applied `paddingBottom: 60 + bottomInset`. Both call sites (`ChapterPage` itself and the inner `TabContent` ScrollViews) get the inset.

### Bug 2 — Landscape: right panel clipped by notch
`components/ui/SplitView.tsx` `handleLayout` passed the container's full outer width to `calculatePanelWidths`. But the container has `paddingLeft: insets.left` + `paddingRight: insets.right`, so the right panel overflowed into the notch region.

**Fix:** compute `innerWidth = width - insets.left - insets.right` and use that everywhere the previous code used `width`. Shifted `containerX.value` by `insets.left` so absolute-X gesture math keeps targeting the inner content area.

## Test plan

- [x] `tsc --noEmit` — passes (0 errors)
- [x] `biome check` on both changed files — clean
- [ ] Manual repro on notched iPhone (portrait): scroll to end of any chapter — last verse line fully visible above FAB/progress bar
- [ ] Manual repro on notched iPhone (landscape): right panel content terminates inside the safe area, no clipping into the notch
- [ ] Existing Jest suites: `__tests__/components/bible/ChapterPage.test.tsx`, `__tests__/components/ui/SplitView.test.tsx`, `__tests__/components/ui/SplitView.web.test.tsx` are currently blocked by a pre-existing `msw/rettime` ESM transform error (same failure on `origin/main`); re-run once that infra issue is resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)