### PR TITLE
fix(prefetch): skip next-chapter prefetch until book metadata loads (VER-75)

### DIFF
--- a/__tests__/integration/chapter-prefetch.test.tsx
+++ b/__tests__/integration/chapter-prefetch.test.tsx
@@ -159,6 +159,29 @@ describe('Chapter Prefetching', () => {
   });
 
   /**
+   * Test 5b (VER-75 regression): Skip prefetch while book metadata is loading.
+   *
+   * Previously, `useChapterState` defaulted totalChapters to 50 before metadata
+   * loaded, which made the prefetch boundary check pass for short books and
+   * request a non-existent next chapter (e.g. Galatians 7). The hook should
+   * now treat an undefined totalChapters as "not ready" and not prefetch.
+   */
+  it('does not prefetch when totalChapters is undefined (metadata still loading)', () => {
+    const prefetchSpy = jest.spyOn(queryClient, 'prefetchQuery');
+
+    // Simulate the call site at Galatians 6 before book metadata loads.
+    // Galatians is bookId=48 and has 6 chapters, but the hook does not know
+    // that yet, so it must skip the prefetch instead of falling back to 50.
+    renderHook(() => usePrefetchNextChapter(48, 6, undefined), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    expect(prefetchSpy).not.toHaveBeenCalled();
+
+    prefetchSpy.mockRestore();
+  });
+
+  /**
    * Test 6: Prefetching doesn't block main thread (synchronous execution)
    */
   it('executes prefetch synchronously without blocking', () => {

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -99,8 +99,15 @@ type ViewMode = 'bible' | 'explanations';
  */
 export default function ChapterScreen() {
   // V3 State Layer: Single source of truth for chapter navigation
-  const { bookId, chapterNumber, bookName, navigateToChapter, booksMetadata, totalChapters } =
-    useChapterState();
+  const {
+    bookId,
+    chapterNumber,
+    bookName,
+    navigateToChapter,
+    booksMetadata,
+    totalChapters,
+    chapterCount,
+  } = useChapterState();
 
   // Extract verse/tab params (not managed by useChapterState)
   const params = useLocalSearchParams<{
@@ -223,7 +230,9 @@ export default function ChapterScreen() {
   const { addRecentBook } = useRecentBooks();
 
   // Prefetch next/previous chapters in background (auto-fires via useEffect inside hooks)
-  usePrefetchNextChapter(bookId, chapterNumber, totalChapters);
+  // Pass the real chapterCount (not the 50 fallback) so we don't 404 on the last
+  // chapter of short books like Galatians 6 before metadata loads — VER-75.
+  usePrefetchNextChapter(bookId, chapterNumber, chapterCount);
   usePrefetchPreviousChapter(bookId, chapterNumber);
 
   // Get navigation metadata using hook

--- a/hooks/bible/__mocks__/index.ts
+++ b/hooks/bible/__mocks__/index.ts
@@ -60,6 +60,7 @@ export const useChapterState = jest.fn(() => ({
   navigateToChapter: jest.fn(),
   booksMetadata: [{ id: 1, name: 'Genesis', testament: 'OT', chapterCount: 50, genre: 1 }],
   totalChapters: 50,
+  chapterCount: 50,
 }));
 
 // Last read position hook (wraps API hook)

--- a/hooks/bible/use-chapter-state.ts
+++ b/hooks/bible/use-chapter-state.ts
@@ -100,6 +100,12 @@ export interface ChapterStateResult {
   booksMetadata: TestamentBook[] | undefined;
   /** Total chapters for the current book (defaults to 50 while loading) */
   totalChapters: number;
+  /**
+   * Real chapter count for the current book, or undefined while metadata loads.
+   * Callers that must not act on the fallback (e.g. prefetch boundary checks)
+   * should use this instead of `totalChapters`.
+   */
+  chapterCount: number | undefined;
 }
 
 /**
@@ -143,7 +149,8 @@ export function useChapterState(): ChapterStateResult {
     () => booksMetadata?.find((b) => b.id === state.bookId),
     [booksMetadata, state.bookId]
   );
-  const totalChapters = bookMetadata?.chapterCount || 50;
+  const chapterCount = bookMetadata?.chapterCount;
+  const totalChapters = chapterCount ?? 50;
 
   // Compute book name from bookId
   const bookName = useMemo(() => {
@@ -268,5 +275,6 @@ export function useChapterState(): ChapterStateResult {
     navigateToChapter,
     booksMetadata,
     totalChapters,
+    chapterCount,
   };
 }

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -589,12 +589,17 @@ export const useBibleDetailed = (
 export const usePrefetchNextChapter = (
   bookId: number,
   currentChapter: number,
-  totalChapters: number
+  totalChapters: number | undefined
 ) => {
   const queryClient = useQueryClient();
   const preferredLanguage = usePreferredLanguage();
 
   useEffect(() => {
+    // Skip prefetch until the book's real chapter count is known. Without this guard
+    // a stale fallback (e.g. 50) on a short book like Galatians would request
+    // Galatians 7 and 404, instead of crossing into the next book.
+    if (!totalChapters) return;
+
     let nextBookId = bookId;
     let nextChapter = currentChapter + 1;
 


### PR DESCRIPTION
## Summary

- `usePrefetchNextChapter` now accepts `number | undefined` for `totalChapters` and returns early when it is falsy, preventing the hook from firing a boundary check against the stale default of 50
- `useChapterState` exposes a new `chapterCount: number | undefined` field (the real chapter count, `undefined` while metadata loads). The existing `totalChapters` field keeps its `50` fallback for UI consumers (book-progress %, chapter picker)
- The chapter-screen call site now passes `chapterCount` — not `totalChapters` — to `usePrefetchNextChapter`
- Added regression test: `does not prefetch when totalChapters is undefined (metadata still loading)` in `chapter-prefetch.test.tsx`

## Root cause

On slow devices / cold starts `useBibleTestaments` hasn't resolved yet when the prefetch effect fires. The stale `50` default caused `nextChapter > totalChapters` (e.g. `7 > 50`) to evaluate `false` for short books, so the hook prefetched Galatians 7 (non-existent) instead of skipping or crossing into Ephesians 1. The 404 was silently swallowed by `prefetchQuery` — it did not block the current chapter render — but it generated noise and a wasted network round-trip.

## Test plan

- [ ] Regression unit test passes: `npm test -- chapter-prefetch`
- [ ] `totalChapters` remains a `number` (50 fallback) everywhere it is consumed by UI (book progress bar, chapter picker component)
- [ ] Manual smoke: open Galatians 6 on a clean install / throttled network — no 404 for Galatians 7 in network logs; prefetch fires only after metadata loads

Closes VER-75