### PR TITLE
Universal dictionary: enable word long-press in Topics and Insights (VER-72)

### DIFF
--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -26,13 +26,16 @@ import {
   Text,
   View,
 } from 'react-native';
-import Markdown from 'react-native-markdown-display';
+import Markdown, { type RenderRules } from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
+import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { AvailableOfflineBadge } from '@/components/offline/AvailableOfflineBadge';
 import { OfflineContentUnavailable } from '@/components/offline/OfflineContentUnavailable';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useToast } from '@/contexts/ToastContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import { useOfflineStatus } from '@/hooks/bible/use-offline-status';
 import { useBibleByLine, useBibleDetailed, useBibleSummary } from '@/src/api';
@@ -132,6 +135,47 @@ export function BibleExplanationsPanel({
   const { styles, markdownStyles } = useMemo(
     () => createStyles(specs, colors, insets),
     [specs, colors, insets]
+  );
+  const { showToast } = useToast();
+
+  // Word definition tooltip state (long-press dictionary lookup on markdown text)
+  const [wordToDefine, setWordToDefine] = useState<{
+    word: string;
+    verseNumber: number;
+  } | null>(null);
+  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
+
+  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
+    setWordToDefine({ word: selection.word, verseNumber: selection.verseNumber });
+    setWordDefinitionVisible(true);
+    clearSelection();
+  }, []);
+
+  const handleWordDefinitionClose = useCallback(() => {
+    setWordDefinitionVisible(false);
+    setWordToDefine(null);
+  }, []);
+
+  const handleWordDefinitionCopy = useCallback(() => {
+    showToast('Copied to clipboard');
+  }, [showToast]);
+
+  // Custom markdown rule that wraps each text leaf with HighlightedText so
+  // long-press triggers the dictionary tooltip across Summary/By Line/Detailed.
+  const dictionaryMarkdownRules: RenderRules = useMemo(
+    () => ({
+      text: (node, _children, _parent, styles, inheritedStyles = {}) => (
+        <HighlightedText
+          key={node.key}
+          text={node.content}
+          verseNumber={0}
+          style={[inheritedStyles, styles.text]}
+          onWordSelect={handleWordSelect}
+          isVisible={true}
+        />
+      ),
+    }),
+    [handleWordSelect]
   );
 
   // Get current language from user preferences (default to 'en-US')
@@ -505,11 +549,15 @@ export function BibleExplanationsPanel({
                     testID={`byline-verse-section-${section.verseNumber}`}
                     collapsable={false}
                   >
-                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                    <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+                      {section.markdown}
+                    </Markdown>
                   </View>
                 ))
               ) : (
-                <Markdown style={markdownStyles}>{tab.data}</Markdown>
+                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+                  {tab.data}
+                </Markdown>
               )}
             </>
           ) : isOffline ? (
@@ -534,6 +582,19 @@ export function BibleExplanationsPanel({
           onInteraction={onFABInteraction}
           bottomOffset={spacing.lg}
           testID={`${testID}-verse-jump`}
+        />
+      )}
+
+      {/* Word Definition Tooltip — dictionary lookup on long-press */}
+      {wordToDefine && (
+        <WordDefinitionTooltip
+          visible={wordDefinitionVisible}
+          word={wordToDefine.word}
+          bookName={bookName}
+          chapterNumber={chapterNumber}
+          verseNumber={wordToDefine.verseNumber}
+          onClose={handleWordDefinitionClose}
+          onCopy={handleWordDefinitionCopy}
         />
       )}
     </View>

--- a/components/topics/TopicContentPanel.tsx
+++ b/components/topics/TopicContentPanel.tsx
@@ -14,7 +14,7 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import type { NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
@@ -22,9 +22,12 @@ import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BottomLogo } from '@/components/bible/BottomLogo';
 import { FloatingActionButtons } from '@/components/bible/FloatingActionButtons';
+import type { WordSelection } from '@/components/bible/HighlightedText';
+import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { TopicText, type VersePress } from '@/components/topics/TopicText';
 import { ReadingProgressBar } from '@/components/ui/ReadingProgressBar';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useToast } from '@/contexts/ToastContext';
 import { useTopicReferences } from '@/src/api';
 import {
   fontSizes,
@@ -144,6 +147,7 @@ export function TopicContentPanel({
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
   const { styles, markdownStyles } = createStyles(specs, colors);
   const insets = useSafeAreaInsets();
+  const { showToast } = useToast();
 
   // Reading progress state
   const [progress, setProgress] = useState(0);
@@ -152,6 +156,28 @@ export function TopicContentPanel({
   // Velocity tracking
   const lastScrollY = useRef(0);
   const lastScrollTime = useRef(0);
+
+  // Word definition tooltip state (long-press dictionary lookup)
+  const [wordToDefine, setWordToDefine] = useState<{
+    word: string;
+    verseNumber: number;
+  } | null>(null);
+  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
+
+  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
+    setWordToDefine({ word: selection.word, verseNumber: selection.verseNumber });
+    setWordDefinitionVisible(true);
+    clearSelection();
+  }, []);
+
+  const handleWordDefinitionClose = useCallback(() => {
+    setWordDefinitionVisible(false);
+    setWordToDefine(null);
+  }, []);
+
+  const handleWordDefinitionCopy = useCallback(() => {
+    showToast('Copied to clipboard');
+  }, [showToast]);
 
   // Fetch references for this topic
   const { data: references } = useTopicReferences(topicId);
@@ -241,6 +267,7 @@ export function TopicContentPanel({
                 markdownContent={contentString}
                 onShare={onShare}
                 onVersePress={onVersePress}
+                onWordSelect={handleWordSelect}
               />
             ) : (
               <>
@@ -300,6 +327,19 @@ export function TopicContentPanel({
         showNext={hasNextTopic}
         visible={visible}
       />
+
+      {/* Word Definition Tooltip — dictionary lookup on long-press */}
+      {wordToDefine && (
+        <WordDefinitionTooltip
+          visible={wordDefinitionVisible}
+          word={wordToDefine.word}
+          bookName={topicName}
+          chapterNumber={0}
+          verseNumber={wordToDefine.verseNumber}
+          onClose={handleWordDefinitionClose}
+          onCopy={handleWordDefinitionCopy}
+        />
+      )}
     </View>
   );
 }

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -16,12 +16,15 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { t } from 'i18next';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
+import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useToast } from '@/contexts/ToastContext';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { useTopicById } from '@/src/api';
 import {
@@ -113,8 +116,50 @@ export function TopicExplanationsPanel({
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
   const { styles, markdownStyles } = createStyles(specs, colors);
   const insets = useSafeAreaInsets();
+  const { showToast } = useToast();
 
   const scrollViewRef = useRef<ScrollView>(null);
+
+  // Word definition tooltip state (long-press dictionary lookup on markdown text)
+  const [wordToDefine, setWordToDefine] = useState<{
+    word: string;
+    verseNumber: number;
+  } | null>(null);
+  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
+
+  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
+    setWordToDefine({ word: selection.word, verseNumber: selection.verseNumber });
+    setWordDefinitionVisible(true);
+    clearSelection();
+  }, []);
+
+  const handleWordDefinitionClose = useCallback(() => {
+    setWordDefinitionVisible(false);
+    setWordToDefine(null);
+  }, []);
+
+  const handleWordDefinitionCopy = useCallback(() => {
+    showToast('Copied to clipboard');
+  }, [showToast]);
+
+  // Custom markdown rule that wraps each text leaf with HighlightedText so
+  // long-press triggers the dictionary tooltip across Summary/By Line/Detailed.
+  const dictionaryMarkdownRules: RenderRules = useMemo(
+    () => ({
+      ...markdownRules,
+      text: (node, _children, _parent, styles, inheritedStyles = {}) => (
+        <HighlightedText
+          key={node.key}
+          text={node.content}
+          verseNumber={0}
+          style={[inheritedStyles, styles.text]}
+          onWordSelect={handleWordSelect}
+          isVisible={true}
+        />
+      ),
+    }),
+    [handleWordSelect]
+  );
 
   // Animation for sliding tab indicator
   const getTabIndex = (tab: ContentTabType) => TAB_OPTIONS.findIndex((t) => t.id === tab);
@@ -311,7 +356,7 @@ export function TopicExplanationsPanel({
         {/* Explanation Content */}
         {hasContent ? (
           <View style={styles.explanationContainer}>
-            <Markdown style={markdownStyles} rules={markdownRules}>
+            <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
               {explanationContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
             </Markdown>
           </View>
@@ -323,6 +368,19 @@ export function TopicExplanationsPanel({
           </View>
         )}
       </ScrollView>
+
+      {/* Word Definition Tooltip — dictionary lookup on long-press */}
+      {wordToDefine && (
+        <WordDefinitionTooltip
+          visible={wordDefinitionVisible}
+          word={wordToDefine.word}
+          bookName={topicName}
+          chapterNumber={0}
+          verseNumber={wordToDefine.verseNumber}
+          onClose={handleWordDefinitionClose}
+          onCopy={handleWordDefinitionCopy}
+        />
+      )}
     </View>
   );
 }

--- a/components/topics/TopicPage.tsx
+++ b/components/topics/TopicPage.tsx
@@ -17,16 +17,19 @@
  * @see Spec: agent-os/specs/2025-12-08-topic-swipe-navigation/spec.md
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
 import { ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
 import { BottomLogo } from '@/components/bible/BottomLogo';
+import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
 import { ShareButton } from '@/components/bible/ShareButton';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
+import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { TopicText, type VersePress } from '@/components/topics/TopicText';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useToast } from '@/contexts/ToastContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import { useTopicById, useTopicReferences } from '@/src/api';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -161,10 +164,52 @@ export function TopicPage({
 }: TopicPageProps) {
   const { colors } = useTheme();
   const { styles, markdownStyles } = createStyles(colors);
+  const { showToast } = useToast();
 
   // TODO: Implement Bible version selection in Settings page
   // For now, hardcoded to NASB1995 (backend default)
   const bibleVersion = 'NASB1995';
+
+  // Word definition tooltip state (long-press dictionary lookup)
+  const [wordToDefine, setWordToDefine] = useState<{
+    word: string;
+    verseNumber: number;
+  } | null>(null);
+  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
+
+  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
+    setWordToDefine({ word: selection.word, verseNumber: selection.verseNumber });
+    setWordDefinitionVisible(true);
+    clearSelection();
+  }, []);
+
+  const handleWordDefinitionClose = useCallback(() => {
+    setWordDefinitionVisible(false);
+    setWordToDefine(null);
+  }, []);
+
+  const handleWordDefinitionCopy = useCallback(() => {
+    showToast('Copied to clipboard');
+  }, [showToast]);
+
+  // Markdown text rule that wraps text nodes with HighlightedText for word
+  // long-press dictionary lookup (used in the Explanations view markdown).
+  const dictionaryMarkdownRules: RenderRules = useMemo(
+    () => ({
+      ...markdownRules,
+      text: (node, _children, _parent, styles, inheritedStyles = {}) => (
+        <HighlightedText
+          key={node.key}
+          text={node.content}
+          verseNumber={0}
+          style={[inheritedStyles, styles.text]}
+          onWordSelect={handleWordSelect}
+          isVisible={true}
+        />
+      ),
+    }),
+    [handleWordSelect]
+  );
 
   // Track last scroll position and timestamp for velocity calculation
   const lastScrollY = useRef(0);
@@ -377,6 +422,7 @@ export function TopicPage({
               markdownContent={displayReferences.content}
               onShare={onShare}
               onVersePress={onVersePress}
+              onWordSelect={handleWordSelect}
             />
           ) : (
             <>
@@ -482,7 +528,7 @@ export function TopicPage({
             >
               {displayTopicData?.explanation?.summary &&
               typeof displayTopicData.explanation.summary === 'string' ? (
-                <Markdown style={markdownStyles} rules={markdownRules}>
+                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
                   {displayTopicData.explanation.summary.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
                 </Markdown>
               ) : (
@@ -503,7 +549,7 @@ export function TopicPage({
             >
               {displayTopicData?.explanation?.byline &&
               typeof displayTopicData.explanation.byline === 'string' ? (
-                <Markdown style={markdownStyles} rules={markdownRules}>
+                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
                   {cleanupBylineReferences(displayTopicData.explanation.byline).replace(
                     /#{1,6}\s*Summary\s*\n/gi,
                     '\n'
@@ -527,7 +573,7 @@ export function TopicPage({
             >
               {displayTopicData?.explanation?.detailed &&
               typeof displayTopicData.explanation.detailed === 'string' ? (
-                <Markdown style={markdownStyles} rules={markdownRules}>
+                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
                   {displayTopicData.explanation.detailed.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
                 </Markdown>
               ) : (
@@ -540,6 +586,19 @@ export function TopicPage({
             </View>
           )}
         </ScrollView>
+      )}
+
+      {/* Word Definition Tooltip — dictionary lookup on long-press */}
+      {wordToDefine && (
+        <WordDefinitionTooltip
+          visible={wordDefinitionVisible}
+          word={wordToDefine.word}
+          bookName={topic?.name || ''}
+          chapterNumber={0}
+          verseNumber={wordToDefine.verseNumber}
+          onClose={handleWordDefinitionClose}
+          onCopy={handleWordDefinitionCopy}
+        />
       )}
     </View>
   );

--- a/components/topics/TopicText.tsx
+++ b/components/topics/TopicText.tsx
@@ -13,6 +13,7 @@
 import * as Haptics from 'expo-haptics';
 import { useMemo } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
+import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
 import { ShareButton } from '@/components/bible/ShareButton';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -37,6 +38,8 @@ interface TopicTextProps {
   markdownContent: string;
   onShare?: () => void;
   onVersePress?: (data: VersePress) => void;
+  /** Callback when a word is long-pressed for dictionary lookup */
+  onWordSelect?: (selection: WordSelection, clearSelection: () => void) => void;
 }
 
 /**
@@ -64,7 +67,13 @@ function toSuperscript(num: number): string {
     .join('');
 }
 
-export function TopicText({ topicName, markdownContent, onShare, onVersePress }: TopicTextProps) {
+export function TopicText({
+  topicName,
+  markdownContent,
+  onShare,
+  onVersePress,
+  onWordSelect,
+}: TopicTextProps) {
   const { colors } = useTheme();
   const styles = createStyles(colors);
 
@@ -150,6 +159,8 @@ export function TopicText({ topicName, markdownContent, onShare, onVersePress }:
                   (verse.reference || verse.clickableReference) && onVersePress
                 );
 
+                const parsedVerseNumber = Number.parseInt(verse.verseNumber ?? '', 10) || 0;
+
                 return (
                   <Text key={`${verse.verseNumber}-${verse.reference}-${verseIndex}`}>
                     {/* Verse number as superscript - only show if verse number exists */}
@@ -158,10 +169,12 @@ export function TopicText({ topicName, markdownContent, onShare, onVersePress }:
                         {toSuperscript(Number.parseInt(verse.verseNumber, 10))}
                       </Text>
                     )}
-                    {/* Verse text - use onPress directly on Text to maintain inline flow */}
-                    <Text
+                    {/* Verse text — HighlightedText adds word long-press for dictionary lookup */}
+                    <HighlightedText
+                      text={verse.text}
+                      verseNumber={parsedVerseNumber}
                       style={[styles.verseText, isPressable && styles.verseTextPressable]}
-                      onPress={
+                      onVerseTap={
                         isPressable
                           ? () =>
                               handleVersePress(
@@ -171,14 +184,13 @@ export function TopicText({ topicName, markdownContent, onShare, onVersePress }:
                               )
                           : undefined
                       }
-                      suppressHighlighting={!isPressable}
-                    >
-                      {verse.text}
-                      {/* Reference citation (grayed out) - only show if reference exists (DISPLAY ONLY) */}
-                      {verse.reference && (
-                        <Text style={styles.verseReference}> ({verse.reference})</Text>
-                      )}
-                    </Text>
+                      onWordSelect={onWordSelect}
+                      isVisible={true}
+                    />
+                    {/* Reference citation (grayed out) - only show if reference exists (DISPLAY ONLY) */}
+                    {verse.reference && (
+                      <Text style={styles.verseReference}> ({verse.reference})</Text>
+                    )}
                     {/* Add space between verses */}
                     {verseIndex < section.verses.length - 1 && ' '}
                   </Text>


### PR DESCRIPTION
## Summary

- Extend the dictionary lookup (long-press a word → definition tooltip) beyond the Bible Chapter screen to the Topics and Insights areas, where QA confirmed it was missing.
- Reuses existing `HighlightedText` (word selection + coordinate-based long-press) and `WordDefinitionTooltip` — no new dictionary infrastructure.

## Changes

- `components/topics/TopicText.tsx` — wrap verse text with `HighlightedText`; bubble `onWordSelect` up while preserving single-tap navigation via `onVerseTap`.
- `components/topics/TopicContentPanel.tsx` — own `WordDefinitionTooltip` state, pass the word-select handler to `TopicText`.
- `components/topics/TopicPage.tsx` — same as `TopicContentPanel` for phone-portrait, plus a markdown `text` rule override on the inline Summary / By Line / Detailed explanations so word-lookup works there too.
- `components/bible/BibleExplanationsPanel.tsx` — markdown `text` rule wraps text leaves with `HighlightedText` across Summary / By Line / Detailed.
- `components/topics/TopicExplanationsPanel.tsx` — same pattern for the Topics split-view right panel.

## Test plan

- [ ] Topics screen: long-press a word in a referenced verse → `WordDefinitionTooltip` appears with the dictionary entry.
- [ ] Topics screen: single-tap on a verse still navigates / opens the existing verse tooltip (no regression).
- [ ] Bible Insights panel (split view): long-press any word in Summary, By Line, Detailed tabs → tooltip appears.
- [ ] Topics Insights panel (split view): long-press any word in Summary, By Line, Detailed → tooltip appears.
- [ ] Phone-portrait Topics Insights: long-press a word in any explanation tab → tooltip appears.
- [ ] Bible Chapter screen dictionary behaviour unchanged.
- [x] `bun tsc --noEmit` clean.
- [x] `biome check` clean on the five touched files (only pre-existing `suppressions/unused` warning remains; not introduced here).
- [ ] Note: existing `TopicPage` / `SimpleTopicPager` Jest suites fail on this branch *and* on `main` baseline with `actImplementation is not a function` — a pre-existing test-infra issue, not caused by this change.