### PR TITLE
fix(bible): restore full-verse selection underline on verse tap (VER-78)

### DIFF
--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -286,15 +286,22 @@ export function HighlightedText({
   // We delay onPress by 300ms and cancel if a second tap (double-tap) or long-press occurs.
   const tapTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Verse-tap selection state: briefly highlights the whole verse while the
+  // debounce window is open so the user sees feedback before the insight
+  // tooltip opens (regressed by PR #260; restored per VER-78).
+  const [verseTapSelected, setVerseTapSelected] = useState(false);
+
   const debouncedPress = (callback: () => void) => {
     if (tapTimerRef.current) {
       // Second tap within 300ms = double-tap for native selection, cancel tooltip
       clearTimeout(tapTimerRef.current);
       tapTimerRef.current = null;
+      setVerseTapSelected(false);
       return;
     }
     tapTimerRef.current = setTimeout(() => {
       tapTimerRef.current = null;
+      setVerseTapSelected(false);
       callback();
     }, 300);
   };
@@ -305,6 +312,7 @@ export function HighlightedText({
       clearTimeout(tapTimerRef.current);
       tapTimerRef.current = null;
     }
+    setVerseTapSelected(false);
   };
 
   // Clean up pending tap timer on unmount
@@ -483,6 +491,9 @@ export function HighlightedText({
   const handleVerseTap = () => {
     if (!onVerseTap) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    // Mark the whole verse as selected for the duration of the debounce window
+    // so the user sees a clear tap target before the insight tooltip opens.
+    setVerseTapSelected(true);
     debouncedPress(() => {
       onVerseTap(verseNumber);
     });
@@ -757,7 +768,7 @@ export function HighlightedText({
           return (
             <Text
               key={`word-${segment.key}-${token.startChar}`}
-              style={isSelected ? selectionStyles.selected : undefined}
+              style={isSelected || verseTapSelected ? selectionStyles.selected : undefined}
               onPress={onPressHandler}
               onLongPress={(e) =>
                 handleTokenizedWordLongPress(token.word, absoluteStartChar, absoluteEndChar, e)
@@ -841,7 +852,11 @@ export function HighlightedText({
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
               suppressHighlighting={true}
             >
-              {segment.text}
+              {verseTapSelected ? (
+                <Text style={selectionStyles.selected}>{segment.text}</Text>
+              ) : (
+                segment.text
+              )}
             </Text>
           );
         }
@@ -876,7 +891,11 @@ export function HighlightedText({
               onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
               suppressHighlighting={true}
             >
-              {segment.text}
+              {verseTapSelected ? (
+                <Text style={selectionStyles.selected}>{segment.text}</Text>
+              ) : (
+                segment.text
+              )}
             </Text>
           );
         }
@@ -905,7 +924,11 @@ export function HighlightedText({
             onLongPress={(e) => detectWordFromLongPress(segment.text, segment.startChar, e)}
             suppressHighlighting={true}
           >
-            {segment.text}
+            {verseTapSelected ? (
+              <Text style={selectionStyles.selected}>{segment.text}</Text>
+            ) : (
+              segment.text
+            )}
           </Text>
         );
       })}


### PR DESCRIPTION
## Summary

Fixes [VER-78](https://paperclip.versemate.org/VER/issues/VER-78). Restores the brief full-verse highlight that users saw before the insight tooltip opens. Regressed by #260 (`fb42593`) when native text selection was enabled; #277 (`368ebce`) only addressed the per-word flash.

## What changed

`components/bible/HighlightedText.tsx`:

- New local state `verseTapSelected` set when a plain-text tap fires `handleVerseTap`, cleared when the 300ms debounce fires the tooltip, a double-tap cancels (native selection takes over), or a long-press preempts the tap.
- Tokenized render applies `selectionStyles.selected` (`#3390FF40`) to every token while the flag is set.
- The three non-tokenized return paths (user highlight, auto-highlight, plain text) wrap their text in a nested `<Text style={selectionStyles.selected}>` while the flag is set. In practice visible verses tokenize, so the tokenized branch is the user-facing path; non-tokenized branches updated for symmetry.

State lives entirely in `HighlightedText`; no `BibleInteractionContext` or `ChapterReader` plumbing required.

## Test plan

- [x] `npx tsc --noEmit` passes (clean).
- [x] `npx biome check components/bible/HighlightedText.tsx` — only the pre-existing `useExhaustiveDependencies` warning on the unmount `useEffect` remains; also present on `main`.
- [x] Pre-commit hook (lint-staged + tsc) passes.
- [ ] Jest tests on this file currently don't run on `main` (MSW/`rettime` ESM/CJS interop failure in `test-setup.ts` → `__tests__/mocks/server.ts`). Pre-existing, unrelated to this change — confirmed by stashing the fix and running against `origin/main`'s HighlightedText: same failure. Worth a separate infra ticket.
- [ ] Manual verification on device by QA: tap a plain verse → blue overlay covers the whole verse text for ~300ms, then insight tooltip opens. Double-tap → native selection; no overlay flash. Long-press → dictionary lookup; no overlay flash. Tap inside a user/auto highlight → existing highlight tooltip; no full-verse flash.

## References

- Regression: `fb42593` (#260)
- Partial fix: `368ebce` (#277)
- QA evidence: [VER-55](https://paperclip.versemate.org/VER/issues/VER-55)