### PR TITLE
fix(byline): decouple verse-jump pill hit area from opacity animation (VER-102)

### DIFF
--- a/__tests__/components/bible/VerseJumpButton.test.tsx
+++ b/__tests__/components/bible/VerseJumpButton.test.tsx
@@ -55,6 +55,35 @@ describe('VerseJumpButton', () => {
     expect(onInteraction).toHaveBeenCalledTimes(1);
   });
 
+  it('keeps the hit-test container static so faded pill stays tappable on web (VER-102)', () => {
+    // Regression: on web, Reanimated opacity on a Pressable's parent suppresses
+    // pointer events on the child (VER-46). The Pressable's ancestor chain up
+    // to the absolute-positioned container must therefore carry no opacity
+    // style. The animated opacity must live INSIDE the Pressable, not above it.
+    const onSelect = jest.fn();
+    const { getByTestId } = renderWithProviders(
+      <VerseJumpButton verses={[1, 2, 3]} onSelect={onSelect} visible={false} />
+    );
+
+    const flatten = (style: unknown): Record<string, unknown>[] => {
+      if (!style) return [];
+      if (Array.isArray(style)) return style.flatMap(flatten);
+      if (typeof style === 'object') return [style as Record<string, unknown>];
+      return [];
+    };
+
+    let node: ReturnType<typeof getByTestId>['parent'] = getByTestId('verse-jump-button').parent;
+    let hops = 0;
+    while (node && hops < 5) {
+      const styles = flatten(node.props?.style);
+      for (const layer of styles) {
+        expect(layer).not.toHaveProperty('opacity');
+      }
+      node = node.parent;
+      hops += 1;
+    }
+  });
+
   it('opens the modal and lists every supplied verse on tap', () => {
     const onSelect = jest.fn();
     renderWithProviders(<VerseJumpButton verses={[1, 2, 17, 176]} onSelect={onSelect} />);

--- a/components/bible/VerseJumpButton.tsx
+++ b/components/bible/VerseJumpButton.tsx
@@ -11,7 +11,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { useEffect, useState } from 'react';
-import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text } from 'react-native';
+import { Modal, Platform, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, { useAnimatedStyle, useSharedValue, withTiming } from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
 import {
@@ -30,9 +30,12 @@ export interface VerseJumpButtonProps {
   onSelect: (verseNumber: number) => void;
   /**
    * Drives the fade-in/out animation. Mirrors the scroll-arrow auto-hide so
-   * the pill disappears on idle and reappears on scroll/tap (VERA-39). The
-   * pill stays mounted at opacity 0 — tapping the faded pill still opens the
-   * verse picker, matching the no-dead-zone arrow behavior.
+   * the pill disappears on idle and reappears on scroll/tap (VERA-39). Only
+   * the visual chrome (gold circle + icon + label) fades — the outer hit area
+   * stays a static View so taps on the faded pill still open the verse picker
+   * on web (VER-102). Reanimated's parent-opacity suppresses pointer events
+   * on web Pressables (VER-46), so the animated wrapper must live inside the
+   * Pressable, not around it.
    */
   visible?: boolean;
   /**
@@ -71,8 +74,8 @@ export function VerseJumpButton({
   const [open, setOpen] = useState(false);
   const styles = createStyles(mode, colors, bottomOffset);
 
-  // Mirror FloatingActionButtons fade — pill stays mounted at opacity 0 so
-  // tapping the faded pill area still opens the picker (VERA-39).
+  // Mirror FloatingActionButtons fade — only the inner chrome animates so the
+  // outer hit area remains tappable at opacity 0 (VERA-39 / VER-102).
   const opacity = useSharedValue(visible ? 1 : 0);
   useEffect(() => {
     opacity.value = withTiming(visible ? 1 : 0, {
@@ -101,21 +104,28 @@ export function VerseJumpButton({
 
   return (
     <>
-      <Animated.View style={[styles.fabContainer, animatedStyle]}>
+      {/* Static container so the hit area stays interactive at any opacity.
+          On web, Reanimated's parent-opacity suppresses pointer events on
+          child Pressables (VER-46). Only the visual chrome inside fades. */}
+      <View style={styles.fabContainer}>
         <Pressable
           onPress={handleOpen}
-          style={({ pressed }) => [styles.fab, pressed && styles.fabPressed]}
+          style={styles.fabHitArea}
           accessibilityLabel="Jump to verse"
           accessibilityRole="button"
           accessibilityHint="Open the list of verses to jump to one in the By Line view"
           testID={testID}
         >
-          <Ionicons name="list" size={22} color="#ffffff" />
-          <Text style={styles.fabLabel} accessibilityElementsHidden>
-            Verse
-          </Text>
+          {({ pressed }) => (
+            <Animated.View style={[styles.fab, pressed && styles.fabPressed, animatedStyle]}>
+              <Ionicons name="list" size={22} color="#ffffff" />
+              <Text style={styles.fabLabel} accessibilityElementsHidden>
+                Verse
+              </Text>
+            </Animated.View>
+          )}
         </Pressable>
-      </Animated.View>
+      </View>
       <Modal
         visible={open}
         animationType="fade"
@@ -166,9 +176,8 @@ const createStyles = (
   bottomOffset?: number
 ) =>
   StyleSheet.create({
-    // Animated wrapper drives fade-in/out (VERA-39). The Pressable inside
-    // retains its hit-target even at opacity 0, so taps on the faded pill
-    // still open the verse picker — mirrors FloatingActionButtons.
+    // Static positioning wrapper — never animated, so the hit area underneath
+    // stays interactive at opacity 0 (VER-102, mirrors FloatingActionButtons).
     fabContainer: {
       position: 'absolute',
       right: spacing.lg,
@@ -176,6 +185,11 @@ const createStyles = (
       // path through ChapterPage). Hosts without a chapter-nav row beneath the
       // ScrollView (split-view / desktop right panel) override via bottomOffset.
       bottom: bottomOffset ?? spacing.lg + 60 + 56 + spacing.md,
+      width: FAB_SIZE,
+      height: FAB_SIZE,
+    },
+    // Hit area for the Pressable — full FAB footprint, always active.
+    fabHitArea: {
       width: FAB_SIZE,
       height: FAB_SIZE,
     },


### PR DESCRIPTION
## Summary

- Applies the [VER-46](/VER/issues/VER-46) / PR #311 fix recipe to `VerseJumpButton`: outer container is now a static `View` and the `Animated.View` opacity wrapper lives inside the `Pressable`, around only the visual chrome.
- On web, Reanimated's parent-opacity suppresses pointer events on child `Pressable`s, so taps at the faded-pill position previously fell through to verse text beneath. Hit area is now always interactive regardless of opacity.
- Existing fade-in / fade-out timing preserved. Adds a structural regression test that walks the Pressable's ancestor chain and asserts no parent `View` carries an opacity style.

Issue: [VER-102](/VER/issues/VER-102)
Audit source: [VER-99](/VER/issues/VER-99)
Pattern reference: PR #311 (FloatingActionButtons)

## Test plan

- [ ] Web (RN Web): tap pill at full opacity opens picker
- [ ] Web (RN Web): wait for auto-hide fade, tap the now-invisible pill area — picker still opens (the bug this fixes)
- [ ] Web (RN Web): tap anywhere outside the 52×52 pill footprint at opacity 0 → does NOT open the picker (no false-positive expansion of hit area)
- [ ] iOS simulator: same three flows above
- [ ] Android emulator: same three flows above
- [ ] Verify fade-in/out timing visually matches the prior behavior (no jank, no double-fade)
- [ ] `npm test -- VerseJumpButton` passes (covers the new VER-102 regression test once local Jest infra is healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)