### PR TITLE
fix(splitview): keep edge-tab hit area active when faded (VER-103)

### DIFF
--- a/__tests__/components/ui/SplitView.test.tsx
+++ b/__tests__/components/ui/SplitView.test.tsx
@@ -137,4 +137,61 @@ describe('SplitView', () => {
     expect(screen.queryByTestId('left-content')).toBeNull();
     expect(screen.queryByTestId('right-content')).toBeNull();
   });
+
+  // Regression test for VER-103: the edge-tab Pressable hit area must stay reachable
+  // even when edgeTabsVisible=false (i.e. opacity has faded to 0). The opacity
+  // animation is intentionally scoped to an inner Reanimated.View so Pressable.onPress
+  // still fires when the visual chrome is invisible. Mirrors the VER-46 / PR #311 fix.
+  describe('edge-tab hit-test (VER-103 regression)', () => {
+    it('fires left edge-tab onPress when edgeTabsVisible=false (right-full mode)', () => {
+      const onViewModeChange = jest.fn();
+      render(
+        <SplitView
+          {...defaultProps}
+          viewMode="right-full"
+          edgeTabsVisible={false}
+          onViewModeChange={onViewModeChange}
+        />
+      );
+      simulateLayout('split-view');
+
+      const leftTabButton = screen.getByTestId('split-view-left-edge-tab-button');
+      fireEvent.press(leftTabButton);
+
+      expect(onViewModeChange).toHaveBeenCalledWith('split');
+    });
+
+    it('fires right edge-tab onPress when edgeTabsVisible=false (left-full mode)', () => {
+      const onViewModeChange = jest.fn();
+      render(
+        <SplitView
+          {...defaultProps}
+          viewMode="left-full"
+          edgeTabsVisible={false}
+          onViewModeChange={onViewModeChange}
+        />
+      );
+      simulateLayout('split-view');
+
+      const rightTabButton = screen.getByTestId('split-view-right-edge-tab-button');
+      fireEvent.press(rightTabButton);
+
+      expect(onViewModeChange).toHaveBeenCalledWith('split');
+    });
+
+    it('does not put opacity on the outer edge-tab wrapper', () => {
+      render(<SplitView {...defaultProps} viewMode="right-full" edgeTabsVisible={false} />);
+      simulateLayout('split-view');
+
+      // The outer wrapper carries slide-only animated style; opacity must live on the
+      // inner visual chrome so the hit area remains active during fade.
+      const leftEdgeTab = screen.getByTestId('split-view-left-edge-tab');
+      const flatten = (style: unknown): Record<string, unknown> => {
+        if (Array.isArray(style)) return Object.assign({}, ...style.map(flatten));
+        return (style as Record<string, unknown>) ?? {};
+      };
+      const merged = flatten(leftEdgeTab.props.style);
+      expect(merged.opacity).toBeUndefined();
+    });
+  });
 });

--- a/components/ui/SplitView.tsx
+++ b/components/ui/SplitView.tsx
@@ -604,12 +604,20 @@ export function SplitView({
 
   const leftTargetButtonStyle = useAnimatedStyle(() => ({ opacity: leftTargetOpacity.value }));
   const rightTargetButtonStyle = useAnimatedStyle(() => ({ opacity: rightTargetOpacity.value }));
+  // Slide-only style for the outer container — transforms are safe to animate without
+  // breaking hit-test on web. Opacity is split into its own inner-only style below
+  // (VER-103, mirrors PR #311 / VER-46 fix in FloatingActionButtons).
   const leftEdgeTabStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: leftEdgeTabSlideAnim.value }],
-    opacity: edgeTabsOpacity.value,
   }));
   const rightEdgeTabStyle = useAnimatedStyle(() => ({
     transform: [{ translateX: rightEdgeTabSlideAnim.value }],
+  }));
+  // Opacity-only style applied to the visual chrome *inside* the Pressable. On web,
+  // Reanimated's opacity animation on a parent suppresses pointer events on children
+  // even with pointerEvents="box-none" — keep the hit area un-animated so taps on
+  // faded edge tabs still reach the Pressable.
+  const edgeTabsOpacityStyle = useAnimatedStyle(() => ({
     opacity: edgeTabsOpacity.value,
   }));
 
@@ -660,16 +668,23 @@ export function SplitView({
           <Reanimated.View
             style={[styles.edgeTab, styles.leftEdgeTab, leftEdgeTabStyle]}
             pointerEvents={viewMode === 'right-full' ? 'box-none' : 'none'}
+            testID={`${testID}-left-edge-tab`}
           >
             <Pressable
-              style={[
-                styles.edgeTabButton,
-                styles.leftEdgeTabButton,
-                { backgroundColor: colors.backgroundElevated },
-              ]}
+              style={styles.edgeTabHitArea}
               onPress={() => onViewModeChange?.('split')}
+              testID={`${testID}-left-edge-tab-button`}
             >
-              <Ionicons name="chevron-forward" size={20} color={colors.textPrimary} />
+              <Reanimated.View
+                style={[
+                  styles.edgeTabButton,
+                  styles.leftEdgeTabButton,
+                  { backgroundColor: colors.backgroundElevated },
+                  edgeTabsOpacityStyle,
+                ]}
+              >
+                <Ionicons name="chevron-forward" size={20} color={colors.textPrimary} />
+              </Reanimated.View>
             </Pressable>
           </Reanimated.View>
 
@@ -743,16 +758,23 @@ export function SplitView({
           <Reanimated.View
             style={[styles.edgeTab, styles.rightEdgeTab, rightEdgeTabStyle]}
             pointerEvents={viewMode === 'left-full' ? 'box-none' : 'none'}
+            testID={`${testID}-right-edge-tab`}
           >
             <Pressable
-              style={[
-                styles.edgeTabButton,
-                styles.rightEdgeTabButton,
-                { backgroundColor: colors.backgroundElevated },
-              ]}
+              style={styles.edgeTabHitArea}
               onPress={() => onViewModeChange?.('split')}
+              testID={`${testID}-right-edge-tab-button`}
             >
-              <Ionicons name="chevron-back" size={20} color={colors.textPrimary} />
+              <Reanimated.View
+                style={[
+                  styles.edgeTabButton,
+                  styles.rightEdgeTabButton,
+                  { backgroundColor: colors.backgroundElevated },
+                  edgeTabsOpacityStyle,
+                ]}
+              >
+                <Ionicons name="chevron-back" size={20} color={colors.textPrimary} />
+              </Reanimated.View>
             </Pressable>
           </Reanimated.View>
         </>
@@ -869,6 +891,14 @@ function createStyles(
       paddingRight: insets.right,
       alignItems: 'flex-end', // Align button to right edge
     },
+    // Hit area for each edge tab. Same dimensions and vertical offset as the visual
+    // button, but always interactive — opacity animation lives on the inner
+    // Reanimated.View so a faded edge tab still receives taps (VER-103).
+    edgeTabHitArea: {
+      width: 32,
+      height: 64,
+      transform: [{ translateY: -80 }],
+    },
     edgeTabButton: {
       width: 32,
       height: 64,
@@ -882,8 +912,6 @@ function createStyles(
       shadowOpacity: 0.15,
       shadowRadius: 4,
       elevation: 4,
-      pointerEvents: 'box-only', // Only this element captures touches
-      transform: [{ translateY: -80 }],
     },
     leftEdgeTabButton: {
       // Half-circle glued to left edge (rounded on right side only)

--- a/components/ui/SplitView.web.tsx
+++ b/components/ui/SplitView.web.tsx
@@ -227,17 +227,21 @@ export function SplitView({
           </View>
 
           {/* Left Edge Tab (visible when right-full) */}
+          {/* pointerEvents lives on the View prop, not in the inline style — */}
+          {/* RNW translates inline pointerEvents to an inline `pointer-events` */}
+          {/* declaration that its reconciler intermittently fails to clear when */}
+          {/* the value transitions from 'none' to 'box-none' (VER-103). */}
           <View
             style={[
               styles.edgeTab,
               styles.leftEdgeTab,
               {
                 opacity: isRightFull && edgeTabsVisible ? 1 : 0,
-                pointerEvents: isRightFull ? 'box-none' : 'none',
                 transitionProperty: 'opacity',
                 transitionDuration: TRANSITION_MS,
               } as any,
             ]}
+            pointerEvents={isRightFull ? 'box-none' : 'none'}
             testID={`${testID}-left-edge-tab`}
           >
             <Pressable
@@ -247,6 +251,7 @@ export function SplitView({
                 { backgroundColor: colors.backgroundElevated },
               ]}
               onPress={() => onViewModeChange?.('split')}
+              testID={`${testID}-left-edge-tab-button`}
             >
               <Ionicons name="chevron-forward" size={20} color={colors.textPrimary} />
             </Pressable>
@@ -259,11 +264,11 @@ export function SplitView({
               styles.rightEdgeTab,
               {
                 opacity: isLeftFull && edgeTabsVisible ? 1 : 0,
-                pointerEvents: isLeftFull ? 'box-none' : 'none',
                 transitionProperty: 'opacity',
                 transitionDuration: TRANSITION_MS,
               } as any,
             ]}
+            pointerEvents={isLeftFull ? 'box-none' : 'none'}
             testID={`${testID}-right-edge-tab`}
           >
             <Pressable
@@ -273,6 +278,7 @@ export function SplitView({
                 { backgroundColor: colors.backgroundElevated },
               ]}
               onPress={() => onViewModeChange?.('split')}
+              testID={`${testID}-right-edge-tab-button`}
             >
               <Ionicons name="chevron-back" size={20} color={colors.textPrimary} />
             </Pressable>


### PR DESCRIPTION
## Summary

Fixes edge-tab hit-test fallthrough on both native and web platforms.

### Native (\`SplitView.tsx\`)
Applies the VER-46 / PR #311 pattern: decouples the opacity animation from the hit-test region by moving the fade-bearing \`Reanimated.View\` inside the \`Pressable\` (wrapping visual chrome only). The outer positioning wrapper retains only translate/slide transforms, which don't suppress pointer events.

### Web (\`SplitView.web.tsx\`)
Fixes a separate RNW inline-\`pointerEvents\` reconciliation bug found by QA. When transitioning from \`pointerEvents:'none'\` → \`'box-none'\` via inline style, RNW's reconciler intermittently fails to clear the inline \`pointer-events: none\` DOM declaration (~33% hit-test fallthrough). Fix: move \`pointerEvents\` to the \`View\` prop, which RNW maps to a stable atomic CSS class.

Also adds \`testID\` to each edge-tab \`Pressable\` on the web variant to match the native testID contract.

## Tests

Regression tests added for the native fix (\`__tests__/components/ui/SplitView.test.tsx\`):
- Fires left edge-tab \`onPress\` when \`edgeTabsVisible=false\` (right-full mode)
- Fires right edge-tab \`onPress\` when \`edgeTabsVisible=false\` (left-full mode)
- Asserts opacity does not live on the outer edge-tab wrapper

Note: RTL × React 19 infra issue (pre-existing) prevents running the suite locally.

## QA preview

Cloudflare Workers preview auto-deploys on push. Please re-verify at the preview URL.