### PR TITLE
fix(offline): track origin of commentary downloads for Available offline badge (VER-87)

### DIFF
--- a/__tests__/services/offline/offline-sync-service.test.ts
+++ b/__tests__/services/offline/offline-sync-service.test.ts
@@ -31,6 +31,8 @@ jest.mock('@/services/offline/sqlite-manager', () => ({
   deleteCommentaries: jest.fn(),
   deleteTopics: jest.fn(),
   deleteBibleVersion: jest.fn(),
+  getAllMetadata: jest.fn(),
+  getMetadata: jest.fn(),
 }));
 
 // Mock global fetch
@@ -440,6 +442,97 @@ describe('OfflineSyncService', () => {
 
       expect(progressValues[0]).toBe(0);
       expect(progressValues[progressValues.length - 1]).toBeGreaterThan(0);
+    });
+  });
+
+  // VER-87: the "Available offline" badge in useBibleChapterExplanation
+  // reads from getDownloadedCommentaryLanguages. Only explicit user-initiated
+  // downloads should drive it — Pass 2 auto-synced rows must not, and legacy
+  // pre-migration rows (origin = NULL) must not either.
+  describe('getDownloadedCommentaryLanguages (VER-87 badge filter)', () => {
+    it('returns only languages with origin === "explicit"', async () => {
+      (sqliteManager.getAllMetadata as jest.Mock).mockResolvedValue([
+        {
+          resource_key: 'commentary:en',
+          last_updated_at: '2024-01-01',
+          downloaded_at: '2024-01-01',
+          size_bytes: 100,
+          origin: 'explicit',
+        },
+        {
+          resource_key: 'commentary:pt',
+          last_updated_at: '2024-01-01',
+          downloaded_at: '2024-01-01',
+          size_bytes: 100,
+          origin: 'auto-sync',
+        },
+        {
+          resource_key: 'commentary:es',
+          last_updated_at: '2024-01-01',
+          downloaded_at: '2024-01-01',
+          size_bytes: 100,
+          // legacy row — origin column NULL → reads as undefined
+        },
+      ]);
+
+      const result = await syncService.getDownloadedCommentaryLanguages();
+
+      expect(result).toEqual(['en']);
+    });
+
+    it('ignores non-commentary metadata rows', async () => {
+      (sqliteManager.getAllMetadata as jest.Mock).mockResolvedValue([
+        {
+          resource_key: 'topics:en',
+          last_updated_at: '2024-01-01',
+          downloaded_at: '2024-01-01',
+          size_bytes: 100,
+          origin: 'explicit',
+        },
+        {
+          resource_key: 'bible:NASB1995',
+          last_updated_at: '2024-01-01',
+          downloaded_at: '2024-01-01',
+          size_bytes: 100,
+          origin: 'explicit',
+        },
+      ]);
+
+      const result = await syncService.getDownloadedCommentaryLanguages();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('downloadCommentaries origin tagging (VER-87)', () => {
+    beforeEach(() => {
+      server.use(
+        http.get('https://api.versemate.org/offline/commentaries/:lang', () => {
+          return HttpResponse.json([]);
+        })
+      );
+    });
+
+    it('defaults to origin="explicit" so user-initiated downloads light the badge', async () => {
+      await syncService.downloadCommentaries('en', mockManifest as any);
+
+      expect(sqliteManager.saveMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource_key: 'commentary:en',
+          origin: 'explicit',
+        })
+      );
+    });
+
+    it('honors a caller-provided "auto-sync" origin (Pass 2 cross-populate)', async () => {
+      await syncService.downloadCommentaries('en', mockManifest as any, undefined, 'auto-sync');
+
+      expect(sqliteManager.saveMetadata).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resource_key: 'commentary:en',
+          origin: 'auto-sync',
+        })
+      );
     });
   });
 });

--- a/services/offline/index.web.ts
+++ b/services/offline/index.web.ts
@@ -14,6 +14,7 @@ import type {
   LanguageBundle,
   LanguageBundleStatus,
   OfflineBookmark,
+  OfflineDownloadOrigin,
   OfflineHighlight,
   OfflineManifest,
   OfflineMetadata,
@@ -204,23 +205,27 @@ export async function fetchManifest(): Promise<OfflineManifest> {
 export async function downloadBibleVersion(
   _versionKey: string,
   _manifest: OfflineManifest,
-  _onProgress?: ProgressCallback
+  _onProgress?: ProgressCallback,
+  _origin?: OfflineDownloadOrigin
 ): Promise<void> {}
 export async function downloadCommentaries(
   _languageCode: string,
   _manifest: OfflineManifest,
-  _onProgress?: ProgressCallback
+  _onProgress?: ProgressCallback,
+  _origin?: OfflineDownloadOrigin
 ): Promise<void> {}
 export async function downloadTopics(
   _languageCode: string,
   _manifest: OfflineManifest,
-  _onProgress?: ProgressCallback
+  _onProgress?: ProgressCallback,
+  _origin?: OfflineDownloadOrigin
 ): Promise<void> {}
 export async function downloadBibleBook(
   _versionKey: string,
   _bookId: number,
   _manifest: OfflineManifest,
-  _onProgress?: ProgressCallback
+  _onProgress?: ProgressCallback,
+  _origin?: OfflineDownloadOrigin
 ): Promise<void> {}
 export async function removeBibleVersion(_versionKey: string): Promise<void> {}
 export async function removeBibleBook(_versionKey: string, _bookId: number): Promise<void> {}

--- a/services/offline/offline-sync-service.ts
+++ b/services/offline/offline-sync-service.ts
@@ -36,6 +36,7 @@ import type {
   DownloadStatus,
   LanguageBundle,
   LanguageBundleStatus,
+  OfflineDownloadOrigin,
   OfflineManifest,
   SyncProgress,
   TopicsDownloadData,
@@ -81,12 +82,19 @@ export async function fetchManifest(): Promise<OfflineManifest> {
 }
 
 /**
- * Download and store a Bible version
+ * Download and store a Bible version.
+ *
+ * `origin` tags the metadata row so we can later distinguish user-initiated
+ * downloads from Pass 2 cross-populated content. Bible versions don't drive
+ * the "Available offline" badge, but the tag keeps schema consistent so a
+ * Pass 1 re-download preserves the row's prior intent rather than silently
+ * promoting an auto-sync row to explicit.
  */
 export async function downloadBibleVersion(
   versionKey: string,
   manifest: OfflineManifest,
-  onProgress?: ProgressCallback
+  onProgress?: ProgressCallback,
+  origin: OfflineDownloadOrigin = 'explicit'
 ): Promise<void> {
   onProgress?.({ current: 0, total: 100, message: `Downloading ${versionKey}...` });
 
@@ -108,6 +116,7 @@ export async function downloadBibleVersion(
     last_updated_at: versionInfo?.updated_at || new Date().toISOString(),
     downloaded_at: new Date().toISOString(),
     size_bytes: versionInfo?.size_bytes || 0,
+    origin,
   });
 
   onProgress?.({ current: 100, total: 100, message: 'Complete!' });
@@ -124,7 +133,8 @@ export async function downloadBibleBook(
   versionKey: string,
   bookId: number,
   manifest: OfflineManifest,
-  onProgress?: ProgressCallback
+  onProgress?: ProgressCallback,
+  origin: OfflineDownloadOrigin = 'explicit'
 ): Promise<void> {
   onProgress?.({ current: 0, total: 100, message: 'Fetching version data...' });
 
@@ -152,18 +162,25 @@ export async function downloadBibleBook(
     last_updated_at: versionInfo?.updated_at || new Date().toISOString(),
     downloaded_at: new Date().toISOString(),
     size_bytes: sizeBytes,
+    origin,
   });
 
   onProgress?.({ current: 100, total: 100, message: 'Complete!' });
 }
 
 /**
- * Download and store commentaries for a language
+ * Download and store commentaries for a language.
+ *
+ * `origin` defaults to `'explicit'` so the offline UI's "Download" button
+ * keeps producing badge-eligible rows. Pass 2 of `checkAndSyncUpdates` must
+ * pass `'auto-sync'` explicitly so the badge does not fire for
+ * cross-populated content the user never asked for.
  */
 export async function downloadCommentaries(
   languageCode: string,
   manifest: OfflineManifest,
-  onProgress?: ProgressCallback
+  onProgress?: ProgressCallback,
+  origin: OfflineDownloadOrigin = 'explicit'
 ): Promise<void> {
   onProgress?.({
     current: 0,
@@ -191,18 +208,21 @@ export async function downloadCommentaries(
     last_updated_at: langInfo?.updated_at || new Date().toISOString(),
     downloaded_at: new Date().toISOString(),
     size_bytes: langInfo?.size_bytes || 0,
+    origin,
   });
 
   onProgress?.({ current: 100, total: 100, message: 'Complete!' });
 }
 
 /**
- * Download and store topics for a language
+ * Download and store topics for a language. See `downloadCommentaries` for
+ * the `origin` parameter's role.
  */
 export async function downloadTopics(
   languageCode: string,
   manifest: OfflineManifest,
-  onProgress?: ProgressCallback
+  onProgress?: ProgressCallback,
+  origin: OfflineDownloadOrigin = 'explicit'
 ): Promise<void> {
   onProgress?.({ current: 0, total: 100, message: `Downloading topics (${languageCode})...` });
 
@@ -226,6 +246,7 @@ export async function downloadTopics(
     last_updated_at: langInfo?.updated_at || new Date().toISOString(),
     downloaded_at: new Date().toISOString(),
     size_bytes: langInfo?.size_bytes || 0,
+    origin,
   });
 
   onProgress?.({ current: 100, total: 100, message: 'Complete!' });
@@ -403,12 +424,21 @@ export async function getDownloadedBibleVersions(): Promise<string[]> {
 }
 
 /**
- * Get list of downloaded commentary language codes
+ * Get list of commentary languages the user explicitly downloaded.
+ *
+ * Only `origin === 'explicit'` rows are returned. Pass 2 cross-populated
+ * rows (`origin === 'auto-sync'`) and legacy rows (`origin` undefined /
+ * NULL) are excluded so the "Available offline" badge — driven by
+ * `matchedLocalLanguage` in `useBibleChapterExplanation` — only fires for
+ * content the user actively asked for.
+ *
+ * Auto-sync content remains queryable through the regular offline read
+ * paths; it just doesn't claim to be "your" download in the UI.
  */
 export async function getDownloadedCommentaryLanguages(): Promise<string[]> {
   const metadata = await getAllMetadata();
   return metadata
-    .filter((m) => m.resource_key.startsWith('commentary:'))
+    .filter((m) => m.resource_key.startsWith('commentary:') && m.origin === 'explicit')
     .map((m) => m.resource_key.replace('commentary:', ''));
 }
 
@@ -465,12 +495,19 @@ export async function checkAndSyncUpdates(onProgress?: ProgressCallback): Promis
         message: `Updating ${type}: ${key}...`,
       });
 
+      // Preserve the row's existing origin so a Pass 1 re-download doesn't
+      // silently promote auto-sync content to explicit (or vice versa).
+      // Legacy rows (origin = NULL) read back as undefined and are treated
+      // as auto-sync, which matches the badge-suppression intent for content
+      // a prior build pulled in without the user knowing.
+      const preservedOrigin: OfflineDownloadOrigin = meta.origin ?? 'auto-sync';
+
       if (type === 'bible') {
-        await downloadBibleVersion(key, manifest);
+        await downloadBibleVersion(key, manifest, undefined, preservedOrigin);
       } else if (type === 'commentary') {
-        await downloadCommentaries(key, manifest);
+        await downloadCommentaries(key, manifest, undefined, preservedOrigin);
       } else if (type === 'topics') {
-        await downloadTopics(key, manifest);
+        await downloadTopics(key, manifest, undefined, preservedOrigin);
       }
 
       updated++;
@@ -500,7 +537,9 @@ export async function checkAndSyncUpdates(onProgress?: ProgressCallback): Promis
         message: `Downloading new topics (${langCode})...`,
       });
 
-      await downloadTopics(langCode, manifest);
+      // Pass 2 cross-population — user never asked for this. Tag as
+      // auto-sync so the badge stays off.
+      await downloadTopics(langCode, manifest, undefined, 'auto-sync');
       updated++;
     }
   }
@@ -517,7 +556,7 @@ export async function checkAndSyncUpdates(onProgress?: ProgressCallback): Promis
         message: `Downloading new commentaries (${langCode})...`,
       });
 
-      await downloadCommentaries(langCode, manifest);
+      await downloadCommentaries(langCode, manifest, undefined, 'auto-sync');
       updated++;
     }
   }

--- a/services/offline/sqlite-manager.ts
+++ b/services/offline/sqlite-manager.ts
@@ -265,9 +265,7 @@ function performInitSync(): SQLite.SQLiteDatabase {
     // the "Available offline" badge only fires for content the user asked for.
     // Legacy rows have NULL origin and are treated as auto-sync on read.
     try {
-      const metaCols = database.getAllSync<{ name: string }>(
-        'PRAGMA table_info(offline_metadata)'
-      );
+      const metaCols = database.getAllSync<{ name: string }>('PRAGMA table_info(offline_metadata)');
       const colNames = metaCols.map((c) => c.name);
       if (!colNames.includes('origin')) {
         if (__DEV__) console.log('[Offline DB] Adding origin column to offline_metadata');

--- a/services/offline/sqlite-manager.ts
+++ b/services/offline/sqlite-manager.ts
@@ -160,7 +160,8 @@ const CREATE_TABLES_SQL = `
     resource_key TEXT PRIMARY KEY,
     last_updated_at TEXT NOT NULL,
     downloaded_at TEXT NOT NULL,
-    size_bytes INTEGER NOT NULL
+    size_bytes INTEGER NOT NULL,
+    origin TEXT
   );
 
   CREATE TABLE IF NOT EXISTS offline_sync_queue (
@@ -254,6 +255,23 @@ function performInitSync(): SQLite.SQLiteDatabase {
       if (!colNames.includes('insight_type')) {
         if (__DEV__) console.log('[Offline DB] Adding insight_type column to offline_bookmarks');
         database.execSync('ALTER TABLE offline_bookmarks ADD COLUMN insight_type TEXT');
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Add origin to offline_metadata (VER-87). Distinguishes user-initiated
+    // ("explicit") downloads from Pass 2 cross-populated ("auto-sync") rows so
+    // the "Available offline" badge only fires for content the user asked for.
+    // Legacy rows have NULL origin and are treated as auto-sync on read.
+    try {
+      const metaCols = database.getAllSync<{ name: string }>(
+        'PRAGMA table_info(offline_metadata)'
+      );
+      const colNames = metaCols.map((c) => c.name);
+      if (!colNames.includes('origin')) {
+        if (__DEV__) console.log('[Offline DB] Adding origin column to offline_metadata');
+        database.execSync('ALTER TABLE offline_metadata ADD COLUMN origin TEXT');
       }
     } catch {
       /* ignore */
@@ -1122,15 +1140,21 @@ export async function deleteAllUserData(): Promise<void> {
 export async function saveMetadata(metadata: OfflineMetadata): Promise<void> {
   const database = await initDatabase();
   database.runSync(
-    'INSERT OR REPLACE INTO offline_metadata (resource_key, last_updated_at, downloaded_at, size_bytes) VALUES (?, ?, ?, ?)',
-    [metadata.resource_key, metadata.last_updated_at, metadata.downloaded_at, metadata.size_bytes]
+    'INSERT OR REPLACE INTO offline_metadata (resource_key, last_updated_at, downloaded_at, size_bytes, origin) VALUES (?, ?, ?, ?, ?)',
+    [
+      metadata.resource_key,
+      metadata.last_updated_at,
+      metadata.downloaded_at,
+      metadata.size_bytes,
+      metadata.origin ?? null,
+    ]
   );
 }
 
 export async function getMetadata(resourceKey: string): Promise<OfflineMetadata | null> {
   const database = await initDatabase();
   const result = database.getFirstSync<OfflineMetadata>(
-    'SELECT resource_key, last_updated_at, downloaded_at, size_bytes FROM offline_metadata WHERE resource_key = ?',
+    'SELECT resource_key, last_updated_at, downloaded_at, size_bytes, origin FROM offline_metadata WHERE resource_key = ?',
     [resourceKey]
   );
   return result ?? null;
@@ -1139,7 +1163,7 @@ export async function getMetadata(resourceKey: string): Promise<OfflineMetadata 
 export async function getAllMetadata(): Promise<OfflineMetadata[]> {
   const database = await initDatabase();
   return database.getAllSync<OfflineMetadata>(
-    'SELECT resource_key, last_updated_at, downloaded_at, size_bytes FROM offline_metadata'
+    'SELECT resource_key, last_updated_at, downloaded_at, size_bytes, origin FROM offline_metadata'
   );
 }
 

--- a/services/offline/types.ts
+++ b/services/offline/types.ts
@@ -81,12 +81,30 @@ export interface TopicsDownloadData {
   explanations: TopicExplanationData[];
 }
 
+/**
+ * How an offline_metadata row came to exist.
+ *
+ * - `explicit`: the user initiated the download from the offline UI.
+ * - `auto-sync`: Pass 2 of `checkAndSyncUpdates` cross-populated the content
+ *   silently because the user already had the sibling content type
+ *   (e.g. user has topics:en, so commentary:en gets pulled too).
+ *
+ * The "Available offline" badge only fires for `explicit` rows. `auto-sync`
+ * content is still usable offline; we just don't claim the user asked for it.
+ *
+ * Legacy rows written before this column existed read back as `undefined`
+ * and are treated as `auto-sync` (no badge) — see filter in
+ * `getDownloadedCommentaryLanguages`.
+ */
+export type OfflineDownloadOrigin = 'explicit' | 'auto-sync';
+
 // Local metadata for tracking downloads
 export interface OfflineMetadata {
   resource_key: string; // e.g., "bible:NASB1995", "commentary:en", "topics:en"
   last_updated_at: string;
   downloaded_at: string;
   size_bytes: number;
+  origin?: OfflineDownloadOrigin;
 }
 
 // Download status


### PR DESCRIPTION
## Summary

Fixes [VER-87](https://paperclip.versemate.org/VER/issues/VER-87) (parent: [VER-84](https://paperclip.versemate.org/VER/issues/VER-84)).

The "Available offline" badge was firing on Bible explanation tabs for users who never explicitly downloaded commentary. Root cause: `offline-sync-service.ts` Pass 2 of `checkAndSyncUpdates` silently auto-downloads the commentary bundle for any language the user already has topics in, writing the same `commentary:<lang>` row that an explicit user-initiated download writes. The badge couldn't tell intent apart from cross-population.

Fix: tag every `offline_metadata` commentary/topics row with an `origin` field:

- `"explicit"` — user initiated the download via the offline UI
- `"auto-sync"` — Pass 2 cross-populated it silently

`getDownloadedCommentaryLanguages` (the source of `matchedLocalLanguage` in `useBibleChapterExplanation`) now only returns rows where `origin === 'explicit'`. Legacy rows pre-migration have `NULL` origin and are treated as `auto-sync`, so existing auto-synced users immediately lose the incorrect badge after upgrade.

Pass 2 auto-sync behavior is unchanged — content is still downloaded silently and remains available offline. We simply stop claiming the user opted into it.

## What changed

- `services/offline/types.ts` — add `OfflineDownloadOrigin` type and optional `origin` field on `OfflineMetadata`.
- `services/offline/sqlite-manager.ts` — add `origin TEXT` column to `offline_metadata` with an `ALTER TABLE` migration; persist and read the column in `saveMetadata`/`getMetadata`/`getAllMetadata`.
- `services/offline/offline-sync-service.ts` — `downloadCommentaries` and `downloadTopics` take an `origin` parameter (default `'explicit'`). Pass 2 callers explicitly pass `'auto-sync'`. Pass 1 (update of existing rows) preserves the row's existing origin, defaulting legacy `NULL` to `'auto-sync'`. `getDownloadedCommentaryLanguages` filters to `origin === 'explicit'`.
- `services/offline/index.web.ts` — web stub signatures updated.

## Acceptance criteria

1. ✅ User with only topics downloaded sees NO "Available offline" badge on explanation tabs (auto-sync rows excluded from `downloadedCommentaryLanguages`).
2. ✅ User who explicitly downloaded commentary DOES see the badge (explicit rows still pass the filter).
3. ✅ Auto-sync still downloads commentary silently — Pass 2 behavior unchanged, content remains available offline.
4. ✅ Existing `offline_metadata` rows without `origin` default to `'auto-sync'` (read-side `NULL` is excluded by the filter) so existing auto-synced users immediately lose the incorrect badge.

## Test plan

- [ ] CI: typecheck and tests pass.
- [ ] Smoke on device:
  - [ ] Fresh install, download topics only for a language. Open a Bible chapter, check the Explanations panel — no "Available offline" badge.
  - [ ] Explicitly download commentary for that language. Open the same chapter — badge appears.
  - [ ] Upgrade an existing build where commentary was auto-synced. Open Explanations — badge is gone (origin=NULL → auto-sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Paperclip <noreply@paperclip.ing>