### PR TITLE
feat(bible): Study tab + StudyPanel — full 1,189-chapter Bible coverage on mobile

### DIFF
--- a/__tests__/components/bible/ChapterPage.test.tsx
+++ b/__tests__/components/bible/ChapterPage.test.tsx
@@ -91,6 +91,13 @@ jest.mock('@/components/bible/ChapterReader', () => ({
   },
 }));
 
+jest.mock('@/components/bible/StudyPanel', () => ({
+  StudyPanel: () => {
+    const { Text } = require('react-native');
+    return <Text testID="study-panel">StudyPanel</Text>;
+  },
+}));
+
 // Mock modals to avoid complex rendering in ChapterPage tests
 jest.mock('@/components/bible/NotesModal', () => ({
   NotesModal: ({ visible }: any) => {

--- a/__tests__/components/bible/StudyPanel.test.tsx
+++ b/__tests__/components/bible/StudyPanel.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * StudyPanel Component Tests
+ *
+ * Smoke tests for the inductive-study renderer. Covers:
+ *   - empty / loading states
+ *   - collapse-by-default behavior
+ *   - Expand All / Collapse All toggle
+ *   - per-card toggling
+ *   - Copy button invokes the clipboard with the serialized payload
+ *
+ * The `@versemate/studies` package is mocked so tests stay deterministic and
+ * don't depend on shipped chapter content evolving over time.
+ */
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import type React from 'react';
+import { StudyPanel } from '@/components/bible/StudyPanel';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+
+jest.mock('expo-clipboard', () => ({
+  setStringAsync: jest.fn(() => Promise.resolve()),
+}));
+// Render markdown children as plain Text so body strings show up in queries.
+jest.mock('react-native-markdown-display', () => {
+  // biome-ignore lint/correctness/noUnusedVariables: required inside factory
+  const React = require('react');
+  const { Text } = require('react-native');
+  return function MockMarkdown({ children }: { children: string }) {
+    return React.createElement(Text, null, children);
+  };
+});
+
+const mockGetStudyFor = jest.fn();
+jest.mock('@versemate/studies', () => ({
+  getStudyFor: (...args: unknown[]) => mockGetStudyFor(...args),
+}));
+
+import * as Clipboard from 'expo-clipboard';
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+const minimalStudy = {
+  bookName: 'James',
+  title: 'James 1',
+  subtitle: 'Testing your faith',
+  themeOneLine: 'Faith stands firm under trial.',
+  steps: [
+    {
+      number: 1,
+      kind: 'prose' as const,
+      title: 'Begin with prayer',
+      summary: 'Ask the Author before you read.',
+      body: 'Open the chapter prayerfully.',
+    },
+    {
+      number: 2,
+      kind: 'qa' as const,
+      title: 'Ask who, what, when, where',
+      summary: 'Find the 5 Ws.',
+      items: [
+        { tag: 'WHO', q: 'Who wrote this?', a: 'James, a servant of God.' },
+        { q: 'When was it written?', a: 'Early — pre-AD 50.' },
+      ],
+    },
+  ],
+  interpretation: {
+    intro: 'Reading the movements in order',
+    movements: [
+      {
+        number: 1,
+        range: '1:1-12',
+        title: 'Trials produce maturity',
+        body: 'When trials come, count it joy.',
+      },
+    ],
+  },
+  application: {
+    intro: 'One question per movement.',
+    questions: [{ range: '1:1-12', question: 'What trial are you facing today?' }],
+  },
+};
+
+describe('StudyPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows loading state before the chapter resolves', () => {
+    // Never resolve so loading state stays visible
+    mockGetStudyFor.mockReturnValue(new Promise(() => {}));
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
+
+    expect(screen.getByTestId('study-panel-loading')).toBeTruthy();
+  });
+
+  it('shows empty state when no study is available', async () => {
+    mockGetStudyFor.mockResolvedValue(null);
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={99} />);
+
+    await waitFor(() => expect(screen.getByTestId('study-panel-empty')).toBeTruthy());
+  });
+
+  it('renders title + theme line and starts collapsed', async () => {
+    mockGetStudyFor.mockResolvedValue(minimalStudy);
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('study-panel-title')).toBeTruthy());
+
+    expect(screen.getByTestId('study-panel-theme')).toBeTruthy();
+    // Step 1 card exists (collapsed)
+    expect(screen.getByTestId('study-panel-step-1')).toBeTruthy();
+    // Body text from the prose step should NOT be visible while collapsed
+    expect(screen.queryByText('Open the chapter prayerfully.')).toBeNull();
+  });
+
+  it('Expand All reveals all card bodies; Collapse All hides them again', async () => {
+    mockGetStudyFor.mockResolvedValue(minimalStudy);
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('study-panel-toggle-all')).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId('study-panel-toggle-all'));
+    // Movement body becomes visible
+    expect(screen.getByText('When trials come, count it joy.')).toBeTruthy();
+    // Application question visible
+    expect(screen.getByText('What trial are you facing today?')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('study-panel-toggle-all'));
+    // Body re-hidden
+    expect(screen.queryByText('When trials come, count it joy.')).toBeNull();
+  });
+
+  it('toggling an individual step card overrides bulk state', async () => {
+    mockGetStudyFor.mockResolvedValue(minimalStudy);
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('study-panel-step-1-toggle')).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId('study-panel-step-1-toggle'));
+    // Step 2 is still collapsed
+    expect(screen.queryByText(/James, a servant of God\./)).toBeNull();
+  });
+
+  it('Copy button writes the serialized payload to the clipboard', async () => {
+    mockGetStudyFor.mockResolvedValue(minimalStudy);
+
+    renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
+
+    await waitFor(() => expect(screen.getByTestId('study-panel-copy')).toBeTruthy());
+
+    fireEvent.press(screen.getByTestId('study-panel-copy'));
+
+    await waitFor(() => expect(Clipboard.setStringAsync).toHaveBeenCalledTimes(1));
+    const payload = (Clipboard.setStringAsync as jest.Mock).mock.calls[0][0] as string;
+    expect(payload).toContain('Inductive Study of James 1');
+    expect(payload).toContain('Theme: Faith stands firm under trial.');
+    expect(payload).toContain('OBSERVATION — 9 INDUCTIVE STEPS');
+    expect(payload).toContain('INTERPRETATION');
+    expect(payload).toContain('APPLICATION');
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
+        "@versemate/studies": "github:verse-mate/verse-mate-studies#4fa8065",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
         "expo-apple-authentication": "~8.0.8",
@@ -818,6 +819,8 @@
     "@urql/core": ["@urql/core@5.2.0", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.13", "wonka": "^6.3.2" } }, "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A=="],
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.3.2", "", { "dependencies": { "@urql/core": "^5.1.2", "wonka": "^6.3.2" } }, "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg=="],
+
+    "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#4fa8065", {}, "verse-mate-verse-mate-studies-4fa8065", "sha512-BNQXMCCTkPytDn+iD1ou7j9gbc/HdT02S6n0gLvv5A8pOooBcUS4Kyx/4i8z/xuWeEQebPw+S5H124lGr2OwZA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
-        "@versemate/studies": "github:verse-mate/verse-mate-studies#4fa8065",
+        "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
         "expo-apple-authentication": "~8.0.8",
@@ -820,7 +820,7 @@
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.3.2", "", { "dependencies": { "@urql/core": "^5.1.2", "wonka": "^6.3.2" } }, "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg=="],
 
-    "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#4fa8065", {}, "verse-mate-verse-mate-studies-4fa8065", "sha512-BNQXMCCTkPytDn+iD1ou7j9gbc/HdT02S6n0gLvv5A8pOooBcUS4Kyx/4i8z/xuWeEQebPw+S5H124lGr2OwZA=="],
+    "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#d9dadca", {}, "verse-mate-verse-mate-studies-d9dadca", "sha512-VrF35pG6eyGD5eigG0e535s5SsOChPkW3gE5iOOwgFc9jNx1PpPsWf6gFuW0/37jjrxoNas4aWeO0x+juct9HA=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -214,6 +214,7 @@ export function BibleExplanationsPanel({
     summaryScrollRef.current?.scrollTo({ y: 0, animated: false });
     byLineScrollRef.current?.scrollTo({ y: 0, animated: false });
     detailedScrollRef.current?.scrollTo({ y: 0, animated: false });
+    studyScrollRef.current?.scrollTo({ y: 0, animated: false });
     byLineSectionRefs.current = {};
   }, [bookId, chapterNumber]);
 

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -52,6 +52,7 @@ import { computeByLineJumpY } from '@/utils/bible/byLineJump';
 import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { AudioInlineEntry } from './AudioInlineEntry';
 import { ShareButton } from './ShareButton';
+import { StudyPanel } from './StudyPanel';
 import { VerseJumpButton } from './VerseJumpButton';
 
 /**
@@ -61,6 +62,7 @@ const TABS: { id: ContentTabType; label: string }[] = [
   { id: 'summary', label: 'Summary' },
   { id: 'byline', label: 'By Line' },
   { id: 'detailed', label: 'Detailed' },
+  { id: 'study', label: 'Study' },
 ];
 
 /**
@@ -199,6 +201,7 @@ export function BibleExplanationsPanel({
   const summaryScrollRef = useRef<ScrollView>(null);
   const byLineScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
+  const studyScrollRef = useRef<ScrollView>(null);
 
   // Quick-verse-jump (VERA-35 / VERA-36): refs to each rendered By Line
   // verse-section View. Populated when byline content is split into per-verse
@@ -430,11 +433,12 @@ export function BibleExplanationsPanel({
           style={styles.tabsRow}
           onLayout={(event) => {
             const { width } = event.nativeEvent.layout;
-            const singleTabWidth = (width - 16) / 3;
+            // 4 tabs: padding 8 + 3 gaps × 4 = 20 subtracted.
+            const singleTabWidth = (width - 20) / 4;
             setTabWidth(singleTabWidth);
           }}
         >
-          {/* Sliding active indicator */}
+          {/* Sliding active indicator. Animation indices match TABS order. */}
           <Animated.View
             style={[
               styles.slidingIndicator,
@@ -443,8 +447,8 @@ export function BibleExplanationsPanel({
                 transform: [
                   {
                     translateX: slideAnim.interpolate({
-                      inputRange: [0, 1, 2],
-                      outputRange: [0, tabWidth + 4, (tabWidth + 4) * 2],
+                      inputRange: [0, 1, 2, 3],
+                      outputRange: [0, tabWidth + 4, (tabWidth + 4) * 2, (tabWidth + 4) * 3],
                     }),
                   },
                 ],
@@ -569,6 +573,22 @@ export function BibleExplanationsPanel({
           )}
         </ScrollView>
       ))}
+
+      {/* Study tab — bundled content from @versemate/studies (no API fetch,
+          no loading state, no offline concerns). Always mounted, hidden
+          when not active so its scroll position persists across tab
+          switches like the other 3 tabs. */}
+      <ScrollView
+        ref={studyScrollRef}
+        style={[styles.scrollView, activeTab !== 'study' && { display: 'none' }]}
+        contentContainerStyle={styles.scrollContent}
+        showsVerticalScrollIndicator={true}
+        onScroll={activeTab === 'study' ? handleInternalScroll : undefined}
+        scrollEventThrottle={16}
+        testID={`${testID}-scroll-study`}
+      >
+        <StudyPanel bookId={bookId} chapter={chapterNumber} testID={`${testID}-study`} />
+      </ScrollView>
 
       {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
           beneath this ScrollView in split / desktop right panel, so use a

--- a/components/bible/ChapterContentTabs.tsx
+++ b/components/bible/ChapterContentTabs.tsx
@@ -34,12 +34,14 @@ interface ChapterContentTabsProps {
 }
 
 /**
- * Tab configuration
+ * Tab configuration. Order MUST match BibleExplanationsPanel.TABS — both
+ * components share the same animation index space.
  */
 const TABS = [
   { id: 'summary' as ContentTabType, label: 'Summary' },
   { id: 'byline' as ContentTabType, label: 'By Line' },
   { id: 'detailed' as ContentTabType, label: 'Detailed' },
+  { id: 'study' as ContentTabType, label: 'Study' },
 ] as const;
 
 /**
@@ -98,16 +100,18 @@ export function ChapterContentTabs({
   // Measure container width to calculate tab positions
   const handleLayout = (event: { nativeEvent: { layout: { width: number } } }) => {
     const { width } = event.nativeEvent.layout;
-    // Each tab width = (containerWidth - padding - gaps) / 3
-    // containerWidth - 8 (padding) - 8 (2 gaps of 4px) = containerWidth - 16
-    const singleTabWidth = (width - 16) / 3;
+    // Each tab width = (containerWidth - padding - gaps) / N
+    // containerWidth - 8 (padding 4 each side) - (N-1) × 4 (gaps) for N tabs.
+    // 4 tabs: 8 + 12 = 20 subtracted; width per tab = (W - 20) / 4.
+    const singleTabWidth = (width - 20) / 4;
     setTabWidth(singleTabWidth);
   };
 
-  // Calculate translateX for sliding indicator
+  // Calculate translateX for sliding indicator. inputRange/outputRange length
+  // must equal TABS.length; each step shifts by (tabWidth + 4 gap).
   const indicatorTranslateX = slideAnim.interpolate({
-    inputRange: [0, 1, 2],
-    outputRange: [0, tabWidth + 4, (tabWidth + 4) * 2], // Add gap (4px) between tabs
+    inputRange: [0, 1, 2, 3],
+    outputRange: [0, tabWidth + 4, (tabWidth + 4) * 2, (tabWidth + 4) * 3],
   });
 
   return (
@@ -190,7 +194,10 @@ const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => 
       flex: 1,
       borderRadius: 100,
       paddingVertical: 2,
-      paddingHorizontal: spacing.lg,
+      // Tight horizontal padding so 4 labels (Summary / By Line / Detailed /
+      // Study) fit on narrow phone widths without truncation. flex:1 already
+      // handles equal sizing; padding here is just for press hit area + edge.
+      paddingHorizontal: spacing.sm,
       justifyContent: 'center',
       alignItems: 'center',
       minHeight: 28,

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -50,6 +50,7 @@ import { parseByLineSections } from '@/utils/bible/parseByLineExplanation';
 import { BottomLogo } from './BottomLogo';
 import { ChapterReader } from './ChapterReader';
 import { SkeletonLoader } from './SkeletonLoader';
+import { StudyPanel } from './StudyPanel';
 import { VerseJumpButton } from './VerseJumpButton';
 
 // Styles for the overall ChapterPage component
@@ -331,6 +332,7 @@ export function ChapterPage({
   const byLineScrollRef = useRef<ScrollView>(null);
   const summaryScrollRef = useRef<ScrollView>(null);
   const detailedScrollRef = useRef<ScrollView>(null);
+  const studyScrollRef = useRef<ScrollView>(null);
 
   // Quick-verse-jump: refs to the rendered View for each By Line verse section.
   // Used with measureLayout(byLineScrollRef) to compute the scroll-to Y on tap.
@@ -950,6 +952,34 @@ export function ChapterPage({
               handleTabContentSizeChange('detailed', h, viewportHeightRef.current)
             }
           />
+          {/* Study tab — uses bundled @versemate/studies data (no API fetch).
+              4th sibling of the TabContent instances above; hidden via the
+              same absolute-positioning trick when activeTab !== 'study'. */}
+          <ScrollView
+            ref={studyScrollRef}
+            style={[
+              styles.container,
+              activeTab !== 'study' && {
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                right: 0,
+                bottom: 0,
+                opacity: 0,
+                zIndex: -1,
+              },
+            ]}
+            contentContainerStyle={styles.contentContainer}
+            showsVerticalScrollIndicator={activeTab === 'study'}
+            testID={`chapter-page-scroll-${bookId}-${chapterNumber}-study`}
+            onScroll={activeTab === 'study' ? handleScroll : undefined}
+            scrollEventThrottle={16}
+            onTouchStart={handleTouchStart}
+            onTouchEnd={handleTouchEnd}
+            pointerEvents={activeTab === 'study' ? 'auto' : 'none'}
+          >
+            <StudyPanel bookId={bookId} chapter={chapterNumber} />
+          </ScrollView>
         </View>
       )}
 

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -27,7 +27,7 @@ import type {
   StudyMovement,
   StudyStep,
 } from '@versemate/studies/types';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -44,7 +44,32 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
   const styles = useMemo(() => createStyles(colors), [colors]);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
 
-  const study = getStudyFor(bookId, chapter) as InductiveStudy | null;
+  // getStudyFor is async — each chapter is its own bundler chunk to keep
+  // assets under Cloudflare Workers' 25 MiB per-file limit at full Bible
+  // coverage. First visit to a chapter pays one fetch; subsequent reads
+  // hit Metro's module cache + the in-package CACHE map.
+  const [study, setStudy] = useState<InductiveStudy | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    getStudyFor(bookId, chapter).then((s) => {
+      if (cancelled) return;
+      setStudy(s);
+      setLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [bookId, chapter]);
+
+  if (loading) {
+    return (
+      <View style={styles.emptyContainer} testID={`${testID}-loading`}>
+        <Text style={styles.emptyText}>Loading…</Text>
+      </View>
+    );
+  }
 
   if (!study) {
     return (

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -88,7 +88,7 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
       if (id in overrides) return overrides[id];
       return bulkState === 'expanded';
     },
-    [bulkState, overrides],
+    [bulkState, overrides]
   );
   const toggle = useCallback((id: string) => {
     setOverrides((prev) => {
@@ -142,8 +142,16 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
   allIds.push('observation-intro');
   for (const s of study.steps) {
     allIds.push(`step-${s.number}`);
-    if (s.kind === 'qa') s.items.forEach((_, i) => allIds.push(`step-${s.number}-qa-${i}`));
-    if (s.kind === 'lists') s.lists.forEach((_, i) => allIds.push(`step-${s.number}-list-${i}`));
+    if (s.kind === 'qa') {
+      s.items.forEach((_, i) => {
+        allIds.push(`step-${s.number}-qa-${i}`);
+      });
+    }
+    if (s.kind === 'lists') {
+      s.lists.forEach((_, i) => {
+        allIds.push(`step-${s.number}-list-${i}`);
+      });
+    }
   }
   if (study.interpretation.intro) allIds.push('interpretation-intro');
   for (const m of study.interpretation.movements) allIds.push(`mv-${m.number}`);
@@ -223,8 +231,8 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
         <Text style={styles.sectionIntro}>
           Observation asks what the text says — slowing down to mark the keywords, contrasts,
           repetitions, and structural cues the author left for you. Each of the nine steps below
-          builds the evidence the interpretation that follows is built on. Don't skip ahead; the
-          meaning comes from what you observed.
+          builds the evidence the interpretation that follows is built on. Don&apos;t skip ahead;
+          the meaning comes from what you observed.
         </Text>
       </Card>
       {study.steps.map((step) => (
@@ -265,12 +273,7 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
           styles={styles}
           testID={`${testID}-movement-${movement.number}`}
         >
-          <MovementBody
-            movement={movement}
-            colors={colors}
-            styles={styles}
-            markdownStyles={markdownStyles}
-          />
+          <MovementBody movement={movement} styles={styles} markdownStyles={markdownStyles} />
         </Card>
       ))}
 
@@ -333,15 +336,7 @@ interface StepCardProps {
   testID: string;
 }
 
-function StepCard({
-  step,
-  isOpen,
-  toggle,
-  colors,
-  styles,
-  markdownStyles,
-  testID,
-}: StepCardProps) {
+function StepCard({ step, isOpen, toggle, colors, styles, markdownStyles, testID }: StepCardProps) {
   const id = `step-${step.number}`;
   const open = isOpen(id);
   return (
@@ -378,7 +373,15 @@ interface StepBodyProps {
   testIDPrefix: string;
 }
 
-function StepBody({ step, isOpen, toggle, colors, styles, markdownStyles, testIDPrefix }: StepBodyProps) {
+function StepBody({
+  step,
+  isOpen,
+  toggle,
+  colors,
+  styles,
+  markdownStyles,
+  testIDPrefix,
+}: StepBodyProps) {
   switch (step.kind) {
     case 'prose':
       return <ProseStep step={step} markdownStyles={markdownStyles} />;
@@ -418,13 +421,7 @@ function StepBody({ step, isOpen, toggle, colors, styles, markdownStyles, testID
 
 // ─── Step-kind renderers ─────────────────────────────────────────────────
 
-function ProseStep({
-  step,
-  markdownStyles,
-}: {
-  step: StepProse;
-  markdownStyles: MarkdownStyles;
-}) {
+function ProseStep({ step, markdownStyles }: { step: StepProse; markdownStyles: MarkdownStyles }) {
   return <Markdown style={markdownStyles}>{step.body}</Markdown>;
 }
 
@@ -654,12 +651,10 @@ function SegmentsStep({
 
 function MovementBody({
   movement,
-  colors,
   styles,
   markdownStyles,
 }: {
   movement: StudyMovement;
-  colors: Colors;
   styles: Styles;
   markdownStyles: MarkdownStyles;
 }) {
@@ -667,7 +662,7 @@ function MovementBody({
     <View>
       {movement.excerpt ? (
         <View style={styles.excerptBlock}>
-          <Text style={styles.excerptText}>"{movement.excerpt}"</Text>
+          <Text style={styles.excerptText}>&quot;{movement.excerpt}&quot;</Text>
         </View>
       ) : null}
       <Markdown style={markdownStyles}>{movement.body}</Markdown>

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -1,0 +1,788 @@
+/**
+ * StudyPanel Component
+ *
+ * Renders the Hendricks OIA / Precept-method inductive Bible study for a
+ * given chapter. Data is bundled via the @versemate/studies package — no
+ * API fetch, no loading state, no offline concerns. Returns null when no
+ * authored study exists for the chapter.
+ *
+ * The data shape is a discriminated union (StudyStep.kind), so each step
+ * type has its own renderer (prose / qa / keywords / lists / contrasts /
+ * bullets / segments).
+ *
+ * Mirrors the web app's StudyPanel.tsx — same content, ported to React
+ * Native primitives (View / Text / StyleSheet) instead of Tailwind.
+ */
+
+import { getStudyFor, type InductiveStudy } from '@versemate/studies';
+import type {
+  StepBullets,
+  StepContrasts,
+  StepKeywords,
+  StepLists,
+  StepProse,
+  StepQA,
+  StepSegments,
+  StudyApplication,
+  StudyMovement,
+  StudyStep,
+} from '@versemate/studies/types';
+import { useMemo } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import Markdown from 'react-native-markdown-display';
+import { useTheme } from '@/contexts/ThemeContext';
+import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
+
+export interface StudyPanelProps {
+  bookId: number;
+  chapter: number;
+  testID?: string;
+}
+
+export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPanelProps) {
+  const { colors } = useTheme();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+  const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
+
+  const study = getStudyFor(bookId, chapter) as InductiveStudy | null;
+
+  if (!study) {
+    return (
+      <View style={styles.emptyContainer} testID={`${testID}-empty`}>
+        <Text style={styles.emptyText}>No study available for this chapter yet.</Text>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container} testID={testID}>
+      {/* Title + chapter theme */}
+      <View style={styles.header}>
+        <Text style={styles.title} testID={`${testID}-title`}>
+          {study.title}
+        </Text>
+        <Text style={styles.subtitle}>{study.subtitle}</Text>
+        <Text style={styles.theme} testID={`${testID}-theme`}>
+          {study.themeOneLine}
+        </Text>
+      </View>
+
+      {/* Observation — 9 steps */}
+      <SectionHeader label="Observation" colors={colors} testID={`${testID}-observation`} />
+      {study.steps.map((step) => (
+        <StepRenderer
+          key={step.number}
+          step={step}
+          colors={colors}
+          markdownStyles={markdownStyles}
+          testID={`${testID}-step-${step.number}`}
+        />
+      ))}
+
+      {/* Interpretation — 4-6 movements */}
+      <SectionHeader label="Interpretation" colors={colors} testID={`${testID}-interpretation`} />
+      {study.interpretation.intro ? (
+        <Text style={styles.intro}>{study.interpretation.intro}</Text>
+      ) : null}
+      {study.interpretation.movements.map((movement) => (
+        <MovementRenderer
+          key={movement.number}
+          movement={movement}
+          colors={colors}
+          markdownStyles={markdownStyles}
+          testID={`${testID}-movement-${movement.number}`}
+        />
+      ))}
+
+      {/* Application — 5-9 questions */}
+      <SectionHeader label="Application" colors={colors} testID={`${testID}-application`} />
+      {study.application.intro ? <Text style={styles.intro}>{study.application.intro}</Text> : null}
+      {study.application.questions.map((q, i) => (
+        <ApplicationRenderer
+          key={`${q.range}-${i}`}
+          question={q}
+          colors={colors}
+          testID={`${testID}-question-${i + 1}`}
+        />
+      ))}
+    </View>
+  );
+}
+
+// ─── Section header ──────────────────────────────────────────────────────
+
+interface SectionHeaderProps {
+  label: string;
+  colors: ReturnType<typeof getColors>;
+  testID: string;
+}
+
+function SectionHeader({ label, colors, testID }: SectionHeaderProps) {
+  return (
+    <View
+      style={{
+        marginTop: spacing.xl,
+        marginBottom: spacing.md,
+        borderTopWidth: 1,
+        borderTopColor: colors.gold,
+        paddingTop: spacing.md,
+      }}
+      testID={testID}
+    >
+      <Text
+        style={{
+          fontSize: fontSizes.caption,
+          fontWeight: '700',
+          color: colors.gold,
+          textTransform: 'uppercase',
+          letterSpacing: 2,
+        }}
+        accessibilityRole="header"
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+// ─── Step dispatcher ─────────────────────────────────────────────────────
+
+interface StepRendererProps {
+  step: StudyStep;
+  colors: ReturnType<typeof getColors>;
+  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  testID: string;
+}
+
+function StepRenderer({ step, colors, markdownStyles, testID }: StepRendererProps) {
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  return (
+    <View style={styles.stepCard} testID={testID}>
+      <View style={styles.stepHeader}>
+        <Text style={styles.stepNumber}>{step.number}</Text>
+        <View style={styles.stepTitleBlock}>
+          <Text style={styles.stepTitle} accessibilityRole="header">
+            {step.title}
+          </Text>
+          <Text style={styles.stepSummary}>{step.summary}</Text>
+        </View>
+      </View>
+
+      <View style={styles.stepBody}>
+        {step.kind === 'prose' && <ProseStep step={step} markdownStyles={markdownStyles} />}
+        {step.kind === 'qa' && <QAStep step={step} colors={colors} />}
+        {step.kind === 'keywords' && <KeywordsStep step={step} colors={colors} />}
+        {step.kind === 'lists' && <ListsStep step={step} colors={colors} />}
+        {step.kind === 'contrasts' && <ContrastsStep step={step} colors={colors} />}
+        {step.kind === 'bullets' && (
+          <BulletsStep step={step} colors={colors} markdownStyles={markdownStyles} />
+        )}
+        {step.kind === 'segments' && (
+          <SegmentsStep step={step} colors={colors} markdownStyles={markdownStyles} />
+        )}
+      </View>
+    </View>
+  );
+}
+
+// ─── Step-kind renderers ─────────────────────────────────────────────────
+
+function ProseStep({
+  step,
+  markdownStyles,
+}: {
+  step: StepProse;
+  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+}) {
+  return <Markdown style={markdownStyles}>{step.body}</Markdown>;
+}
+
+function QAStep({ step, colors }: { step: StepQA; colors: ReturnType<typeof getColors> }) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      {step.items.map((item, i) => (
+        <View key={`${item.q}-${i}`} style={styles.qaItem}>
+          {item.tag ? (
+            <View style={styles.tagPill}>
+              <Text style={styles.tagPillText}>{item.tag}</Text>
+            </View>
+          ) : null}
+          <Text style={styles.qaQuestion}>{item.q}</Text>
+          <Text style={styles.qaAnswer}>{item.a}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function KeywordsStep({
+  step,
+  colors,
+}: {
+  step: StepKeywords;
+  colors: ReturnType<typeof getColors>;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      {step.inventory.map((kw, i) => (
+        <View key={`${kw.word}-${i}`} style={styles.keywordRow}>
+          <View style={styles.keywordHeader}>
+            <Text style={styles.keywordWord}>{kw.word}</Text>
+            {kw.greek ? <Text style={styles.keywordGreek}>{kw.greek}</Text> : null}
+            <View style={styles.countBadge}>
+              <Text style={styles.countBadgeText}>{kw.count}×</Text>
+            </View>
+          </View>
+          {kw.definition ? <Text style={styles.keywordDef}>{kw.definition}</Text> : null}
+          <Text style={styles.keywordVerses}>{kw.verses}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function ListsStep({ step, colors }: { step: StepLists; colors: ReturnType<typeof getColors> }) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      {step.lists.map((list, listIdx) => (
+        <View key={`${list.title}-${listIdx}`} style={styles.listBlock}>
+          <Text style={styles.listTitle}>{list.title}</Text>
+          {list.rows.map((row, i) => (
+            <View key={`${row.ref}-${i}`} style={styles.listRow}>
+              <Text style={styles.listRef}>{row.ref}</Text>
+              <Text style={styles.listTruth}>{row.truth}</Text>
+            </View>
+          ))}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function ContrastsStep({
+  step,
+  colors,
+}: {
+  step: StepContrasts;
+  colors: ReturnType<typeof getColors>;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      {step.items.map((item, i) => (
+        <View key={`${item.verses}-${i}`} style={styles.contrastRow}>
+          <View style={styles.contrastMeta}>
+            <Text style={styles.contrastVerses}>{item.verses}</Text>
+            <View style={[styles.contrastTypePill, contrastTypeColor(item.type, colors)]}>
+              <Text style={styles.contrastTypeText}>{item.type}</Text>
+            </View>
+          </View>
+          <Text style={styles.contrastPairing}>{item.pairing}</Text>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function contrastTypeColor(type: string, colors: ReturnType<typeof getColors>) {
+  // Three canonical tints; model-emitted variants ("Irony", etc.) fall
+  // through to the comparison tint so the row still renders cleanly.
+  switch (type) {
+    case 'Contrast':
+      return { backgroundColor: colors.gold };
+    case 'Comparison':
+    case 'Metaphor':
+    default:
+      return { backgroundColor: colors.backgroundElevated };
+  }
+}
+
+function BulletsStep({
+  step,
+  colors,
+  markdownStyles,
+}: {
+  step: StepBullets;
+  colors: ReturnType<typeof getColors>;
+  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      {step.intro ? <Markdown style={markdownStyles}>{step.intro}</Markdown> : null}
+      {step.items.map((item, i) => (
+        <View key={`${item.text.slice(0, 30)}-${i}`} style={styles.bulletItem}>
+          {item.tag ? (
+            <View style={styles.bulletTag}>
+              <Text style={styles.bulletTagText}>{item.tag}</Text>
+            </View>
+          ) : null}
+          <View style={styles.bulletBody}>
+            <Markdown style={markdownStyles}>{item.text}</Markdown>
+          </View>
+        </View>
+      ))}
+      {step.note ? (
+        <View style={styles.noteBlock}>
+          <Markdown style={markdownStyles}>{step.note}</Markdown>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+function SegmentsStep({
+  step,
+  colors,
+  markdownStyles,
+}: {
+  step: StepSegments;
+  colors: ReturnType<typeof getColors>;
+  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View>
+      <Text style={styles.themeHeadline}>{step.themeHeadline}</Text>
+      {step.segments.map((seg, i) => (
+        <View key={`${seg.title}-${i}`} style={styles.segmentBlock}>
+          <Text style={styles.segmentTitle}>{seg.title}</Text>
+          <Markdown style={markdownStyles}>{seg.body}</Markdown>
+        </View>
+      ))}
+    </View>
+  );
+}
+
+// ─── Interpretation movements ────────────────────────────────────────────
+
+function MovementRenderer({
+  movement,
+  colors,
+  markdownStyles,
+  testID,
+}: {
+  movement: StudyMovement;
+  colors: ReturnType<typeof getColors>;
+  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  testID: string;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View style={styles.movementCard} testID={testID}>
+      <View style={styles.movementHeader}>
+        <Text style={styles.movementNumber}>Movement {movement.number}</Text>
+        <Text style={styles.movementRange}>{movement.range}</Text>
+      </View>
+      <Text style={styles.movementTitle} accessibilityRole="header">
+        {movement.title}
+      </Text>
+      {movement.excerpt ? (
+        <View style={styles.excerptBlock}>
+          <Text style={styles.excerptText}>“{movement.excerpt}”</Text>
+        </View>
+      ) : null}
+      <View style={styles.movementBody}>
+        <Markdown style={markdownStyles}>{movement.body}</Markdown>
+      </View>
+    </View>
+  );
+}
+
+// ─── Application question ────────────────────────────────────────────────
+
+function ApplicationRenderer({
+  question,
+  colors,
+  testID,
+}: {
+  question: StudyApplication;
+  colors: ReturnType<typeof getColors>;
+  testID: string;
+}) {
+  const styles = createStyles(colors);
+  return (
+    <View style={styles.appCard} testID={testID}>
+      <Text style={styles.appRange}>{question.range}</Text>
+      <Text style={styles.appQuestion}>{question.question}</Text>
+    </View>
+  );
+}
+
+// ─── Styles ──────────────────────────────────────────────────────────────
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    container: {
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.md,
+      paddingBottom: spacing.xxl,
+    },
+    emptyContainer: {
+      padding: spacing.xl,
+      alignItems: 'center',
+    },
+    emptyText: {
+      fontSize: fontSizes.body,
+      color: colors.textSecondary,
+      textAlign: 'center',
+    },
+
+    header: {
+      marginBottom: spacing.lg,
+    },
+    title: {
+      fontSize: fontSizes.heading1,
+      fontWeight: fontWeights.bold,
+      color: colors.textPrimary,
+      marginBottom: spacing.xs,
+    },
+    subtitle: {
+      fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
+      color: colors.textSecondary,
+      marginBottom: spacing.sm,
+    },
+    theme: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+      lineHeight: fontSizes.body * lineHeights.body,
+    },
+
+    intro: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textSecondary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+      marginBottom: spacing.md,
+    },
+
+    // Observation step card
+    stepCard: {
+      backgroundColor: colors.backgroundElevated,
+      borderRadius: 12,
+      padding: spacing.md,
+      marginBottom: spacing.md,
+      borderLeftWidth: 3,
+      borderLeftColor: colors.gold,
+    },
+    stepHeader: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginBottom: spacing.sm,
+    },
+    stepNumber: {
+      fontSize: fontSizes.heading1,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      width: 36,
+      lineHeight: fontSizes.heading1,
+    },
+    stepTitleBlock: {
+      flex: 1,
+    },
+    stepTitle: {
+      fontSize: fontSizes.heading3,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      marginBottom: spacing.xs,
+    },
+    stepSummary: {
+      fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
+      color: colors.textSecondary,
+    },
+    stepBody: {
+      marginTop: spacing.sm,
+    },
+
+    // QA
+    qaItem: {
+      marginBottom: spacing.md,
+      paddingTop: spacing.sm,
+      borderTopWidth: 1,
+      borderTopColor: colors.gray100,
+    },
+    tagPill: {
+      alignSelf: 'flex-start',
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 4,
+      backgroundColor: colors.gold,
+      marginBottom: spacing.xs,
+    },
+    tagPillText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
+      letterSpacing: 1,
+    },
+    qaQuestion: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      marginBottom: spacing.xs,
+    },
+    qaAnswer: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textSecondary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Keywords
+    keywordRow: {
+      paddingVertical: spacing.sm,
+      borderTopWidth: 1,
+      borderTopColor: colors.gray100,
+    },
+    keywordHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexWrap: 'wrap',
+      gap: spacing.sm,
+      marginBottom: spacing.xs,
+    },
+    keywordWord: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.bold,
+      color: colors.textPrimary,
+    },
+    keywordGreek: {
+      fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
+      color: colors.gold,
+    },
+    countBadge: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 4,
+      backgroundColor: colors.backgroundElevated,
+    },
+    countBadgeText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.semibold,
+      color: colors.textSecondary,
+    },
+    keywordDef: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textSecondary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+      marginBottom: spacing.xs,
+    },
+    keywordVerses: {
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+      fontFamily: undefined,
+    },
+
+    // Lists
+    listBlock: {
+      marginBottom: spacing.lg,
+    },
+    listTitle: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.bold,
+      color: colors.textPrimary,
+      marginBottom: spacing.sm,
+    },
+    listRow: {
+      flexDirection: 'row',
+      paddingVertical: spacing.xs,
+      borderTopWidth: 1,
+      borderTopColor: colors.gray100,
+    },
+    listRef: {
+      width: 70,
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+    },
+    listTruth: {
+      flex: 1,
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Contrasts
+    contrastRow: {
+      paddingVertical: spacing.sm,
+      borderTopWidth: 1,
+      borderTopColor: colors.gray100,
+    },
+    contrastMeta: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
+      marginBottom: spacing.xs,
+    },
+    contrastVerses: {
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+    },
+    contrastTypePill: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 4,
+    },
+    contrastTypeText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.semibold,
+      color: colors.gray900,
+    },
+    contrastPairing: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Bullets
+    bulletItem: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginBottom: spacing.sm,
+      gap: spacing.sm,
+    },
+    bulletTag: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 4,
+      backgroundColor: colors.gold,
+      marginTop: 2,
+    },
+    bulletTagText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
+      letterSpacing: 1,
+    },
+    bulletBody: {
+      flex: 1,
+    },
+    noteBlock: {
+      marginTop: spacing.md,
+      padding: spacing.md,
+      borderRadius: 8,
+      backgroundColor: colors.backgroundElevated,
+    },
+
+    // Segments (chapter theme)
+    themeHeadline: {
+      fontSize: fontSizes.heading3,
+      fontWeight: fontWeights.bold,
+      fontStyle: 'italic',
+      color: colors.gold,
+      marginBottom: spacing.md,
+      lineHeight: fontSizes.heading3 * lineHeights.body,
+    },
+    segmentBlock: {
+      marginBottom: spacing.md,
+    },
+    segmentTitle: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      marginBottom: spacing.xs,
+    },
+
+    // Movements
+    movementCard: {
+      marginBottom: spacing.lg,
+      paddingBottom: spacing.md,
+    },
+    movementHeader: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      marginBottom: spacing.xs,
+    },
+    movementNumber: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    movementRange: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.semibold,
+      color: colors.textSecondary,
+    },
+    movementTitle: {
+      fontSize: fontSizes.heading3,
+      fontWeight: fontWeights.bold,
+      color: colors.textPrimary,
+      marginBottom: spacing.sm,
+    },
+    excerptBlock: {
+      borderLeftWidth: 3,
+      borderLeftColor: colors.gold,
+      paddingLeft: spacing.md,
+      paddingVertical: spacing.xs,
+      marginBottom: spacing.sm,
+    },
+    excerptText: {
+      fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
+      color: colors.textSecondary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+    movementBody: {
+      marginTop: spacing.sm,
+    },
+
+    // Application
+    appCard: {
+      backgroundColor: colors.backgroundElevated,
+      borderRadius: 8,
+      padding: spacing.md,
+      marginBottom: spacing.sm,
+      borderLeftWidth: 3,
+      borderLeftColor: colors.gold,
+    },
+    appRange: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      marginBottom: spacing.xs,
+    },
+    appQuestion: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+  });
+
+const createMarkdownStyles = (colors: ReturnType<typeof getColors>) => ({
+  body: {
+    fontSize: fontSizes.bodySmall,
+    color: colors.textPrimary,
+    lineHeight: fontSizes.bodySmall * lineHeights.body,
+  },
+  paragraph: {
+    marginBottom: spacing.sm,
+  },
+  strong: {
+    fontWeight: fontWeights.bold,
+    color: colors.textPrimary,
+  },
+  em: {
+    fontStyle: 'italic' as const,
+  },
+  blockquote: {
+    borderLeftWidth: 3,
+    borderLeftColor: colors.gold,
+    paddingLeft: spacing.md,
+    marginVertical: spacing.sm,
+    backgroundColor: 'transparent',
+  },
+  link: {
+    color: colors.gold,
+    textDecorationLine: 'underline' as const,
+  },
+});

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -2,18 +2,25 @@
  * StudyPanel Component
  *
  * Renders the Hendricks OIA / Precept-method inductive Bible study for a
- * given chapter. Data is bundled via the @versemate/studies package — no
- * API fetch, no loading state, no offline concerns. Returns null when no
- * authored study exists for the chapter.
+ * given chapter, mirroring the web app's StudyPanel.tsx.
  *
- * The data shape is a discriminated union (StudyStep.kind), so each step
- * type has its own renderer (prose / qa / keywords / lists / contrasts /
- * bullets / segments).
+ * Data is loaded async via `getStudyFor` from the `@versemate/studies`
+ * package — chapters are code-split (each is its own bundler chunk) so we
+ * pay one fetch on first visit per chapter, then hit the in-package CACHE.
  *
- * Mirrors the web app's StudyPanel.tsx — same content, ported to React
- * Native primitives (View / Text / StyleSheet) instead of Tailwind.
+ * Behavior parity with web:
+ *   - Default state: every section collapsed.
+ *   - Bulk Expand All / Collapse All toggle.
+ *   - Per-card overrides win over bulk state once the user touches a card.
+ *   - Copy / Share buttons emit the same plain-text payload as web.
+ *   - Step kinds with sub-items (qa, lists) nest collapsibles per item.
+ *
+ * State persistence is in-memory only (BibleExplanationsPanel keeps this
+ * tab mounted, so state survives tab switches). Switching chapters resets
+ * to default-collapsed, since the IDs are chapter-scoped on web too.
  */
 
+import { Ionicons } from '@expo/vector-icons';
 import { getStudyFor, type InductiveStudy } from '@versemate/studies';
 import type {
   StepBullets,
@@ -27,8 +34,9 @@ import type {
   StudyMovement,
   StudyStep,
 } from '@versemate/studies/types';
-import { useEffect, useMemo, useState } from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import * as Clipboard from 'expo-clipboard';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, Share, StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -39,15 +47,15 @@ export interface StudyPanelProps {
   testID?: string;
 }
 
+type Colors = ReturnType<typeof getColors>;
+type Styles = ReturnType<typeof createStyles>;
+type MarkdownStyles = ReturnType<typeof createMarkdownStyles>;
+
 export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPanelProps) {
   const { colors } = useTheme();
   const styles = useMemo(() => createStyles(colors), [colors]);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
 
-  // getStudyFor is async — each chapter is its own bundler chunk to keep
-  // assets under Cloudflare Workers' 25 MiB per-file limit at full Bible
-  // coverage. First visit to a chapter pays one fetch; subsequent reads
-  // hit Metro's module cache + the in-package CACHE map.
   const [study, setStudy] = useState<InductiveStudy | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   useEffect(() => {
@@ -62,6 +70,56 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
       cancelled = true;
     };
   }, [bookId, chapter]);
+
+  // Bulk state drives the default for every section. Per-card overrides
+  // win when the user toggles individually after a bulk action.
+  const [bulkState, setBulkState] = useState<'expanded' | 'collapsed'>('collapsed');
+  const [overrides, setOverrides] = useState<Record<string, boolean>>({});
+  // Reset open/closed state when the chapter changes — IDs (step-1, step-2,
+  // etc.) are generic across chapters, so without a reset the previous
+  // chapter's expanded sections would bleed into the new chapter.
+  useEffect(() => {
+    setBulkState('collapsed');
+    setOverrides({});
+  }, [bookId, chapter]);
+
+  const isOpen = useCallback(
+    (id: string): boolean => {
+      if (id in overrides) return overrides[id];
+      return bulkState === 'expanded';
+    },
+    [bulkState, overrides],
+  );
+  const toggle = useCallback((id: string) => {
+    setOverrides((prev) => {
+      const wasOpen = id in prev ? prev[id] : false;
+      return { ...prev, [id]: !wasOpen };
+    });
+  }, []);
+
+  // Copy / Share feedback (checkmark flash after copy)
+  const [copied, setCopied] = useState(false);
+  const onCopy = useCallback(async () => {
+    if (!study) return;
+    try {
+      await Clipboard.setStringAsync(buildStudyCopyText(study));
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // ignore — clipboard occasionally fails on simulator
+    }
+  }, [study]);
+  const onShare = useCallback(async () => {
+    if (!study) return;
+    try {
+      await Share.share({
+        title: `Inductive Study of ${study.title}`,
+        message: buildStudyCopyText(study),
+      });
+    } catch {
+      // ignore — user dismissal also throws
+    }
+  }, [study]);
 
   if (loading) {
     return (
@@ -79,136 +137,283 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
     );
   }
 
+  // Build the full id list for bulk Expand-All / Collapse-All. Mirrors web.
+  const allIds: string[] = [];
+  allIds.push('observation-intro');
+  for (const s of study.steps) {
+    allIds.push(`step-${s.number}`);
+    if (s.kind === 'qa') s.items.forEach((_, i) => allIds.push(`step-${s.number}-qa-${i}`));
+    if (s.kind === 'lists') s.lists.forEach((_, i) => allIds.push(`step-${s.number}-list-${i}`));
+  }
+  if (study.interpretation.intro) allIds.push('interpretation-intro');
+  for (const m of study.interpretation.movements) allIds.push(`mv-${m.number}`);
+  allIds.push('application');
+
+  const allOpen = allIds.every((id) => isOpen(id));
+  const setAll = (open: boolean) => {
+    setBulkState(open ? 'expanded' : 'collapsed');
+    setOverrides({});
+  };
+
   return (
     <View style={styles.container} testID={testID}>
-      {/* Title + chapter theme */}
-      <View style={styles.header}>
-        <Text style={styles.title} testID={`${testID}-title`}>
-          {study.title}
+      {/* Title row + Copy / Share */}
+      <View style={styles.titleRow}>
+        <Text style={styles.title} testID={`${testID}-title`} accessibilityRole="header">
+          Inductive Study of {study.title}
         </Text>
-        <Text style={styles.subtitle}>{study.subtitle}</Text>
+        <View style={styles.titleActions}>
+          <Pressable
+            onPress={onCopy}
+            style={styles.iconButton}
+            accessibilityRole="button"
+            accessibilityLabel="Copy study"
+            testID={`${testID}-copy`}
+            hitSlop={8}
+          >
+            <Ionicons
+              name={copied ? 'checkmark' : 'copy-outline'}
+              size={20}
+              color={copied ? colors.gold : colors.textPrimary}
+            />
+          </Pressable>
+          <Pressable
+            onPress={onShare}
+            style={styles.iconButton}
+            accessibilityRole="button"
+            accessibilityLabel="Share study"
+            testID={`${testID}-share`}
+            hitSlop={8}
+          >
+            <Ionicons name="share-outline" size={20} color={colors.textPrimary} />
+          </Pressable>
+        </View>
+      </View>
+
+      {/* Subtitle + theme line — small, muted, just below the title row */}
+      {study.subtitle ? <Text style={styles.subtitle}>{study.subtitle}</Text> : null}
+      {study.themeOneLine ? (
         <Text style={styles.theme} testID={`${testID}-theme`}>
           {study.themeOneLine}
         </Text>
+      ) : null}
+
+      {/* Expand All / Collapse All */}
+      <View style={styles.expandAllRow}>
+        <Pressable
+          onPress={() => setAll(!allOpen)}
+          accessibilityRole="button"
+          testID={`${testID}-toggle-all`}
+          hitSlop={6}
+        >
+          <Text style={styles.expandAllText}>{allOpen ? 'Collapse All' : 'Expand All'}</Text>
+        </Pressable>
       </View>
 
-      {/* Observation — 9 steps */}
-      <SectionHeader label="Observation" colors={colors} testID={`${testID}-observation`} />
+      {/* OBSERVATION */}
+      <SectionHeading label="Observation — 9 Inductive Steps" colors={colors} styles={styles} />
+      <Card
+        open={isOpen('observation-intro')}
+        onToggle={() => toggle('observation-intro')}
+        heading="About the nine observation steps"
+        colors={colors}
+        styles={styles}
+        testID={`${testID}-observation-intro`}
+      >
+        <Text style={styles.sectionIntro}>
+          Observation asks what the text says — slowing down to mark the keywords, contrasts,
+          repetitions, and structural cues the author left for you. Each of the nine steps below
+          builds the evidence the interpretation that follows is built on. Don't skip ahead; the
+          meaning comes from what you observed.
+        </Text>
+      </Card>
       {study.steps.map((step) => (
-        <StepRenderer
+        <StepCard
           key={step.number}
           step={step}
+          isOpen={isOpen}
+          toggle={toggle}
           colors={colors}
+          styles={styles}
           markdownStyles={markdownStyles}
           testID={`${testID}-step-${step.number}`}
         />
       ))}
 
-      {/* Interpretation — 4-6 movements */}
-      <SectionHeader label="Interpretation" colors={colors} testID={`${testID}-interpretation`} />
+      {/* INTERPRETATION */}
+      <SectionHeading label="Interpretation" colors={colors} styles={styles} />
       {study.interpretation.intro ? (
-        <Text style={styles.intro}>{study.interpretation.intro}</Text>
+        <Card
+          open={isOpen('interpretation-intro')}
+          onToggle={() => toggle('interpretation-intro')}
+          heading="About the interpretation movements"
+          colors={colors}
+          styles={styles}
+          testID={`${testID}-interpretation-intro`}
+        >
+          <Text style={styles.sectionIntro}>{study.interpretation.intro}</Text>
+        </Card>
       ) : null}
       {study.interpretation.movements.map((movement) => (
-        <MovementRenderer
+        <Card
           key={movement.number}
-          movement={movement}
+          open={isOpen(`mv-${movement.number}`)}
+          onToggle={() => toggle(`mv-${movement.number}`)}
+          heading={`Movement ${movement.number} — ${movement.title}`}
+          subPill={movement.range}
           colors={colors}
-          markdownStyles={markdownStyles}
+          styles={styles}
           testID={`${testID}-movement-${movement.number}`}
-        />
+        >
+          <MovementBody
+            movement={movement}
+            colors={colors}
+            styles={styles}
+            markdownStyles={markdownStyles}
+          />
+        </Card>
       ))}
 
-      {/* Application — 5-9 questions */}
-      <SectionHeader label="Application" colors={colors} testID={`${testID}-application`} />
-      {study.application.intro ? <Text style={styles.intro}>{study.application.intro}</Text> : null}
-      {study.application.questions.map((q, i) => (
-        <ApplicationRenderer
-          key={`${q.range}-${i}`}
-          question={q}
-          colors={colors}
-          testID={`${testID}-question-${i + 1}`}
-        />
-      ))}
+      {/* APPLICATION */}
+      <SectionHeading label="Application" colors={colors} styles={styles} />
+      <Card
+        open={isOpen('application')}
+        onToggle={() => toggle('application')}
+        heading="Apply, one question per movement"
+        colors={colors}
+        styles={styles}
+        testID={`${testID}-application`}
+      >
+        {study.application.intro ? (
+          <Text style={[styles.sectionIntro, styles.applicationIntro]}>
+            {study.application.intro}
+          </Text>
+        ) : null}
+        {study.application.questions.map((q, i) => (
+          <ApplicationRow
+            key={`${q.range}-${i}`}
+            question={q}
+            colors={colors}
+            styles={styles}
+            testID={`${testID}-question-${i + 1}`}
+          />
+        ))}
+      </Card>
     </View>
   );
 }
 
-// ─── Section header ──────────────────────────────────────────────────────
+// ─── Section heading ─────────────────────────────────────────────────────
 
-interface SectionHeaderProps {
+interface SectionHeadingProps {
   label: string;
-  colors: ReturnType<typeof getColors>;
-  testID: string;
+  colors: Colors;
+  styles: Styles;
 }
 
-function SectionHeader({ label, colors, testID }: SectionHeaderProps) {
+function SectionHeading({ label, styles }: SectionHeadingProps) {
   return (
-    <View
-      style={{
-        marginTop: spacing.xl,
-        marginBottom: spacing.md,
-        borderTopWidth: 1,
-        borderTopColor: colors.gold,
-        paddingTop: spacing.md,
-      }}
-      testID={testID}
-    >
-      <Text
-        style={{
-          fontSize: fontSizes.caption,
-          fontWeight: '700',
-          color: colors.gold,
-          textTransform: 'uppercase',
-          letterSpacing: 2,
-        }}
-        accessibilityRole="header"
-      >
+    <View style={styles.sectionHeadingWrap}>
+      <Text style={styles.sectionHeadingText} accessibilityRole="header">
         {label}
       </Text>
     </View>
   );
 }
 
-// ─── Step dispatcher ─────────────────────────────────────────────────────
+// ─── Step card ───────────────────────────────────────────────────────────
 
-interface StepRendererProps {
+interface StepCardProps {
   step: StudyStep;
-  colors: ReturnType<typeof getColors>;
-  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+  colors: Colors;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
   testID: string;
 }
 
-function StepRenderer({ step, colors, markdownStyles, testID }: StepRendererProps) {
-  const styles = useMemo(() => createStyles(colors), [colors]);
-
+function StepCard({
+  step,
+  isOpen,
+  toggle,
+  colors,
+  styles,
+  markdownStyles,
+  testID,
+}: StepCardProps) {
+  const id = `step-${step.number}`;
+  const open = isOpen(id);
   return (
-    <View style={styles.stepCard} testID={testID}>
-      <View style={styles.stepHeader}>
-        <Text style={styles.stepNumber}>{step.number}</Text>
-        <View style={styles.stepTitleBlock}>
-          <Text style={styles.stepTitle} accessibilityRole="header">
-            {step.title}
-          </Text>
-          <Text style={styles.stepSummary}>{step.summary}</Text>
-        </View>
-      </View>
-
-      <View style={styles.stepBody}>
-        {step.kind === 'prose' && <ProseStep step={step} markdownStyles={markdownStyles} />}
-        {step.kind === 'qa' && <QAStep step={step} colors={colors} />}
-        {step.kind === 'keywords' && <KeywordsStep step={step} colors={colors} />}
-        {step.kind === 'lists' && <ListsStep step={step} colors={colors} />}
-        {step.kind === 'contrasts' && <ContrastsStep step={step} colors={colors} />}
-        {step.kind === 'bullets' && (
-          <BulletsStep step={step} colors={colors} markdownStyles={markdownStyles} />
-        )}
-        {step.kind === 'segments' && (
-          <SegmentsStep step={step} colors={colors} markdownStyles={markdownStyles} />
-        )}
-      </View>
-    </View>
+    <Card
+      open={open}
+      onToggle={() => toggle(id)}
+      heading={step.title}
+      subheading={step.summary}
+      stepNumber={step.number}
+      colors={colors}
+      styles={styles}
+      testID={testID}
+    >
+      <StepBody
+        step={step}
+        isOpen={isOpen}
+        toggle={toggle}
+        colors={colors}
+        styles={styles}
+        markdownStyles={markdownStyles}
+        testIDPrefix={testID}
+      />
+    </Card>
   );
+}
+
+interface StepBodyProps {
+  step: StudyStep;
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+  colors: Colors;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
+  testIDPrefix: string;
+}
+
+function StepBody({ step, isOpen, toggle, colors, styles, markdownStyles, testIDPrefix }: StepBodyProps) {
+  switch (step.kind) {
+    case 'prose':
+      return <ProseStep step={step} markdownStyles={markdownStyles} />;
+    case 'qa':
+      return (
+        <QAStep
+          step={step}
+          isOpen={isOpen}
+          toggle={toggle}
+          colors={colors}
+          styles={styles}
+          markdownStyles={markdownStyles}
+          testIDPrefix={testIDPrefix}
+        />
+      );
+    case 'keywords':
+      return <KeywordsStep step={step} styles={styles} />;
+    case 'lists':
+      return (
+        <ListsStep
+          step={step}
+          isOpen={isOpen}
+          toggle={toggle}
+          colors={colors}
+          styles={styles}
+          testIDPrefix={testIDPrefix}
+        />
+      );
+    case 'contrasts':
+      return <ContrastsStep step={step} colors={colors} styles={styles} />;
+    case 'bullets':
+      return <BulletsStep step={step} styles={styles} markdownStyles={markdownStyles} />;
+    case 'segments':
+      return <SegmentsStep step={step} styles={styles} markdownStyles={markdownStyles} />;
+  }
 }
 
 // ─── Step-kind renderers ─────────────────────────────────────────────────
@@ -218,38 +423,52 @@ function ProseStep({
   markdownStyles,
 }: {
   step: StepProse;
-  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  markdownStyles: MarkdownStyles;
 }) {
   return <Markdown style={markdownStyles}>{step.body}</Markdown>;
 }
 
-function QAStep({ step, colors }: { step: StepQA; colors: ReturnType<typeof getColors> }) {
-  const styles = createStyles(colors);
+function QAStep({
+  step,
+  isOpen,
+  toggle,
+  colors,
+  styles,
+  markdownStyles,
+  testIDPrefix,
+}: {
+  step: StepQA;
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+  colors: Colors;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
+  testIDPrefix: string;
+}) {
   return (
     <View>
-      {step.items.map((item, i) => (
-        <View key={`${item.q}-${i}`} style={styles.qaItem}>
-          {item.tag ? (
-            <View style={styles.tagPill}>
-              <Text style={styles.tagPillText}>{item.tag}</Text>
-            </View>
-          ) : null}
-          <Text style={styles.qaQuestion}>{item.q}</Text>
-          <Text style={styles.qaAnswer}>{item.a}</Text>
-        </View>
-      ))}
+      {step.items.map((item, i) => {
+        const id = `step-${step.number}-qa-${i}`;
+        return (
+          <NestedCard
+            key={`${item.q}-${i}`}
+            open={isOpen(id)}
+            onToggle={() => toggle(id)}
+            heading={item.q}
+            tag={item.tag}
+            colors={colors}
+            styles={styles}
+            testID={`${testIDPrefix}-qa-${i}`}
+          >
+            <Markdown style={markdownStyles}>{item.a}</Markdown>
+          </NestedCard>
+        );
+      })}
     </View>
   );
 }
 
-function KeywordsStep({
-  step,
-  colors,
-}: {
-  step: StepKeywords;
-  colors: ReturnType<typeof getColors>;
-}) {
-  const styles = createStyles(colors);
+function KeywordsStep({ step, styles }: { step: StepKeywords; styles: Styles }) {
   return (
     <View>
       {step.inventory.map((kw, i) => (
@@ -258,32 +477,65 @@ function KeywordsStep({
             <Text style={styles.keywordWord}>{kw.word}</Text>
             {kw.greek ? <Text style={styles.keywordGreek}>{kw.greek}</Text> : null}
             <View style={styles.countBadge}>
-              <Text style={styles.countBadgeText}>{kw.count}×</Text>
+              <Text style={styles.countBadgeText}>×{kw.count}</Text>
             </View>
           </View>
+          <Text style={styles.keywordVerses}>
+            <Text style={styles.keywordVersesLabel}>VERSES </Text>
+            {kw.verses}
+          </Text>
           {kw.definition ? <Text style={styles.keywordDef}>{kw.definition}</Text> : null}
-          <Text style={styles.keywordVerses}>{kw.verses}</Text>
         </View>
       ))}
     </View>
   );
 }
 
-function ListsStep({ step, colors }: { step: StepLists; colors: ReturnType<typeof getColors> }) {
-  const styles = createStyles(colors);
+function ListsStep({
+  step,
+  isOpen,
+  toggle,
+  colors,
+  styles,
+  testIDPrefix,
+}: {
+  step: StepLists;
+  isOpen: (id: string) => boolean;
+  toggle: (id: string) => void;
+  colors: Colors;
+  styles: Styles;
+  testIDPrefix: string;
+}) {
   return (
     <View>
-      {step.lists.map((list, listIdx) => (
-        <View key={`${list.title}-${listIdx}`} style={styles.listBlock}>
-          <Text style={styles.listTitle}>{list.title}</Text>
-          {list.rows.map((row, i) => (
-            <View key={`${row.ref}-${i}`} style={styles.listRow}>
-              <Text style={styles.listRef}>{row.ref}</Text>
-              <Text style={styles.listTruth}>{row.truth}</Text>
+      {step.lists.map((list, listIdx) => {
+        const id = `step-${step.number}-list-${listIdx}`;
+        const [colLeft, colRight] = list.columns;
+        return (
+          <NestedCard
+            key={`${list.title}-${listIdx}`}
+            open={isOpen(id)}
+            onToggle={() => toggle(id)}
+            heading={list.title}
+            colors={colors}
+            styles={styles}
+            testID={`${testIDPrefix}-list-${listIdx}`}
+          >
+            <View style={styles.listHeaderRow}>
+              <Text style={[styles.listHeaderCell, styles.listHeaderRef]}>{colLeft}</Text>
+              <Text style={[styles.listHeaderCell, styles.listHeaderTruth]}>{colRight}</Text>
             </View>
-          ))}
-        </View>
-      ))}
+            {list.rows.map((row, i) => (
+              <View key={`${row.ref}-${i}`} style={styles.listRow}>
+                <View style={styles.listRefPill}>
+                  <Text style={styles.listRefPillText}>{row.ref}</Text>
+                </View>
+                <Text style={styles.listTruth}>{row.truth}</Text>
+              </View>
+            ))}
+          </NestedCard>
+        );
+      })}
     </View>
   );
 }
@@ -291,19 +543,29 @@ function ListsStep({ step, colors }: { step: StepLists; colors: ReturnType<typeo
 function ContrastsStep({
   step,
   colors,
+  styles,
 }: {
   step: StepContrasts;
-  colors: ReturnType<typeof getColors>;
+  colors: Colors;
+  styles: Styles;
 }) {
-  const styles = createStyles(colors);
   return (
     <View>
       {step.items.map((item, i) => (
         <View key={`${item.verses}-${i}`} style={styles.contrastRow}>
           <View style={styles.contrastMeta}>
-            <Text style={styles.contrastVerses}>{item.verses}</Text>
-            <View style={[styles.contrastTypePill, contrastTypeColor(item.type, colors)]}>
-              <Text style={styles.contrastTypeText}>{item.type}</Text>
+            <View style={styles.contrastVersesPill}>
+              <Text style={styles.contrastVersesPillText}>{item.verses}</Text>
+            </View>
+            <View style={[styles.contrastTypePill, contrastTypePillStyle(item.type, colors)]}>
+              <Text
+                style={[
+                  styles.contrastTypePillText,
+                  { color: contrastTypeTextColor(item.type, colors) },
+                ]}
+              >
+                {String(item.type).toUpperCase()}
+              </Text>
             </View>
           </View>
           <Text style={styles.contrastPairing}>{item.pairing}</Text>
@@ -313,29 +575,32 @@ function ContrastsStep({
   );
 }
 
-function contrastTypeColor(type: string, colors: ReturnType<typeof getColors>) {
-  // Three canonical tints; model-emitted variants ("Irony", etc.) fall
-  // through to the comparison tint so the row still renders cleanly.
-  switch (type) {
-    case 'Contrast':
-      return { backgroundColor: colors.gold };
-    case 'Comparison':
-    case 'Metaphor':
-    default:
-      return { backgroundColor: colors.backgroundElevated };
-  }
+/**
+ * Web styles CONTRAST as solid-gold border and COMPARISON as dashed-gold;
+ * other types (Metaphor, Irony, etc.) fall through to comparison.
+ */
+function contrastTypePillStyle(type: string, colors: Colors) {
+  const upper = String(type).toUpperCase();
+  const dashed = upper === 'COMPARISON';
+  return {
+    borderColor: colors.gold,
+    borderStyle: dashed ? ('dashed' as const) : ('solid' as const),
+  };
+}
+
+function contrastTypeTextColor(_type: string, colors: Colors) {
+  return colors.gold;
 }
 
 function BulletsStep({
   step,
-  colors,
+  styles,
   markdownStyles,
 }: {
   step: StepBullets;
-  colors: ReturnType<typeof getColors>;
-  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
 }) {
-  const styles = createStyles(colors);
   return (
     <View>
       {step.intro ? <Markdown style={markdownStyles}>{step.intro}</Markdown> : null}
@@ -362,17 +627,19 @@ function BulletsStep({
 
 function SegmentsStep({
   step,
-  colors,
+  styles,
   markdownStyles,
 }: {
   step: StepSegments;
-  colors: ReturnType<typeof getColors>;
-  markdownStyles: ReturnType<typeof createMarkdownStyles>;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
 }) {
-  const styles = createStyles(colors);
   return (
     <View>
-      <Text style={styles.themeHeadline}>{step.themeHeadline}</Text>
+      <View style={styles.themeBlock}>
+        <Text style={styles.themeLabel}>CHAPTER THEME</Text>
+        <Text style={styles.themeHeadline}>{step.themeHeadline}</Text>
+      </View>
       {step.segments.map((seg, i) => (
         <View key={`${seg.title}-${i}`} style={styles.segmentBlock}>
           <Text style={styles.segmentTitle}>{seg.title}</Text>
@@ -383,64 +650,291 @@ function SegmentsStep({
   );
 }
 
-// ─── Interpretation movements ────────────────────────────────────────────
+// ─── Movement (Interpretation) body ──────────────────────────────────────
 
-function MovementRenderer({
+function MovementBody({
   movement,
   colors,
+  styles,
   markdownStyles,
-  testID,
 }: {
   movement: StudyMovement;
-  colors: ReturnType<typeof getColors>;
-  markdownStyles: ReturnType<typeof createMarkdownStyles>;
-  testID: string;
+  colors: Colors;
+  styles: Styles;
+  markdownStyles: MarkdownStyles;
 }) {
-  const styles = createStyles(colors);
   return (
-    <View style={styles.movementCard} testID={testID}>
-      <View style={styles.movementHeader}>
-        <Text style={styles.movementNumber}>Movement {movement.number}</Text>
-        <Text style={styles.movementRange}>{movement.range}</Text>
-      </View>
-      <Text style={styles.movementTitle} accessibilityRole="header">
-        {movement.title}
-      </Text>
+    <View>
       {movement.excerpt ? (
         <View style={styles.excerptBlock}>
-          <Text style={styles.excerptText}>“{movement.excerpt}”</Text>
+          <Text style={styles.excerptText}>"{movement.excerpt}"</Text>
         </View>
       ) : null}
-      <View style={styles.movementBody}>
-        <Markdown style={markdownStyles}>{movement.body}</Markdown>
-      </View>
+      <Markdown style={markdownStyles}>{movement.body}</Markdown>
     </View>
   );
 }
 
-// ─── Application question ────────────────────────────────────────────────
+// ─── Application row ─────────────────────────────────────────────────────
 
-function ApplicationRenderer({
+function ApplicationRow({
   question,
-  colors,
+  styles,
   testID,
 }: {
   question: StudyApplication;
-  colors: ReturnType<typeof getColors>;
+  colors: Colors;
+  styles: Styles;
   testID: string;
 }) {
-  const styles = createStyles(colors);
   return (
-    <View style={styles.appCard} testID={testID}>
-      <Text style={styles.appRange}>{question.range}</Text>
+    <View style={styles.appRow} testID={testID}>
+      <View style={styles.appRangePill}>
+        <Text style={styles.appRangePillText}>{question.range}</Text>
+      </View>
       <Text style={styles.appQuestion}>{question.question}</Text>
     </View>
   );
 }
 
+// ─── Collapsible primitives ──────────────────────────────────────────────
+
+interface CardProps {
+  open: boolean;
+  onToggle: () => void;
+  heading: string;
+  subheading?: string;
+  /** Number for the gold circle on Observation step cards. */
+  stepNumber?: number;
+  /** Verse-range pill rendered to the left of the heading (interpretation movements). */
+  subPill?: string;
+  colors: Colors;
+  styles: Styles;
+  testID: string;
+  children: React.ReactNode;
+}
+
+function Card({
+  open,
+  onToggle,
+  heading,
+  subheading,
+  stepNumber,
+  subPill,
+  colors,
+  styles,
+  testID,
+  children,
+}: CardProps) {
+  return (
+    <View style={styles.card} testID={testID}>
+      <Pressable
+        onPress={onToggle}
+        style={styles.cardHeaderPressable}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        accessibilityLabel={heading}
+        testID={`${testID}-toggle`}
+      >
+        <View style={styles.cardHeader}>
+          <View style={styles.cardHeaderContent}>
+            <View style={styles.cardHeadingRow}>
+              {typeof stepNumber === 'number' ? (
+                <View style={styles.stepNumberCircle}>
+                  <Text style={styles.stepNumberText}>{stepNumber}</Text>
+                </View>
+              ) : null}
+              {subPill ? (
+                <View style={styles.rangePill}>
+                  <Text style={styles.rangePillText}>{subPill}</Text>
+                </View>
+              ) : null}
+              <Text style={styles.cardHeading} accessibilityRole="header">
+                {heading}
+              </Text>
+            </View>
+            {subheading ? <Text style={styles.cardSubheading}>{subheading}</Text> : null}
+          </View>
+          <Ionicons
+            name={open ? 'chevron-up' : 'chevron-down'}
+            size={18}
+            color={colors.textSecondary}
+          />
+        </View>
+      </Pressable>
+      {open ? <View style={styles.cardBody}>{children}</View> : null}
+    </View>
+  );
+}
+
+interface NestedCardProps {
+  open: boolean;
+  onToggle: () => void;
+  heading: string;
+  tag?: string;
+  colors: Colors;
+  styles: Styles;
+  testID: string;
+  children: React.ReactNode;
+}
+
+function NestedCard({
+  open,
+  onToggle,
+  heading,
+  tag,
+  colors,
+  styles,
+  testID,
+  children,
+}: NestedCardProps) {
+  return (
+    <View style={styles.nestedCard} testID={testID}>
+      <Pressable
+        onPress={onToggle}
+        style={styles.nestedHeaderPressable}
+        accessibilityRole="button"
+        accessibilityState={{ expanded: open }}
+        accessibilityLabel={heading}
+        testID={`${testID}-toggle`}
+      >
+        <View style={styles.nestedHeader}>
+          <View style={styles.nestedHeaderContent}>
+            {tag ? (
+              <View style={styles.nestedTag}>
+                <Text style={styles.nestedTagText}>{tag}</Text>
+              </View>
+            ) : null}
+            <Text style={styles.nestedHeading}>{heading}</Text>
+          </View>
+          <Ionicons
+            name={open ? 'chevron-up' : 'chevron-down'}
+            size={16}
+            color={colors.textSecondary}
+          />
+        </View>
+      </Pressable>
+      {open ? <View style={styles.nestedBody}>{children}</View> : null}
+    </View>
+  );
+}
+
+// ─── Copy-text helpers (parity with web buildStudyCopyText) ──────────────
+
+function stripStudyMarkdown(text: string): string {
+  return text
+    .replace(/^#+\s*/gm, '')
+    .replace(/^>\s?/gm, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .trim();
+}
+
+/**
+ * Serialise an InductiveStudy to plain text for the Copy / Share buttons.
+ * Mirrors web/src/components/StudyPanel.tsx::buildStudyCopyText.
+ */
+export function buildStudyCopyText(study: InductiveStudy): string {
+  const lines: string[] = [];
+  lines.push(`Inductive Study of ${study.title}`);
+  if (study.subtitle) lines.push(study.subtitle);
+  if (study.themeOneLine) {
+    lines.push('');
+    lines.push(`Theme: ${study.themeOneLine}`);
+  }
+  lines.push('');
+  lines.push('OBSERVATION — 9 INDUCTIVE STEPS');
+  for (const step of study.steps) {
+    lines.push('');
+    lines.push(`${step.number}. ${step.title}`);
+    if (step.summary) lines.push(`   ${step.summary}`);
+    switch (step.kind) {
+      case 'prose':
+        lines.push('');
+        lines.push(stripStudyMarkdown(step.body));
+        break;
+      case 'qa':
+        for (const item of step.items) {
+          lines.push('');
+          if (item.tag) lines.push(`   [${item.tag}] ${item.q}`);
+          else lines.push(`   ${item.q}`);
+          lines.push(`   ${stripStudyMarkdown(item.a)}`);
+        }
+        break;
+      case 'keywords':
+        for (const row of step.inventory) {
+          lines.push('');
+          const greek = row.greek ? ` (${row.greek})` : '';
+          lines.push(`   ${row.word}${greek} — ×${row.count} — ${row.verses}`);
+          if (row.definition) lines.push(`   ${stripStudyMarkdown(row.definition)}`);
+        }
+        break;
+      case 'lists':
+        for (const list of step.lists) {
+          lines.push('');
+          lines.push(`   ${list.title}`);
+          for (const r of list.rows) {
+            lines.push(`   • ${r.ref} — ${stripStudyMarkdown(r.truth)}`);
+          }
+        }
+        break;
+      case 'contrasts':
+        for (const item of step.items) {
+          lines.push(`   • ${item.verses} (${item.type}) — ${stripStudyMarkdown(item.pairing)}`);
+        }
+        break;
+      case 'bullets':
+        if (step.intro) {
+          lines.push('');
+          lines.push(`   ${stripStudyMarkdown(step.intro)}`);
+        }
+        for (const item of step.items) {
+          const tag = item.tag ? `[${item.tag}] ` : '';
+          lines.push(`   • ${tag}${stripStudyMarkdown(item.text)}`);
+        }
+        if (step.note) {
+          lines.push('');
+          lines.push(`   ${stripStudyMarkdown(step.note)}`);
+        }
+        break;
+      case 'segments':
+        if (step.themeHeadline) {
+          lines.push('');
+          lines.push(`   Chapter theme: ${step.themeHeadline}`);
+        }
+        for (const seg of step.segments) {
+          lines.push('');
+          lines.push(`   ${seg.title}`);
+          lines.push(`   ${stripStudyMarkdown(seg.body)}`);
+        }
+        break;
+    }
+  }
+  lines.push('');
+  lines.push('INTERPRETATION');
+  for (const mv of study.interpretation.movements) {
+    lines.push('');
+    lines.push(`Movement ${mv.number} — ${mv.title} (${mv.range})`);
+    if (mv.excerpt) lines.push(`   "${mv.excerpt}"`);
+    lines.push('');
+    lines.push(stripStudyMarkdown(mv.body));
+  }
+  lines.push('');
+  lines.push('APPLICATION');
+  if (study.application.intro) {
+    lines.push('');
+    lines.push(stripStudyMarkdown(study.application.intro));
+  }
+  for (const q of study.application.questions) {
+    lines.push('');
+    lines.push(`${q.range} — ${q.question}`);
+  }
+  return lines.join('\n');
+}
+
 // ─── Styles ──────────────────────────────────────────────────────────────
 
-const createStyles = (colors: ReturnType<typeof getColors>) =>
+const createStyles = (colors: Colors) =>
   StyleSheet.create({
     container: {
       paddingHorizontal: spacing.lg,
@@ -457,105 +951,189 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
       textAlign: 'center',
     },
 
-    header: {
-      marginBottom: spacing.lg,
+    titleRow: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      alignItems: 'flex-start',
+      marginBottom: spacing.xs,
+      gap: spacing.sm,
     },
     title: {
-      fontSize: fontSizes.heading1,
+      flex: 1,
+      fontSize: fontSizes.heading2,
       fontWeight: fontWeights.bold,
       color: colors.textPrimary,
-      marginBottom: spacing.xs,
+      lineHeight: fontSizes.heading2 * lineHeights.heading,
+    },
+    titleActions: {
+      flexDirection: 'row',
+      gap: spacing.xs,
+    },
+    iconButton: {
+      padding: 6,
     },
     subtitle: {
       fontSize: fontSizes.bodySmall,
       fontStyle: 'italic',
       color: colors.textSecondary,
-      marginBottom: spacing.sm,
+      marginBottom: spacing.xs,
     },
     theme: {
       fontSize: fontSizes.body,
       fontWeight: fontWeights.semibold,
       color: colors.gold,
       lineHeight: fontSizes.body * lineHeights.body,
+      marginBottom: spacing.sm,
     },
 
-    intro: {
+    expandAllRow: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      marginBottom: spacing.sm,
+    },
+    expandAllText: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.gold,
+      fontWeight: fontWeights.semibold,
+    },
+
+    sectionHeadingWrap: {
+      marginTop: spacing.xl,
+      marginBottom: spacing.sm,
+    },
+    sectionHeadingText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      textTransform: 'uppercase',
+      letterSpacing: 2,
+    },
+
+    sectionIntro: {
       fontSize: fontSizes.bodySmall,
       color: colors.textSecondary,
       lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+    applicationIntro: {
       marginBottom: spacing.md,
     },
 
-    // Observation step card
-    stepCard: {
-      backgroundColor: colors.backgroundElevated,
-      borderRadius: 12,
-      padding: spacing.md,
-      marginBottom: spacing.md,
-      borderLeftWidth: 3,
-      borderLeftColor: colors.gold,
+    // Card
+    card: {
+      borderBottomWidth: 1,
+      borderBottomColor: colors.gray100,
     },
-    stepHeader: {
+    cardHeaderPressable: {
+      paddingVertical: spacing.md,
+    },
+    cardHeader: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      marginBottom: spacing.sm,
+      justifyContent: 'space-between',
+      gap: spacing.sm,
     },
-    stepNumber: {
-      fontSize: fontSizes.heading1,
-      fontWeight: fontWeights.bold,
-      color: colors.gold,
-      width: 36,
-      lineHeight: fontSizes.heading1,
-    },
-    stepTitleBlock: {
+    cardHeaderContent: {
       flex: 1,
+      minWidth: 0,
     },
-    stepTitle: {
-      fontSize: fontSizes.heading3,
-      fontWeight: fontWeights.semibold,
-      color: colors.textPrimary,
-      marginBottom: spacing.xs,
+    cardHeadingRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
+      flexWrap: 'wrap',
     },
-    stepSummary: {
-      fontSize: fontSizes.bodySmall,
-      fontStyle: 'italic',
-      color: colors.textSecondary,
-    },
-    stepBody: {
-      marginTop: spacing.sm,
-    },
-
-    // QA
-    qaItem: {
-      marginBottom: spacing.md,
-      paddingTop: spacing.sm,
-      borderTopWidth: 1,
-      borderTopColor: colors.gray100,
-    },
-    tagPill: {
-      alignSelf: 'flex-start',
-      paddingHorizontal: spacing.sm,
-      paddingVertical: 2,
-      borderRadius: 4,
-      backgroundColor: colors.gold,
-      marginBottom: spacing.xs,
-    },
-    tagPillText: {
-      fontSize: fontSizes.caption,
-      fontWeight: fontWeights.bold,
-      color: colors.gray900,
-      letterSpacing: 1,
-    },
-    qaQuestion: {
+    cardHeading: {
+      flexShrink: 1,
       fontSize: fontSizes.body,
       fontWeight: fontWeights.semibold,
       color: colors.textPrimary,
-      marginBottom: spacing.xs,
+      lineHeight: fontSizes.body * lineHeights.heading,
     },
-    qaAnswer: {
+    cardSubheading: {
       fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
       color: colors.textSecondary,
+      marginTop: spacing.xs,
+      paddingLeft: 36, // align under step title (28px circle + ~8px gap)
       lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+    cardBody: {
+      paddingBottom: spacing.md,
+    },
+
+    // Step number circle
+    stepNumberCircle: {
+      width: 28,
+      height: 28,
+      borderRadius: 14,
+      backgroundColor: colors.gold,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    stepNumberText: {
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
+    },
+
+    // Range pill (used on interpretation movements + lists rows)
+    rangePill: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: colors.gold,
+      minWidth: 56,
+      alignItems: 'center',
+    },
+    rangePillText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
+    },
+
+    // NestedCard
+    nestedCard: {
+      borderTopWidth: 1,
+      borderTopColor: colors.gray100,
+    },
+    nestedHeaderPressable: {
+      paddingVertical: spacing.sm,
+    },
+    nestedHeader: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: spacing.sm,
+    },
+    nestedHeaderContent: {
+      flex: 1,
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.sm,
+      flexWrap: 'wrap',
+    },
+    nestedHeading: {
+      flex: 1,
+      flexShrink: 1,
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.heading,
+    },
+    nestedTag: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: colors.gold,
+    },
+    nestedTagText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
+      letterSpacing: 0.5,
+    },
+    nestedBody: {
+      paddingBottom: spacing.sm,
     },
 
     // Keywords
@@ -579,52 +1157,77 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
     keywordGreek: {
       fontSize: fontSizes.bodySmall,
       fontStyle: 'italic',
-      color: colors.gold,
+      color: colors.textSecondary,
     },
     countBadge: {
+      marginLeft: 'auto',
       paddingHorizontal: spacing.sm,
       paddingVertical: 2,
-      borderRadius: 4,
-      backgroundColor: colors.backgroundElevated,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: colors.gold,
     },
     countBadgeText: {
       fontSize: fontSizes.caption,
-      fontWeight: fontWeights.semibold,
-      color: colors.textSecondary,
-    },
-    keywordDef: {
-      fontSize: fontSizes.bodySmall,
-      color: colors.textSecondary,
-      lineHeight: fontSizes.bodySmall * lineHeights.body,
-      marginBottom: spacing.xs,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
     },
     keywordVerses: {
       fontSize: fontSizes.caption,
       color: colors.textSecondary,
-      fontFamily: undefined,
+      marginBottom: spacing.xs,
+    },
+    keywordVersesLabel: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.textSecondary,
+      letterSpacing: 1,
+    },
+    keywordDef: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
     },
 
     // Lists
-    listBlock: {
-      marginBottom: spacing.lg,
+    listHeaderRow: {
+      flexDirection: 'row',
+      paddingVertical: spacing.xs,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.gray100,
+      marginBottom: spacing.xs,
     },
-    listTitle: {
-      fontSize: fontSizes.body,
+    listHeaderCell: {
+      fontSize: fontSizes.caption,
       fontWeight: fontWeights.bold,
-      color: colors.textPrimary,
-      marginBottom: spacing.sm,
+      color: colors.gold,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+    },
+    listHeaderRef: {
+      width: 80,
+    },
+    listHeaderTruth: {
+      flex: 1,
     },
     listRow: {
       flexDirection: 'row',
+      alignItems: 'flex-start',
       paddingVertical: spacing.xs,
-      borderTopWidth: 1,
-      borderTopColor: colors.gray100,
+      gap: spacing.sm,
     },
-    listRef: {
-      width: 70,
-      fontSize: fontSizes.bodySmall,
-      fontWeight: fontWeights.semibold,
-      color: colors.gold,
+    listRefPill: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: colors.gold,
+      minWidth: 64,
+      alignItems: 'center',
+    },
+    listRefPillText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
     },
     listTruth: {
       flex: 1,
@@ -636,29 +1239,41 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
     // Contrasts
     contrastRow: {
       paddingVertical: spacing.sm,
-      borderTopWidth: 1,
-      borderTopColor: colors.gray100,
+      paddingHorizontal: spacing.sm,
+      borderRadius: 8,
+      backgroundColor: colors.backgroundElevated,
+      borderWidth: 1,
+      borderColor: colors.gray100,
+      marginBottom: spacing.xs,
     },
     contrastMeta: {
       flexDirection: 'row',
       alignItems: 'center',
       gap: spacing.sm,
       marginBottom: spacing.xs,
+      flexWrap: 'wrap',
     },
-    contrastVerses: {
-      fontSize: fontSizes.bodySmall,
-      fontWeight: fontWeights.semibold,
-      color: colors.gold,
+    contrastVersesPill: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: colors.gold,
+    },
+    contrastVersesPillText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gray900,
     },
     contrastTypePill: {
       paddingHorizontal: spacing.sm,
       paddingVertical: 2,
-      borderRadius: 4,
+      borderRadius: 999,
+      borderWidth: 1,
     },
-    contrastTypeText: {
+    contrastTypePillText: {
       fontSize: fontSizes.caption,
-      fontWeight: fontWeights.semibold,
-      color: colors.gray900,
+      fontWeight: fontWeights.bold,
+      letterSpacing: 1,
     },
     contrastPairing: {
       fontSize: fontSizes.bodySmall,
@@ -670,13 +1285,15 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
     bulletItem: {
       flexDirection: 'row',
       alignItems: 'flex-start',
-      marginBottom: spacing.sm,
+      paddingVertical: spacing.sm,
       gap: spacing.sm,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.gray100,
     },
     bulletTag: {
       paddingHorizontal: spacing.sm,
       paddingVertical: 2,
-      borderRadius: 4,
+      borderRadius: 999,
       backgroundColor: colors.gold,
       marginTop: 2,
     },
@@ -684,29 +1301,49 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
       fontSize: fontSizes.caption,
       fontWeight: fontWeights.bold,
       color: colors.gray900,
-      letterSpacing: 1,
+      letterSpacing: 0.5,
     },
     bulletBody: {
       flex: 1,
     },
     noteBlock: {
-      marginTop: spacing.md,
+      marginTop: spacing.sm,
       padding: spacing.md,
       borderRadius: 8,
       backgroundColor: colors.backgroundElevated,
     },
 
-    // Segments (chapter theme)
-    themeHeadline: {
-      fontSize: fontSizes.heading3,
-      fontWeight: fontWeights.bold,
-      fontStyle: 'italic',
-      color: colors.gold,
+    // Segments
+    themeBlock: {
       marginBottom: spacing.md,
-      lineHeight: fontSizes.heading3 * lineHeights.body,
+      padding: spacing.md,
+      borderRadius: 10,
+      backgroundColor: colors.backgroundElevated,
+      borderLeftWidth: 3,
+      borderLeftColor: colors.gold,
+    },
+    themeLabel: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+      marginBottom: spacing.xs,
+    },
+    themeHeadline: {
+      fontSize: fontSizes.body,
+      fontStyle: 'italic',
+      color: colors.textPrimary,
+      fontWeight: fontWeights.semibold,
+      lineHeight: fontSizes.body * lineHeights.body,
     },
     segmentBlock: {
-      marginBottom: spacing.md,
+      padding: spacing.md,
+      borderRadius: 8,
+      backgroundColor: colors.backgroundElevated,
+      borderWidth: 1,
+      borderColor: colors.gray100,
+      marginBottom: spacing.sm,
     },
     segmentTitle: {
       fontSize: fontSizes.body,
@@ -715,35 +1352,7 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
       marginBottom: spacing.xs,
     },
 
-    // Movements
-    movementCard: {
-      marginBottom: spacing.lg,
-      paddingBottom: spacing.md,
-    },
-    movementHeader: {
-      flexDirection: 'row',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      marginBottom: spacing.xs,
-    },
-    movementNumber: {
-      fontSize: fontSizes.caption,
-      fontWeight: fontWeights.bold,
-      color: colors.gold,
-      textTransform: 'uppercase',
-      letterSpacing: 1,
-    },
-    movementRange: {
-      fontSize: fontSizes.caption,
-      fontWeight: fontWeights.semibold,
-      color: colors.textSecondary,
-    },
-    movementTitle: {
-      fontSize: fontSizes.heading3,
-      fontWeight: fontWeights.bold,
-      color: colors.textPrimary,
-      marginBottom: spacing.sm,
-    },
+    // Movement excerpt
     excerptBlock: {
       borderLeftWidth: 3,
       borderLeftColor: colors.gold,
@@ -754,36 +1363,40 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
     excerptText: {
       fontSize: fontSizes.bodySmall,
       fontStyle: 'italic',
-      color: colors.textSecondary,
+      color: colors.textPrimary,
       lineHeight: fontSizes.bodySmall * lineHeights.body,
-    },
-    movementBody: {
-      marginTop: spacing.sm,
     },
 
     // Application
-    appCard: {
-      backgroundColor: colors.backgroundElevated,
-      borderRadius: 8,
-      padding: spacing.md,
-      marginBottom: spacing.sm,
-      borderLeftWidth: 3,
-      borderLeftColor: colors.gold,
+    appRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: spacing.sm,
+      paddingVertical: spacing.sm,
     },
-    appRange: {
+    appRangePill: {
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 999,
+      backgroundColor: colors.gold,
+      minWidth: 56,
+      alignItems: 'center',
+      marginTop: 2,
+    },
+    appRangePillText: {
       fontSize: fontSizes.caption,
       fontWeight: fontWeights.bold,
-      color: colors.gold,
-      marginBottom: spacing.xs,
+      color: colors.gray900,
     },
     appQuestion: {
+      flex: 1,
       fontSize: fontSizes.bodySmall,
       color: colors.textPrimary,
       lineHeight: fontSizes.bodySmall * lineHeights.body,
     },
   });
 
-const createMarkdownStyles = (colors: ReturnType<typeof getColors>) => ({
+const createMarkdownStyles = (colors: Colors) => ({
   body: {
     fontSize: fontSizes.bodySmall,
     color: colors.textPrimary,
@@ -805,6 +1418,7 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) => ({
     paddingLeft: spacing.md,
     marginVertical: spacing.sm,
     backgroundColor: 'transparent',
+    fontStyle: 'italic' as const,
   },
   link: {
     color: colors.gold,

--- a/hooks/bible/use-active-tab.ts
+++ b/hooks/bible/use-active-tab.ts
@@ -93,7 +93,9 @@ export function useActiveTab(): UseActiveTabResult {
   const setActiveTab = async (tab: ContentTabType): Promise<void> => {
     try {
       if (!isContentTabType(tab)) {
-        throw new Error(`Invalid tab type: ${tab}. Must be 'summary', 'byline', or 'detailed'.`);
+        throw new Error(
+          `Invalid tab type: ${tab}. Must be 'summary', 'byline', 'detailed', or 'study'.`
+        );
       }
       setActiveTabState(tab);
       inMemoryCache = tab;

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,7 +25,9 @@ module.exports = {
 
   // Transform Expo, React Native, and MSW packages
   transformIgnorePatterns: [
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|msw|@mswjs/.*|@bundled-es-modules/.*|until-async))',
+    // Whitelist @versemate/studies — ships .ts source via a github: dep,
+    // so Jest needs to run it through babel-jest like any project file.
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|msw|@mswjs/.*|@bundled-es-modules/.*|until-async|@versemate/studies))',
   ],
 
   // Ignore flow type files

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -77,7 +77,7 @@ export interface ViewModeSwitchedProperties {
 }
 
 export interface ExplanationTabChangedProperties {
-  tab: 'summary' | 'byline' | 'detailed';
+  tab: 'summary' | 'byline' | 'detailed' | 'study';
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
-    "@versemate/studies": "github:verse-mate/verse-mate-studies#4fa8065",
+    "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-community/slider": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@versemate/studies": "github:verse-mate/verse-mate-studies#4fa8065",
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-native-community/slider": "5.0.1",

--- a/test-setup.ts
+++ b/test-setup.ts
@@ -68,6 +68,15 @@ jest.mock('@/contexts/OfflineContext', () => ({
   OfflineProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+// Mock @versemate/studies to keep tests off the dynamic-import code-split path.
+// The real package does `await import(...)` per chapter to keep bundles small,
+// but jest's CJS environment errors with "dynamic import callback was invoked
+// without --experimental-vm-modules". Tests that need real study content (e.g.
+// StudyPanel.test.tsx) override this with their own jest.mock.
+jest.mock('@versemate/studies', () => ({
+  getStudyFor: jest.fn().mockResolvedValue(null),
+}));
+
 // Mock device info to avoid AsyncStorage and Dimensions listeners in tests
 jest.mock('@/hooks/use-device-info', () => ({
   useDeviceInfo: () => ({

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "skipLibCheck": true,
     "paths": {
       "@/*": [
         "./*"
@@ -14,5 +15,11 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".expo",
+    "dist",
+    "build"
   ]
 }

--- a/types/bible.ts
+++ b/types/bible.ts
@@ -33,8 +33,10 @@ export type {
  * - summary: High-level chapter overview
  * - byline: Verse-by-verse explanation
  * - detailed: In-depth theological analysis
+ * - study: Inductive Bible study (Hendricks OIA / Precept method) — bundled
+ *   from the @versemate/studies package, no API fetch
  */
-export type ContentTabType = 'summary' | 'byline' | 'detailed';
+export type ContentTabType = 'summary' | 'byline' | 'detailed' | 'study';
 
 /**
  * View mode type for chapter screen
@@ -209,7 +211,8 @@ export const DEFAULT_CHAPTER = 1;
  */
 export function isContentTabType(value: unknown): value is ContentTabType {
   return (
-    typeof value === 'string' && (value === 'summary' || value === 'byline' || value === 'detailed')
+    typeof value === 'string' &&
+    (value === 'summary' || value === 'byline' || value === 'detailed' || value === 'study')
   );
 }
 


### PR DESCRIPTION
## Summary

Adds the **Study** tab to the existing Insight pane, mirroring the web app's tab structure (Summary / By Line / Detailed / Study). Renders the Hendricks OIA / Precept-method inductive study content for any chapter that has one — **all 1,189 Bible chapters** via the bundled [@versemate/studies](https://github.com/verse-mate/verse-mate-studies) package (no API call needed).

This is the mobile half of the cross-platform Study rollout already shipped on web.

## What lands

- **[components/bible/StudyPanel.tsx](components/bible/StudyPanel.tsx)** (new, ~750 lines): RN renderer with step-kind renderers for all 7 kinds (prose / qa / keywords / lists / contrasts / bullets / segments), interpretation movements, and application questions. Theme-aware via `useTheme()`; `testID` + `accessibilityRole` on every element. Markdown via `react-native-markdown-display`.
- **[components/bible/ChapterContentTabs.tsx](components/bible/ChapterContentTabs.tsx)**: 4-tab animation (`inputRange [0,1,2,3]`, `tabWidth = (W-20)/4`); tighter horizontal padding so "Detailed" doesn't truncate on narrow phone widths.
- **[components/bible/BibleExplanationsPanel.tsx](components/bible/BibleExplanationsPanel.tsx)**: 4th ScrollView always mounted (`display: 'none'` when not active so scroll position persists like the other 3); animation math updated.
- **[types/bible.ts](types/bible.ts)**: `'study'` added to `ContentTabType` + `isContentTabType` validator.
- **[hooks/bible/use-active-tab.ts](hooks/bible/use-active-tab.ts)**: error message accepts 'study'.
- **[lib/analytics/types.ts](lib/analytics/types.ts)**: `EXPLANATION_TAB_CHANGED` event accepts 'study'.
- **[package.json](package.json)**: `@versemate/studies` pinned to `4fa8065` (full 1,189-chapter coverage).
- **[tsconfig.json](tsconfig.json)**: added `skipLibCheck: true` + `exclude: [node_modules, ...]` — standard project hygiene; was missing before, causing the typechecker to descend into `node_modules/@versemate/studies` source.

## Test plan

- [x] `bun run type-check` clean
- [x] Existing `ChapterContentTabs` tests still pass (5/5)
- [ ] Reviewer: open any chapter → tap **Insight** → tap **Study** tab → verify the inductive study renders (theme tokens, scrolling, tap accessibility)
- [ ] Reviewer: switch between Study and Summary/By Line/Detailed → confirm scroll positions persist per tab
- [ ] Reviewer: open a chapter that has *no* study (none currently — all 1,189 are covered, but if any future chapter is added without a study, the empty state should show "No study available for this chapter yet.")
- [ ] Reviewer: verify "Detailed" label doesn't truncate on narrow widths (iPhone SE)

## Follow-ups (separate PRs)

- Maestro test: `.maestro/bible-reading/study-tab-flow.yaml`
- Optional: Storybook story for `StudyPanel`

🤖 Generated with [Claude Code](https://claude.com/claude-code)