### PR TITLE
fix(nav): pin current book at position 0 in Recents (VER-94)

### DIFF
--- a/__tests__/components/bible/BibleNavigationModal.test.tsx
+++ b/__tests__/components/bible/BibleNavigationModal.test.tsx
@@ -158,8 +158,10 @@ describe('BibleNavigationModal', () => {
     expect(screen.getAllByText('Genesis')[0]).toBeTruthy();
 
     // Select Genesis (current book) from ALL BOOKS list
-    const genesisButton = screen.getByLabelText('Genesis, 50 chapters');
-    fireEvent.press(genesisButton);
+    // Genesis appears in both RECENTS (pinned current book) and ALL BOOKS;
+    // select the ALL BOOKS instance (last match), matching the Psalms pattern below.
+    const genesisButtons = screen.getAllByLabelText('Genesis, 50 chapters');
+    fireEvent.press(genesisButtons[genesisButtons.length - 1]);
 
     // Wait for chapter grid to render
     await waitFor(() => {
@@ -210,8 +212,10 @@ describe('BibleNavigationModal', () => {
     );
 
     // Select Genesis from ALL BOOKS list
-    const genesisButton = screen.getByLabelText('Genesis, 50 chapters');
-    fireEvent.press(genesisButton);
+    // Genesis appears in both RECENTS (pinned current book) and ALL BOOKS;
+    // select the ALL BOOKS instance (last match), matching the Psalms pattern below.
+    const genesisButtons = screen.getAllByLabelText('Genesis, 50 chapters');
+    fireEvent.press(genesisButtons[genesisButtons.length - 1]);
 
     // Wait for chapter grid to render
     await waitFor(() => {
@@ -284,8 +288,10 @@ describe('BibleNavigationModal', () => {
       );
 
       // Select Genesis from book list
-      const genesisButton = screen.getByLabelText('Genesis, 50 chapters');
-      fireEvent.press(genesisButton);
+      // Genesis appears in both RECENTS (pinned current book) and ALL BOOKS;
+      // select the ALL BOOKS instance (last match).
+      const genesisButtons = screen.getAllByLabelText('Genesis, 50 chapters');
+      fireEvent.press(genesisButtons[genesisButtons.length - 1]);
 
       // Wait for chapter grid
       await waitFor(() => {

--- a/components/bible/BibleNavigationModal.tsx
+++ b/components/bible/BibleNavigationModal.tsx
@@ -72,7 +72,7 @@ import {
   type ThemeMode,
 } from '@/theme/tokens';
 import type { BookMetadata, Testament } from '@/types/bible';
-import { getTestamentFromBookId } from '@/types/bible';
+import { getTestamentFromBookId, MAX_RECENT_BOOKS } from '@/types/bible';
 import type { TopicCategory } from '@/types/topics';
 
 interface BibleNavigationModalProps {
@@ -369,14 +369,20 @@ function BibleNavigationModalComponent({
     });
   }, [currentTopics, topicFilterText]);
 
-  // Recent books across all testaments (sorted by timestamp)
+  // Recent books across all testaments — current book always at position 0
   const recentBooksFiltered = useMemo(() => {
-    // Sort by timestamp (most recent first)
-    return recentBooks
+    // Build stored list, removing any entry that matches currentBookId (dedup)
+    const stored = recentBooks
+      .filter((rb) => rb.bookId !== currentBookId)
       .sort((a, b) => b.timestamp - a.timestamp)
       .map((rb) => allBooks.find((b) => b.id === rb.bookId))
-      .filter((book): book is BookMetadata => book !== undefined);
-  }, [allBooks, recentBooks]);
+      .filter((book): book is BookMetadata => book !== undefined)
+      .slice(0, MAX_RECENT_BOOKS - 1); // leave room for current book at position 0
+
+    // Inject current book at position 0
+    const currentBook = allBooks.find((b) => b.id === currentBookId);
+    return currentBook ? [currentBook, ...stored] : stored;
+  }, [allBooks, recentBooks, currentBookId]);
 
   // Build SectionList sections for book list
   const bookSections = useMemo((): BookListSection[] => {


### PR DESCRIPTION
## Summary

Implements **T1** from the approved spec at `verse-mate-meta/specs/2026-05-16-1200-recents-current-book/` (merged via verse-mate-meta PR #10).

In `BibleNavigationModal.tsx`, the `recentBooksFiltered` useMemo now pins the currently-reading book at position 0 of the RECENTS list, deduping any stored copy.

## Business rules enforced

- **br-rec-001:** Current book is always at position 0 when `currentBookId` is provided.
- **br-rec-002:** Stored duplicate of current book is removed before injection.
- **br-rec-003:** Total displayed count ≤ `MAX_RECENT_BOOKS` (4). Current book counts as one.
- **br-rec-004:** Write path (`addRecentBook`) unchanged — pure display fix.

## Verification

- `bun run type-check` — passes.
- Existing Jest suite for this component fails with a pre-existing `actImplementation is not a function` setup error (confirmed on `main` prior to this change). Not caused by this PR; tracked separately.
- Manual smoke required per spec acceptance: open app → open nav modal → current book is first in RECENTS → navigate elsewhere → reopen modal → new current book is first, previous one second, no duplicates.

## Linked issue

- VER-94 (Paperclip issue)

## Out of scope

- Write-path changes to `addRecentBook` / `useRecentBooks`.
- VER-40 "search broken" symptom (separate ticket).
- Visual treatment beyond position 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)