### PR TITLE
fix(auth): re-read token cache when null so login picks up new JWT (VER-38)

### DIFF
--- a/__tests__/lib/api/client-interceptors-token-cache.test.ts
+++ b/__tests__/lib/api/client-interceptors-token-cache.test.ts
@@ -7,7 +7,11 @@
  * repeated AsyncStorage reads.
  */
 
-import { setupClientInterceptors } from '@/lib/api/client-interceptors';
+import {
+  clearTokenCache,
+  requestInterceptor,
+  setupClientInterceptors,
+} from '@/lib/api/client-interceptors';
 import { getAccessToken } from '@/lib/auth/token-storage';
 import { client } from '@/src/api/generated/client.gen';
 
@@ -15,9 +19,16 @@ jest.mock('@/lib/auth/token-storage');
 
 const mockGetAccessToken = getAccessToken as jest.MockedFunction<typeof getAccessToken>;
 
+// The interceptor signature takes a second ResolvedRequestOptions argument
+// that the implementation ignores. Pass an unknown-cast empty object so we
+// don't have to construct the full options object in every test.
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+const opts = {} as any;
+
 describe('requestInterceptor token caching', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    clearTokenCache();
     mockGetAccessToken.mockResolvedValue('token-abc');
   });
 
@@ -89,5 +100,40 @@ describe('requestInterceptor token caching', () => {
     const interceptors = require('@/lib/api/client-interceptors');
 
     expect(interceptors.clearTokenCache).toBeDefined();
+  });
+
+  it('[REGRESSION VER-38] picks up a token written after the first interceptor call (login-after-guest)', async () => {
+    // Guest opens the app: first interceptor call sees no token in storage.
+    mockGetAccessToken.mockResolvedValueOnce(null);
+    const guestReq = new Request('https://api.example.com/bible/books');
+    const afterGuest = await requestInterceptor(guestReq, opts);
+    expect(afterGuest.headers.has('Authorization')).toBe(false);
+
+    // User logs in: setAccessToken writes to storage. The interceptor
+    // should re-read storage on the next request and attach the new token.
+    mockGetAccessToken.mockResolvedValueOnce('fresh-jwt');
+    const sessionReq = new Request('https://api.example.com/auth/session');
+    const afterLogin = await requestInterceptor(sessionReq, opts);
+    expect(afterLogin.headers.get('Authorization')).toBe('Bearer fresh-jwt');
+  });
+
+  it('[REGRESSION VER-38] caches the token across requests once known (no extra storage reads)', async () => {
+    mockGetAccessToken.mockResolvedValue('jwt-1');
+    await requestInterceptor(new Request('https://api.example.com/a'), opts);
+    await requestInterceptor(new Request('https://api.example.com/b'), opts);
+    await requestInterceptor(new Request('https://api.example.com/c'), opts);
+    // First call populates the cache; subsequent calls hit it.
+    expect(mockGetAccessToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('[REGRESSION VER-38] clearTokenCache forces a fresh storage read', async () => {
+    mockGetAccessToken.mockResolvedValueOnce('old-jwt');
+    await requestInterceptor(new Request('https://api.example.com/a'), opts);
+
+    clearTokenCache();
+    mockGetAccessToken.mockResolvedValueOnce('new-jwt');
+    const next = await requestInterceptor(new Request('https://api.example.com/b'), opts);
+
+    expect(next.headers.get('Authorization')).toBe('Bearer new-jwt');
   });
 });

--- a/lib/api/client-interceptors.ts
+++ b/lib/api/client-interceptors.ts
@@ -21,9 +21,12 @@ import { getAccessToken } from '@/lib/auth/token-storage';
 // Track retry attempts per request to prevent infinite loops
 const retryAttempts = new WeakMap<Request, number>();
 
-// In-memory token cache to avoid repeated AsyncStorage reads on every request
+// In-memory token cache to avoid repeated AsyncStorage / SecureStore reads on
+// every request once the user is signed in. A null value means "unknown" —
+// the next interceptor invocation re-reads storage. This is what lets a
+// post-login request pick up the token written by setAccessToken without
+// requiring callers to remember to invalidate the cache. (VER-38)
 let cachedToken: string | null = null;
-let tokenCachePopulated = false;
 
 /**
  * Clear the in-memory token cache.
@@ -31,7 +34,6 @@ let tokenCachePopulated = false;
  */
 export function clearTokenCache(): void {
   cachedToken = null;
-  tokenCachePopulated = false;
 }
 
 // PostHog instance for error tracking
@@ -47,16 +49,21 @@ export function setPostHogInstance(posthog: { captureException: (error: unknown,
 }
 
 /**
- * Request interceptor: Add Authorization header with access token
+ * Request interceptor: Add Authorization header with access token.
+ *
+ * Exported for direct unit testing — production callers go through
+ * `setupClientInterceptors()`, which wires this into the generated client.
  */
-async function requestInterceptor(
+export async function requestInterceptor(
   request: Request,
   _options: ResolvedRequestOptions,
 ): Promise<Request> {
-  // Use cached token if available, otherwise read from AsyncStorage and cache it
-  if (!tokenCachePopulated) {
+  // Re-read from storage whenever the cache is empty. Treating null as
+  // "unknown" rather than a sticky "no token" answer is what makes the
+  // first request after login pick up the freshly written token. The cache
+  // still skips storage reads on the hot path once a token is known.
+  if (cachedToken === null) {
     cachedToken = await getAccessToken();
-    tokenCachePopulated = true;
   }
   const token = cachedToken;
 


### PR DESCRIPTION
## Summary

P0 production hotfix for [VER-38](https://paperclip.versemate.org/VER/issues/VER-38). The request interceptor cached the result of `getAccessToken()` on first read and only re-read on logout — so a guest-then-login flow stuck at `cachedToken=null`, the `GET /auth/session` request after login fired with no `Authorization` header, and every authenticated feature (Bookmarks, Notes, Highlights) was blocked behind a 401 "Invalid bearer token".

QA's reproduction on `mobile.versemate.org` (Expo web export of this app): `curl` with the same JWT works against `/auth/session`, the FE never sends the header. Andy's TestFlight reports — "Bookmarks just spins / saved notes don't appear" — are downstream of this broken login → session handshake.

## Root cause

`lib/api/client-interceptors.ts`:

```ts
if (!tokenCachePopulated) {
  cachedToken = await getAccessToken();
  tokenCachePopulated = true;
}
```

Once `tokenCachePopulated` flipped to `true` it stayed `true` until `clearTokenCache()` ran on logout. So:

1. Guest opens app → first request → no token → `cachedToken = null`, `tokenCachePopulated = true`.
2. User logs in → `setAccessToken(jwt)` writes to AsyncStorage / SecureStore.
3. `fetchUserSession()` fires `GET /auth/session` → interceptor uses stale `null` → 401.

The `refreshAccessToken` 401 retry used to write `cachedToken = newToken`, which masked this bug. D-005 removed refresh; the bug surfaced.

## Fix

Drop `tokenCachePopulated`. Treat `cachedToken === null` as "unknown" rather than a sticky "no token" answer. The cache still skips storage reads on the hot path once a token is known; the first request after login now re-reads storage and attaches the JWT.

## Test plan

- [x] Added three regression tests in `__tests__/lib/api/client-interceptors-token-cache.test.ts` that drive the real interceptor:
  - guest-then-login: null on first call, token on second call → Authorization header set on second call.
  - cache hit on subsequent requests: `getAccessToken` called once across three requests.
  - `clearTokenCache` forces a fresh storage read.
- [x] `npm test -- --testPathPattern='client-interceptors-token-cache'` → 8/8 passing.
- [ ] QA: end-to-end verification on `mobile.versemate.org` and TestFlight — login, then exercise Bookmarks / Notes / Highlights against a freshly cleared session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)