### PR TITLE
fix(byline): preserve Bible scroll on switch to line-by-line (VER-74)

### DIFF
--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -408,12 +408,28 @@ export function ChapterPage({
     };
   }, [isPreloading]);
 
+  // Track explanation tab content heights for scroll syncing
+  const tabContentHeightsRef = useRef<
+    Record<string, { contentHeight: number; viewHeight: number }>
+  >({});
+
+  // VER-74: Pending scroll fractions awaiting a tab's first measurement.
+  // The previous one-shot 100ms timeout raced against staggered tab mounting
+  // (byline mounts at stage 3 / 1600ms when inactive) and against in-flight
+  // explanation fetches. We now stash the fraction here on view switch and let
+  // handleTabContentSizeChange apply it as soon as dims arrive.
+  const pendingScrollFractionRef = useRef<Record<string, number>>({});
+
   // Reset scroll state when book/chapter changes (not on view change)
   // biome-ignore lint/correctness/useExhaustiveDependencies: Ref reset should react to chapter change
   useEffect(() => {
     hasScrolledRef.current = false;
     sectionPositionsRef.current = {};
     currentScrollYRef.current = 0;
+    // VER-74: clear cross-view scroll state so a fraction or pending scroll
+    // from the previous chapter can't fire on the new one's first tab switch.
+    bibleScrollFractionRef.current = 0;
+    pendingScrollFractionRef.current = {};
 
     // Reset scroll position to top when chapter changes
     // This prevents "height teleportation" from previous chapter
@@ -437,16 +453,36 @@ export function ChapterPage({
     visibleYRangeRef.current = null;
   }, [bookId, chapterNumber]);
 
-  // Track explanation tab content heights for scroll syncing
-  const tabContentHeightsRef = useRef<
-    Record<string, { contentHeight: number; viewHeight: number }>
-  >({});
+  // Stable across renders: only reads refs, never state. Wrapping in useCallback
+  // with [] keeps the effect-dep list quiet without spurious re-runs.
+  const applyPendingScroll = useCallback((tab: string) => {
+    const fraction = pendingScrollFractionRef.current[tab];
+    if (fraction == null) return;
+    const dims = tabContentHeightsRef.current[tab];
+    if (!dims || dims.contentHeight <= dims.viewHeight) return;
+
+    const targetRef =
+      tab === 'summary'
+        ? summaryScrollRef
+        : tab === 'byline'
+          ? byLineScrollRef
+          : tab === 'detailed'
+            ? detailedScrollRef
+            : null;
+    if (!targetRef) return;
+
+    const scrollableHeight = dims.contentHeight - dims.viewHeight;
+    const targetY = Math.round(fraction * scrollableHeight);
+    targetRef.current?.scrollTo({ y: targetY, animated: false });
+    delete pendingScrollFractionRef.current[tab];
+  }, []);
 
   const handleTabContentSizeChange = (tab: string, contentHeight: number, viewHeight: number) => {
     tabContentHeightsRef.current[tab] = {
       contentHeight,
       viewHeight: viewHeight || viewportHeightRef.current,
     };
+    applyPendingScroll(tab);
   };
 
   // Sync scroll position when switching from Bible to explanations view
@@ -454,28 +490,17 @@ export function ChapterPage({
     if (activeView !== 'bible') {
       hasScrolledRef.current = true;
 
-      // Sync scroll position from Bible view to the active explanation tab
       const fraction = bibleScrollFractionRef.current;
       if (fraction > 0.01) {
-        const targetRef =
-          activeTab === 'summary'
-            ? summaryScrollRef
-            : activeTab === 'byline'
-              ? byLineScrollRef
-              : detailedScrollRef;
-
-        // Small delay to allow layout after view switch
-        setTimeout(() => {
-          const dims = tabContentHeightsRef.current[activeTab];
-          if (dims && dims.contentHeight > dims.viewHeight) {
-            const scrollableHeight = dims.contentHeight - dims.viewHeight;
-            const targetY = Math.round(fraction * scrollableHeight);
-            targetRef.current?.scrollTo({ y: targetY, animated: false });
-          }
-        }, 100);
+        // Record the desired fraction for the active tab. If dims are already
+        // measured we can scroll immediately; otherwise applyPendingScroll
+        // fires from handleTabContentSizeChange when the tab finishes mounting
+        // and its content lays out.
+        pendingScrollFractionRef.current[activeTab] = fraction;
+        applyPendingScroll(activeTab);
       }
     }
-  }, [activeView, activeTab]);
+  }, [activeView, activeTab, applyPendingScroll]);
 
   // Track last scroll position and timestamp for velocity calculation
   const lastScrollY = useRef(0);


### PR DESCRIPTION
## Summary

Fix VER-74: scroll position resets to top when switching from Bible view to the line-by-line (byline) explanation tab. Replaces the one-shot 100 ms `setTimeout` (which lost the race against staggered tab mounting and in-flight explanation fetches) with a deferred, measurement-driven scroll.

- Stash the desired fraction in a per-tab `pendingScrollFractionRef` on view switch and call `applyPendingScroll`.
- `applyPendingScroll` scrolls immediately if the tab's dims are already known; otherwise `handleTabContentSizeChange` fires it as soon as the first `onContentSizeChange` arrives.
- Clear `bibleScrollFractionRef` and `pendingScrollFractionRef` on chapter change so stale state from the previous chapter can't fire on the next first switch. Bible-view `scrollTo({y:0})` reset is unaffected.

Source: [VER-50](/VER/issues/VER-50) (QA confirmed). Closes [VER-74](/VER/issues/VER-74).

## Test plan

- [ ] Cold-open a chapter, scroll mid-chapter in Bible view, switch quickly to Line-by-Line → scroll lands near the same fractional position (not at top).
- [ ] Repeat the switch immediately after opening (before byline tab has mounted) — scroll still lands at fraction once byline measures.
- [ ] Change chapter via swipe/nav — Bible view still resets to top, no stale fraction leaks to the new chapter's first switch.
- [ ] Verify the Summary and Detailed tabs also pick up the pending scroll (same code path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)