### PR TITLE
fix(dictionary): rely on Webster's inline fallback on iOS

### DIFF
--- a/__tests__/components/bible/WordDefinitionTooltip.test.tsx
+++ b/__tests__/components/bible/WordDefinitionTooltip.test.tsx
@@ -10,7 +10,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import * as Clipboard from 'expo-clipboard';
 import * as Haptics from 'expo-haptics';
 import React from 'react';
-import { Share } from 'react-native';
+import { Platform, Share } from 'react-native';
 import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import type { DictionaryResult, StrongsEntry } from '@/types/dictionary';
 
@@ -525,7 +525,21 @@ describe('WordDefinitionTooltip', () => {
   });
 
   describe('Native Dictionary', () => {
-    it('should show native dictionary button when available', async () => {
+    it('should not show native dictionary button on iOS even when available', async () => {
+      mockHasDefinition.mockResolvedValue(true);
+
+      const { queryByTestId } = render(<WordDefinitionTooltip {...defaultProps} />);
+
+      jest.runAllTimers();
+
+      await waitFor(() => {
+        expect(queryByTestId('word-definition-native-button')).toBeNull();
+      });
+    });
+
+    it('should show native dictionary button on Android when available and no internal definition', async () => {
+      const originalOS = Platform.OS;
+      (Platform as { OS: string }).OS = 'android';
       mockHasDefinition.mockResolvedValue(true);
 
       const { getByTestId } = render(<WordDefinitionTooltip {...defaultProps} />);
@@ -535,6 +549,8 @@ describe('WordDefinitionTooltip', () => {
       await waitFor(() => {
         expect(getByTestId('word-definition-native-button')).toBeTruthy();
       });
+
+      (Platform as { OS: string }).OS = originalOS;
     });
 
     it('should not show native dictionary button when unavailable', async () => {
@@ -555,7 +571,9 @@ describe('WordDefinitionTooltip', () => {
       });
     });
 
-    it('should call showDefinition when native button pressed', async () => {
+    it('should call showDefinition when native button pressed on Android', async () => {
+      const originalOS = Platform.OS;
+      (Platform as { OS: string }).OS = 'android';
       mockHasDefinition.mockResolvedValue(true);
 
       const { getByTestId } = render(<WordDefinitionTooltip {...defaultProps} />);
@@ -568,11 +586,12 @@ describe('WordDefinitionTooltip', () => {
 
       fireEvent.press(getByTestId('word-definition-native-button'));
 
-      // Wait for async handler to complete
       await waitFor(() => {
         expect(Haptics.impactAsync).toHaveBeenCalledWith(Haptics.ImpactFeedbackStyle.Light);
         expect(mockShowDefinition).toHaveBeenCalledWith('love');
       });
+
+      (Platform as { OS: string }).OS = originalOS;
     });
   });
 

--- a/components/bible/WordDefinitionTooltip.tsx
+++ b/components/bible/WordDefinitionTooltip.tsx
@@ -161,7 +161,7 @@ export function WordDefinitionTooltip({
 
         // Check native dictionary availability (iOS only, or when no other source found)
         let hasNative = false;
-        if (nativeAvailable && (Platform.OS === 'ios' || result.source === 'none')) {
+        if (nativeAvailable && result.source === 'none' && Platform.OS !== 'ios') {
           hasNative = await hasDefinitionRef.current(word);
         }
 


### PR DESCRIPTION
UIReferenceLibraryViewController has no API to extract definition text, so the "Open in System Dictionary" button on iOS produced a worse UX than the inline Webster's 1913 fallback that lookupWord() already returns. Gate the native-dictionary availability check behind Platform.OS !== 'ios' so iOS reads identically to Android: Easton's → Strong's → Webster's → "No definition available".

Also polyfill global.File in jest-env-setup.js for Node 18, where undici v6+ expects it on globalThis.