### PR TITLE
test(nav): assert current book in Recents on first modal open (VER-97)

### DIFF
--- a/.maestro/recents/recents-flow.yaml
+++ b/.maestro/recents/recents-flow.yaml
@@ -25,6 +25,30 @@ tags:
     timeout: 30000
 
 # ============================================
+# Test 0: Current book appears in Recents immediately (no prior navigation)
+# ============================================
+
+# Open navigation modal before navigating anywhere
+- tapOn:
+    id: "chapter-selector-button"
+
+- assertVisible:
+    id: "bible-navigation-modal"
+
+# RECENTS section must be visible with the currently-open book (Genesis)
+- assertVisible:
+    text: "RECENTS"
+
+- assertVisible:
+    id: "book-item-genesis"
+
+# Close modal
+- tapOn:
+    id: "close-modal-button"
+
+- waitForAnimationToEnd
+
+# ============================================
 # Test 1: Navigate to Multiple Books
 # ============================================
 

--- a/components/bible/BibleNavigationModal.tsx
+++ b/components/bible/BibleNavigationModal.tsx
@@ -1001,7 +1001,7 @@ function BibleNavigationModalComponent({
       >
         {/* Backdrop that handles both tap to close and swipe to dismiss - positioned first to be behind modal */}
         <GestureDetector gesture={Gesture.Simultaneous(backdropPanGesture, backdropTapGesture)}>
-          <Animated.View style={styles.backdropTouchable} />
+          <Animated.View style={styles.backdropTouchable} testID="close-modal-button" />
         </GestureDetector>
         <Animated.View
           style={[styles.container, animatedModalStyle]}


### PR DESCRIPTION
## Summary

- Extends `.maestro/recents/recents-flow.yaml` with a **Test 0** block that opens the navigation modal before any navigation has occurred and asserts the currently-open book (Genesis) is visible in the RECENTS section — proving the VER-94 pin fix holds end-to-end.
- Adds `testID="close-modal-button"` to the backdrop touchable in `BibleNavigationModal.tsx`. The spec block taps this ID to close the modal, but no such testID existed; the backdrop already closes the modal on tap — this is a purely labelling change with no behavioral impact.

## Spec

`verse-mate-meta/specs/2026-05-16-1200-recents-current-book/` — T3, merged via PR #10.

## Depends on

- VER-94 fix merged to main in #314 ✅

## Test plan

- [ ] `maestro test .maestro/recents/recents-flow.yaml` on a clean iOS simulator starting at Genesis 1 — all four test blocks (0, 1, 2, 3) should pass
- [ ] Verify modal closes cleanly after Test 0 tap on backdrop and Test 1 navigation proceeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)