### PR TITLE
fix(byline): reset Insight scroll to top on chapter change (VER-100)

### DIFF
--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -420,6 +420,14 @@ export function ChapterPage({
     // ONLY if shouldResetScroll is true (skipped during seamless pager snaps)
     if (shouldResetScroll) {
       animatedScrollRef.current?.scrollTo({ y: 0, animated: false });
+      // VER-100: explanation tab ScrollViews preserve their own scrollTop
+      // across chapter changes (most visibly on web, where the ScrollView's
+      // DOM node persists). Reset all three so users land at verse 1 of the
+      // new chapter on By Line / Summary / Detailed — matches the split-view
+      // path in BibleExplanationsPanel.tsx.
+      summaryScrollRef.current?.scrollTo({ y: 0, animated: false });
+      byLineScrollRef.current?.scrollTo({ y: 0, animated: false });
+      detailedScrollRef.current?.scrollTo({ y: 0, animated: false });
     }
 
     // Close tooltip and clear timers when changing book/chapter


### PR DESCRIPTION
## Summary

The [VER-41](/VER/issues/VER-41) fix scrolled the Bible view back to the top on chapter navigation but left the **Insight** tab ScrollViews (Summary / By Line / Detailed) at the previous chapter's pixel offset. On mobile.versemate.org the `ScrollView`'s DOM node persists across re-renders, so users land mid-chapter on the next chapter's By Line instead of at verse 1.

The split-view path (`BibleExplanationsPanel.tsx` 209-215) already resets all three explanation refs on chapter change; the phone-portrait `ChapterPage` only reset the Bible-view ref. Mirror the pattern in the same `useEffect` so behavior is consistent across layouts.

## Change

`components/bible/ChapterPage.tsx` — inside the existing `bookId / chapterNumber` reset effect, after `animatedScrollRef.current?.scrollTo({ y: 0, animated: false })`, also call `scrollTo({ y: 0, animated: false })` on `summaryScrollRef`, `byLineScrollRef`, and `detailedScrollRef`. Gated by the existing `shouldResetScroll` so seamless pager snaps are unaffected.

## Test plan

- [ ] Open https://mobile.versemate.org on Genesis 1, switch to Insight → By Line
- [ ] Scroll the By Line tab mid-chapter (≈ verse 5+)
- [ ] Tap Next Chapter → confirm By Line lands at verse 1 of Genesis 2 (not the previous pixel offset)
- [ ] Repeat for Summary and Detailed tabs
- [ ] Sanity check: Bible view continues to land at verse 1 on chapter change (no regression from VER-41)

🤖 Generated with [Claude Code](https://claude.com/claude-code)