### PR TITLE
fix(offline): stop lying that Insight tabs don't exist when offline (VER-39)

### DIFF
--- a/__tests__/components/bible/ChapterPage.test.tsx
+++ b/__tests__/components/bible/ChapterPage.test.tsx
@@ -69,6 +69,14 @@ jest.mock('@/contexts/AuthContext', () => ({
   })),
 }));
 
+// Mock NetInfo so useOfflineStatus (now called inside TabContent for VER-39) can
+// initialise without hitting the real native module. Mirrors the stub used in
+// the other Bible-tree tests (chapterNumber.test.tsx, topic-swipe-integration.test.tsx).
+jest.mock('@react-native-community/netinfo', () => ({
+  addEventListener: jest.fn(() => jest.fn()),
+  fetch: jest.fn(() => Promise.resolve({ isInternetReachable: true })),
+}));
+
 // Mock Safe Area Context (used by ToastProvider)
 jest.mock('react-native-safe-area-context', () => ({
   SafeAreaProvider: jest.fn(({ children }) => children),

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -31,6 +31,7 @@ import { NotesModal } from '@/components/bible/NotesModal';
 import { NoteViewModal } from '@/components/bible/NoteViewModal';
 import { VerseMateTooltip } from '@/components/bible/VerseMateTooltip';
 import { AvailableOfflineBadge } from '@/components/offline/AvailableOfflineBadge';
+import { OfflineContentUnavailable } from '@/components/offline/OfflineContentUnavailable';
 import { useAuth } from '@/contexts/AuthContext';
 import { useBibleInteraction } from '@/contexts/BibleInteractionContext';
 import { TextVisibilityContext, type VisibleYRange } from '@/contexts/TextVisibilityContext';
@@ -38,6 +39,7 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import { useNotes } from '@/hooks/bible/use-notes';
+import { useOfflineStatus } from '@/hooks/bible/use-offline-status';
 import { usePreferredLanguage } from '@/hooks/use-preferred-language';
 import { useBibleByLine, useBibleChapter, useBibleDetailed, useBibleSummary } from '@/src/api';
 import { animations, type getColors, spacing } from '@/theme/tokens';
@@ -133,6 +135,7 @@ function TabContent({
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
   const styles = createStyles(colors, insets.bottom); // Use local createStyles for TabContent
+  const { isOffline } = useOfflineStatus();
 
   const isHidden = !visible;
   if (isHidden && !shouldRenderHidden) return null;
@@ -179,26 +182,38 @@ function TabContent({
       onContentSizeChange={onTabContentSizeChange}
     >
       {error ? (
-        <Animated.View
-          entering={FadeIn.duration(animations.tabSwitch.duration)}
-          exiting={FadeOut.duration(animations.tabSwitch.duration)}
-          style={styles.errorContainer}
-        >
-          <Text style={styles.errorText}>Failed to load {activeTab} explanation.</Text>
-        </Animated.View>
+        isOffline ? (
+          <OfflineContentUnavailable contentType="explanation" />
+        ) : (
+          <Animated.View
+            entering={FadeIn.duration(animations.tabSwitch.duration)}
+            exiting={FadeOut.duration(animations.tabSwitch.duration)}
+            style={styles.errorContainer}
+          >
+            <Text style={styles.errorText}>Failed to load {activeTab} explanation.</Text>
+          </Animated.View>
+        )
       ) : showSkeleton ? (
         // Only show skeleton on initial load when no content exists yet
         <SkeletonLoader />
       ) : !hasContent ? (
-        <Animated.View
-          entering={FadeIn.duration(animations.tabSwitch.duration)}
-          exiting={FadeOut.duration(animations.tabSwitch.duration)}
-          style={styles.errorContainer}
-        >
-          <Text style={styles.errorText}>
-            No {activeTab} explanation available for this chapter yet.
-          </Text>
-        </Animated.View>
+        // VER-39: When offline and the explanation isn't cached locally, the
+        // remote fetch fails (or never resolves) and we'd otherwise lie that
+        // the content doesn't exist. Match BibleExplanationsPanel and surface
+        // the proper "You're offline / Manage Downloads" placeholder instead.
+        isOffline ? (
+          <OfflineContentUnavailable contentType="explanation" />
+        ) : (
+          <Animated.View
+            entering={FadeIn.duration(animations.tabSwitch.duration)}
+            exiting={FadeOut.duration(animations.tabSwitch.duration)}
+            style={styles.errorContainer}
+          >
+            <Text style={styles.errorText}>
+              No {activeTab} explanation available for this chapter yet.
+            </Text>
+          </Animated.View>
+        )
       ) : (
         <View>
           {/* TASK-017: audio entry is also mounted in BibleExplanationsPanel


### PR DESCRIPTION
## Summary

Fix [VER-39](/VER/issues/VER-39): the phone-portrait commentary view was telling users a chapter's Detailed/By Line/Summary explanation *doesn't exist* whenever the device was offline and the explanation hadn't been cached in React Query yet. The split-view sibling (`BibleExplanationsPanel`) already routes that case to `OfflineContentUnavailable` (the proper "You're offline / Manage Downloads" placeholder). PR #259's offline hardening missed the phone-portrait `TabContent` inside `ChapterPage.tsx`. This PR mirrors the same pattern there.

QA's smoking-gun pair on Jude 1 (`mobile.versemate.org`, mobile viewport):

- **Online — Detailed:** shows "In-Depth Analysis of Jude 1" with a full Introduction.
- **Offline — Detailed (before this PR):** "No detailed explanation available for this chapter yet." (a lie).
- **Offline — Detailed (after this PR):** the existing offline placeholder with the **Manage Downloads** call-to-action that the rest of the app already uses for cold-offline chapters.

### Behavior matrix after the fix

| Path | Online | Offline |
|---|---|---|
| `error` set | "Failed to load X explanation." (unchanged) | `OfflineContentUnavailable` (new) |
| `!hasContent` (data resolved empty) | "No X explanation available for this chapter yet." (unchanged) | `OfflineContentUnavailable` (new) |
| `hasContent` | renders content (unchanged) | renders content (unchanged) |

### Scope notes

- Single-component, single-branch fix on an existing surface. Per VER-28's spec gate, this is the trivial-work exemption (regression fix, no contract/data-model change).
- Out of scope: the underlying reason Detailed often has *no* cached data when offline. On web, `services/offline/sqlite-manager.web.ts` is a no-op stub, and `usePrefetchPreviousChapter` / `usePrefetchNextChapter` only prefetch `summary` for adjacent chapters. Making Insight tabs actually-available offline (vs. correctly-messaged offline) is a separate product call about how much of the Insight bundle to auto-cache — not what this bug asked for.

## Test plan

- [x] `bun tsc --noEmit` clean.
- [x] `bun run lint` clean (0 errors; the 270 warnings are all preexisting `i18next/no-literal-string` from elsewhere in the repo).
- [ ] **QA needs to re-verify the original repro on `mobile.versemate.org`** (390x844, force offline, navigate via Previous chapter, tap Insight → Detailed): expected outcome is the offline placeholder instead of "No detailed explanation available for this chapter yet."
- [ ] Native iOS / Android paths: I cannot drive a simulator from this environment. Native re-verification stays a QA follow-up. The change is platform-agnostic (uses the same `useOfflineStatus` hook the split-view sibling has been using on native + web since PR #259), so the risk is low.
- [ ] **Pre-existing test infra note:** `__tests__/components/bible/ChapterPage.test.tsx` is currently broken on `main` with `TypeError: actImplementation is not a function`. Same on every test that calls `@testing-library/react-native`'s `render` against this component. Not introduced by this PR; flagging so the next person touching ChapterPage doesn't burn time on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)