### PR TITLE
feat(bible): @versemate/lexicon — tap dotted word → Greek/Hebrew popover

### DIFF
--- a/__mocks__/@versemate/lexicon.ts
+++ b/__mocks__/@versemate/lexicon.ts
@@ -1,0 +1,62 @@
+// Test-only mock for @versemate/lexicon.
+//
+// The real package ships 38 MB of generated TypeScript + JSON via a
+// `file:` symlink. Jest's babel transform tries to resolve
+// `@babel/runtime/helpers/...` relative to the source file's location
+// (outside the mobile repo's node_modules) and fails. Existing tests
+// don't actually exercise lexicon loading — ChapterReader just imports
+// from the package — so this stub keeps imports resolvable and
+// `loadAlignmentFor` returns `null` (the "no alignment" branch falls
+// straight through to the legacy WordDefinitionTooltip path).
+
+export type LemmaKey = string;
+
+export interface RelatedWord {
+  lemma: string;
+  translit: string;
+  note: string;
+}
+
+export interface LexEntry {
+  lemma: string;
+  translit: string;
+  pronunciation?: string;
+  strongs: string;
+  pos: string;
+  basicGloss: string;
+  semanticRange?: string[];
+  ntFrequency?: number;
+  otFrequency?: number;
+  loaded?: boolean;
+  related?: RelatedWord[];
+  notes?: string;
+}
+
+export interface AlignedToken {
+  surface: string;
+  lemma: LemmaKey;
+  contextual?: string;
+}
+
+export interface ChapterAlignment {
+  bookId: number;
+  book: string;
+  chapter: number;
+  version: string;
+  verses: Record<number, AlignedToken[]>;
+  lexicon: Record<LemmaKey, LexEntry>;
+  themeLemmas?: LemmaKey[];
+}
+
+export async function loadAlignmentFor(
+  _bookId: number,
+  _chapter: number,
+): Promise<ChapterAlignment | null> {
+  return null;
+}
+
+export function getBookSlug(_bookId: number): string | null {
+  return null;
+}
+
+export const BOOK_SLUGS: Record<number, string> = {};

--- a/__tests__/components/bible/HighlightedText.test.tsx
+++ b/__tests__/components/bible/HighlightedText.test.tsx
@@ -91,7 +91,31 @@ describe('HighlightedText', () => {
     expect(rootText.props.selectable).toBe(true);
   });
 
-  it('should have onLongPress handlers on segment Text elements for dictionary lookup', () => {
+  it('should wire onLongPress on segment Text elements when onWordSelect is provided', () => {
+    // Long-press is opt-in now: callers that want the legacy word-select
+    // gesture (BibleExplanationsPanel / TopicContentPanel) must pass
+    // onWordSelect. ChapterReader's lexicon mode deliberately leaves it
+    // off so native text selection can take over.
+    const { root } = render(
+      <HighlightedText
+        text="In the beginning God created the heavens and the earth."
+        verseNumber={1}
+        highlights={[mockHighlight]}
+        onWordSelect={() => {}}
+      />
+    );
+
+    const textElements = root.findAllByType(Text);
+    const elementsWithLongPress = textElements.filter(
+      (el: ReactTestInstance) => el.props.onLongPress !== undefined
+    );
+    expect(elementsWithLongPress.length).toBeGreaterThan(0);
+  });
+
+  it('should NOT wire onLongPress when neither onWordSelect nor onWordLongPress is provided', () => {
+    // Lexicon mode (ChapterReader after the dotted-underline migration):
+    // no per-word long-press handler so native text selection works on
+    // the outer selectable Text.
     const { root } = render(
       <HighlightedText
         text="In the beginning God created the heavens and the earth."
@@ -101,12 +125,10 @@ describe('HighlightedText', () => {
     );
 
     const textElements = root.findAllByType(Text);
-
-    // Segment Text elements should have onLongPress for dictionary
     const elementsWithLongPress = textElements.filter(
       (el: ReactTestInstance) => el.props.onLongPress !== undefined
     );
-    expect(elementsWithLongPress.length).toBeGreaterThan(0);
+    expect(elementsWithLongPress.length).toBe(0);
   });
 
   it('should render text with semi-transparent highlight background', () => {

--- a/bun.lock
+++ b/bun.lock
@@ -15,6 +15,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
+        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
         "expo-apple-authentication": "~8.0.8",
@@ -818,6 +819,8 @@
     "@urql/core": ["@urql/core@5.2.0", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.13", "wonka": "^6.3.2" } }, "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A=="],
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.3.2", "", { "dependencies": { "@urql/core": "^5.1.2", "wonka": "^6.3.2" } }, "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg=="],
+
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#26012e6", {}, "verse-mate-verse-mate-lexicon-26012e6"],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -32,11 +32,10 @@ import {
 import Markdown from 'react-native-markdown-display';
 import { BookmarkToggle } from '@/components/bible/BookmarkToggle';
 import { ErrorModal } from '@/components/bible/ErrorModal';
-import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
+import { HighlightedText } from '@/components/bible/HighlightedText';
 import { LexiconPopover } from '@/components/bible/LexiconPopover';
 import { NotesButton } from '@/components/bible/NotesButton';
 import { ShareButton } from '@/components/bible/ShareButton';
-import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import {
   type AlignedToken,
   type ChapterAlignment,
@@ -325,18 +324,11 @@ export function ChapterReader({
     return groupConsecutiveHighlights(chapterHighlights);
   }, [chapterHighlights]);
 
-  // Word definition tooltip state (legacy Easton/Strong/Webster path — used
-  // as fallback for words the lexicon doesn't cover).
-  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
-  const [wordToDefine, setWordToDefine] = useState<{
-    word: string;
-    verseNumber: number;
-  } | null>(null);
-
-  // Chapter-aligned Greek/Hebrew lexicon — preferred path. `loadAlignmentFor`
-  // returns null for chapters with no alignment (e.g. before the ingest runs
-  // on a new book), in which case every long-press falls back to the legacy
-  // dictionary tooltip.
+  // Chapter-aligned Greek/Hebrew lexicon. `loadAlignmentFor` returns null
+  // for chapters with no alignment (e.g. before the ingest runs on a new
+  // book) — in that case no words get the dotted underline and tap falls
+  // through to the regular verse-insight handler. Long-press always goes
+  // to native text selection in this screen now.
   const [alignment, setAlignment] = useState<ChapterAlignment | null>(null);
   useEffect(() => {
     let cancelled = false;
@@ -407,46 +399,6 @@ export function ChapterReader({
   };
 
   /**
-   * Handle word selection (long-press) from HighlightedText.
-   *
-   * Routing: if the pressed word matches a token in this chapter's
-   * alignment, open the LexiconPopover (Greek/Hebrew lexical card).
-   * Otherwise fall back to the legacy dictionary tooltip
-   * (Easton/Strong/Webster). The fallback covers (a) chapters with no
-   * alignment yet, and (b) words inside an aligned chapter that aren't
-   * tagged (proper nouns, English filler).
-   */
-  const handleWordSelect = (selection: WordSelection, clearSelection: () => void) => {
-    const tokens = alignment?.verses[selection.verseNumber] ?? [];
-    if (tokens.length > 0) {
-      // Strip trailing punctuation and lowercase for whole-word match.
-      const normalized = selection.word.toLowerCase().replace(/[.,;:!?'"’()]+$/g, '');
-      const matched = tokens.find((t) => t.surface.toLowerCase() === normalized);
-      if (matched) {
-        const entry = alignment?.lexicon[matched.lemma];
-        if (entry) {
-          setLexiconActive({
-            surface: selection.word,
-            entry,
-            token: matched,
-            isTheme: alignment?.themeLemmas?.includes(matched.lemma) ?? false,
-          });
-          clearSelection();
-          return;
-        }
-      }
-    }
-
-    // Fallback: legacy dictionary tooltip.
-    setWordToDefine({
-      word: selection.word,
-      verseNumber: selection.verseNumber,
-    });
-    setWordDefinitionVisible(true);
-    clearSelection();
-  };
-
-  /**
    * Handle tap on highlighted text
    * Shows grouped tooltip via context
    */
@@ -500,18 +452,20 @@ export function ChapterReader({
   };
 
   /**
-   * Handle close word definition tooltip
+   * Tap on a lexicon-covered word in the verse text — open the popover.
    */
-  const handleWordDefinitionClose = () => {
-    setWordDefinitionVisible(false);
-    setWordToDefine(null);
-  };
-
-  /**
-   * Handle copy from word definition tooltip
-   */
-  const handleWordDefinitionCopy = () => {
-    showToast('Copied to clipboard');
+  const handleLexiconWordPress = ({
+    surface,
+    token,
+    entry,
+    isTheme,
+  }: {
+    surface: string;
+    token: NonNullable<typeof lexiconActive>['token'];
+    entry: LexEntry;
+    isTheme: boolean;
+  }) => {
+    setLexiconActive({ surface, token, entry, isTheme });
   };
 
   /**
@@ -708,7 +662,8 @@ export function ChapterReader({
                                 onHighlightTap={handleHighlightTap}
                                 onAutoHighlightPress={handleAutoHighlightPress}
                                 onVerseTap={handleVerseTap}
-                                onWordSelect={handleWordSelect}
+                                alignment={alignment}
+                                onLexiconWordPress={handleLexiconWordPress}
                                 style={styles.verseTextInline}
                                 isVisible={isVerseVisible(group[0].verseNumber)}
                               />
@@ -739,7 +694,8 @@ export function ChapterReader({
                       onHighlightTap={handleHighlightTap}
                       onAutoHighlightPress={handleAutoHighlightPress}
                       onVerseTap={handleVerseTap}
-                      onWordSelect={handleWordSelect}
+                      alignment={alignment}
+                      onLexiconWordPress={handleLexiconWordPress}
                       style={styles.verseText}
                       isVisible={true}
                     />
@@ -847,20 +803,11 @@ export function ChapterReader({
         onClose={() => setErrorModalVisible(false)}
       />
 
-      {/* Word Definition Tooltip — legacy dictionary fallback */}
-      {wordToDefine && (
-        <WordDefinitionTooltip
-          visible={wordDefinitionVisible}
-          word={wordToDefine.word}
-          bookName={chapter.title.split(' ').slice(0, -1).join(' ')}
-          chapterNumber={chapter.chapterNumber}
-          verseNumber={wordToDefine.verseNumber}
-          onClose={handleWordDefinitionClose}
-          onCopy={handleWordDefinitionCopy}
-        />
-      )}
-
-      {/* Lexicon Popover — preferred path for words with chapter alignment */}
+      {/* Lexicon Popover — opens on tap of a dotted-underlined word.
+          Long-press is now reserved for native text selection; the legacy
+          Easton/Strong/Webster WordDefinitionTooltip is no longer wired
+          into the Bible reader (it still serves BibleExplanationsPanel
+          and topic surfaces, which keep the long-press → dictionary flow). */}
       {lexiconActive && (
         <LexiconPopover
           visible={true}

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -33,9 +33,16 @@ import Markdown from 'react-native-markdown-display';
 import { BookmarkToggle } from '@/components/bible/BookmarkToggle';
 import { ErrorModal } from '@/components/bible/ErrorModal';
 import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
+import { LexiconPopover } from '@/components/bible/LexiconPopover';
 import { NotesButton } from '@/components/bible/NotesButton';
 import { ShareButton } from '@/components/bible/ShareButton';
 import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
+import {
+  type AlignedToken,
+  type ChapterAlignment,
+  type LexEntry,
+  loadAlignmentFor,
+} from '@versemate/lexicon';
 import type { HighlightColor } from '@/constants/highlight-colors';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useBibleInteraction } from '@/contexts/BibleInteractionContext';
@@ -318,11 +325,35 @@ export function ChapterReader({
     return groupConsecutiveHighlights(chapterHighlights);
   }, [chapterHighlights]);
 
-  // Word definition tooltip state
+  // Word definition tooltip state (legacy Easton/Strong/Webster path — used
+  // as fallback for words the lexicon doesn't cover).
   const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
   const [wordToDefine, setWordToDefine] = useState<{
     word: string;
     verseNumber: number;
+  } | null>(null);
+
+  // Chapter-aligned Greek/Hebrew lexicon — preferred path. `loadAlignmentFor`
+  // returns null for chapters with no alignment (e.g. before the ingest runs
+  // on a new book), in which case every long-press falls back to the legacy
+  // dictionary tooltip.
+  const [alignment, setAlignment] = useState<ChapterAlignment | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    setAlignment(null);
+    loadAlignmentFor(chapter.bookId, chapter.chapterNumber).then((a) => {
+      if (!cancelled) setAlignment(a);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [chapter.bookId, chapter.chapterNumber]);
+
+  const [lexiconActive, setLexiconActive] = useState<{
+    surface: string;
+    entry: LexEntry;
+    token: AlignedToken;
+    isTheme: boolean;
   } | null>(null);
 
   // Line layout information for paragraph groups (for accurate tap detection)
@@ -376,18 +407,42 @@ export function ChapterReader({
   };
 
   /**
-   * Handle word selection from HighlightedText
-   * Directly opens dictionary definition (no intermediate selection UI)
+   * Handle word selection (long-press) from HighlightedText.
+   *
+   * Routing: if the pressed word matches a token in this chapter's
+   * alignment, open the LexiconPopover (Greek/Hebrew lexical card).
+   * Otherwise fall back to the legacy dictionary tooltip
+   * (Easton/Strong/Webster). The fallback covers (a) chapters with no
+   * alignment yet, and (b) words inside an aligned chapter that aren't
+   * tagged (proper nouns, English filler).
    */
   const handleWordSelect = (selection: WordSelection, clearSelection: () => void) => {
-    // Directly open definition
+    const tokens = alignment?.verses[selection.verseNumber] ?? [];
+    if (tokens.length > 0) {
+      // Strip trailing punctuation and lowercase for whole-word match.
+      const normalized = selection.word.toLowerCase().replace(/[.,;:!?'"’()]+$/g, '');
+      const matched = tokens.find((t) => t.surface.toLowerCase() === normalized);
+      if (matched) {
+        const entry = alignment?.lexicon[matched.lemma];
+        if (entry) {
+          setLexiconActive({
+            surface: selection.word,
+            entry,
+            token: matched,
+            isTheme: alignment?.themeLemmas?.includes(matched.lemma) ?? false,
+          });
+          clearSelection();
+          return;
+        }
+      }
+    }
+
+    // Fallback: legacy dictionary tooltip.
     setWordToDefine({
       word: selection.word,
       verseNumber: selection.verseNumber,
     });
     setWordDefinitionVisible(true);
-
-    // Clear any selection highlight
     clearSelection();
   };
 
@@ -792,7 +847,7 @@ export function ChapterReader({
         onClose={() => setErrorModalVisible(false)}
       />
 
-      {/* Word Definition Tooltip */}
+      {/* Word Definition Tooltip — legacy dictionary fallback */}
       {wordToDefine && (
         <WordDefinitionTooltip
           visible={wordDefinitionVisible}
@@ -802,6 +857,18 @@ export function ChapterReader({
           verseNumber={wordToDefine.verseNumber}
           onClose={handleWordDefinitionClose}
           onCopy={handleWordDefinitionCopy}
+        />
+      )}
+
+      {/* Lexicon Popover — preferred path for words with chapter alignment */}
+      {lexiconActive && (
+        <LexiconPopover
+          visible={true}
+          onClose={() => setLexiconActive(null)}
+          surface={lexiconActive.surface}
+          entry={lexiconActive.entry}
+          token={lexiconActive.token}
+          isTheme={lexiconActive.isTheme}
         />
       )}
     </View>

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -21,6 +21,12 @@
  * @see Task Group 3: Share Button and UI Integration
  */
 
+import {
+  type AlignedToken,
+  type ChapterAlignment,
+  type LexEntry,
+  loadAlignmentFor,
+} from '@versemate/lexicon';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type NativeSyntheticEvent,
@@ -36,18 +42,11 @@ import { HighlightedText } from '@/components/bible/HighlightedText';
 import { LexiconPopover } from '@/components/bible/LexiconPopover';
 import { NotesButton } from '@/components/bible/NotesButton';
 import { ShareButton } from '@/components/bible/ShareButton';
-import {
-  type AlignedToken,
-  type ChapterAlignment,
-  type LexEntry,
-  loadAlignmentFor,
-} from '@versemate/lexicon';
 import type { HighlightColor } from '@/constants/highlight-colors';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useBibleInteraction } from '@/contexts/BibleInteractionContext';
 import { isElementVisible, useTextVisibility } from '@/contexts/TextVisibilityContext';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useToast } from '@/contexts/ToastContext';
 import { useFontSize } from '@/hooks/bible/use-font-size';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import {
@@ -283,7 +282,6 @@ export function ChapterReader({
   const { fontSize: userFontSize } = useFontSize();
   const styles = createStyles(colors, explanationsOnly, userFontSize);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
-  const { showToast } = useToast();
 
   // Use Bible Interaction Context for highlights and interactions
   const {

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -1075,45 +1075,29 @@ const selectionStyles = StyleSheet.create({
 });
 
 /**
- * Styles for lexicon-covered words. Dotted underline in gold to mirror
- * the web's `.lex-word` / `.lex-word-theme` treatment.
+ * Styles for lexicon-covered words.
  *
- * Implementation note: `textDecorationStyle: 'dotted'` is iOS-only — Android
- * silently falls back to a solid line. To get real dots on both platforms
- * we use a Text-level `borderBottom` with `borderStyle: 'dotted'`, which
- * Android honors on inline Text. Combined with `textDecoration*` for iOS
- * (where the border approach can render lower than expected), both
- * platforms get a true dotted line.
+ * On iOS we get an actual dotted line via `textDecorationStyle: 'dotted'`,
+ * matching the web's `.lex-word` treatment exactly. On Android, RN's
+ * `textDecorationStyle` quietly falls back to `solid` — and `borderStyle:
+ * 'dotted'` doesn't render on inline `<Text>` either. So Android shows a
+ * solid gold underline for now; a custom SVG-based dotted underline is
+ * a follow-up.
  *
- * Theme words use a slightly thicker border + heavier weight so the
- * chapter's spine reads at a glance.
+ * Theme words get a slightly heavier weight so the chapter's spine
+ * reads at a glance.
  */
 const LEX_UNDERLINE = '#B09A6D';
 const lexiconWordStyles = StyleSheet.create({
-  regular: Platform.select({
-    ios: {
-      textDecorationLine: 'underline' as const,
-      textDecorationStyle: 'dotted' as const,
-      textDecorationColor: LEX_UNDERLINE,
-    },
-    default: {
-      borderBottomWidth: 1,
-      borderStyle: 'dotted' as const,
-      borderColor: LEX_UNDERLINE,
-    },
-  }),
-  theme: Platform.select({
-    ios: {
-      textDecorationLine: 'underline' as const,
-      textDecorationStyle: 'dotted' as const,
-      textDecorationColor: LEX_UNDERLINE,
-      fontWeight: '500' as const,
-    },
-    default: {
-      borderBottomWidth: 1.5,
-      borderStyle: 'dotted' as const,
-      borderColor: LEX_UNDERLINE,
-      fontWeight: '500' as const,
-    },
-  }),
+  regular: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'dotted', // iOS: real dots; Android: falls back to solid
+    textDecorationColor: LEX_UNDERLINE,
+  },
+  theme: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'dotted',
+    textDecorationColor: LEX_UNDERLINE,
+    fontWeight: '500',
+  },
 });

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -31,9 +31,7 @@ import {
   Text,
   type TextLayoutEventData,
   type TextProps,
-  View,
 } from 'react-native';
-import Svg, { Line } from 'react-native-svg';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Highlight } from '@/hooks/bible/use-highlights';
@@ -838,12 +836,19 @@ export function HighlightedText({
             onResponderTerminationRequest: () => true,
           };
 
-          // Lexicon-covered word? Render via LexiconWord (Text + SVG dotted
-          // underline) and route tap to the lexicon callback. Trailing
-          // punctuation + space are siblings so the underline stops at the
-          // last word character.
+          // Lexicon-covered word? Render with dotted underline and route tap
+          // to the lexicon callback (not the segment's regular tap).
+          //
+          // Splitting:
+          //   token.word may include trailing punctuation ("trials,", "joy.").
+          //   We underline ONLY the word characters — punctuation and the
+          //   trailing space stay in a separate, unstyled Text so the dotted
+          //   line doesn't bleed past the word itself.
           const lexHit = lexiconMatch(token.word);
           if (lexHit && onLexiconWordPress) {
+            const lexStyle = lexHit.isTheme
+              ? lexiconWordStyles.theme
+              : lexiconWordStyles.regular;
             const match = token.word.match(/^([\p{L}\p{M}\p{N}'’-]+)(.*)$/u);
             const wordCore = match ? match[1] : token.word;
             const trailing = match ? match[2] : '';
@@ -854,10 +859,11 @@ export function HighlightedText({
                 suppressHighlighting={true}
                 {...responderProps}
               >
-                <LexiconWord
-                  text={wordCore}
-                  isTheme={lexHit.isTheme}
-                  selected={isSelected || verseTapSelected}
+                <Text
+                  style={[
+                    lexStyle,
+                    (isSelected || verseTapSelected) && selectionStyles.selected,
+                  ]}
                   onPress={() => {
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     onLexiconWordPress({
@@ -867,8 +873,12 @@ export function HighlightedText({
                       isTheme: lexHit.isTheme,
                     });
                   }}
+                  suppressHighlighting={true}
+                  accessibilityRole="button"
                   accessibilityLabel={`${wordCore} — ${lexHit.entry.translit}, ${lexHit.entry.basicGloss}`}
-                />
+                >
+                  {wordCore}
+                </Text>
                 {trailing}
                 {space}
               </Text>
@@ -1065,85 +1075,29 @@ const selectionStyles = StyleSheet.create({
 });
 
 /**
- * Lexicon-covered words. We can't rely on `textDecorationStyle: 'dotted'`
- * because Android silently falls back to solid, and `borderStyle: 'dotted'`
- * doesn't render on inline `<Text>` on Android. So we draw the underline
- * ourselves with an inline SVG element positioned beneath the word — works
- * the same on both platforms. Theme words get a slightly thicker stroke +
- * heavier weight so the chapter spine reads at a glance.
+ * Styles for lexicon-covered words.
+ *
+ * On iOS we get an actual dotted line via `textDecorationStyle: 'dotted'`,
+ * matching the web's `.lex-word` treatment exactly. On Android, RN's
+ * `textDecorationStyle` quietly falls back to `solid` — and `borderStyle:
+ * 'dotted'` doesn't render on inline `<Text>` either. So Android shows a
+ * solid gold underline for now; a custom SVG-based dotted underline is
+ * a follow-up.
+ *
+ * Theme words get a slightly heavier weight so the chapter's spine
+ * reads at a glance.
  */
 const LEX_UNDERLINE = '#B09A6D';
 const lexiconWordStyles = StyleSheet.create({
-  // Word-text style (no textDecoration — the SVG draws the line)
-  regular: {},
-  theme: { fontWeight: '500' },
-  // Outer wrapper: a positioning context for the absolutely-positioned SVG.
-  // View nested inside <Text> is inline-block in RN; it auto-sizes to its
-  // Text child after the first layout pass.
-  wrapper: { position: 'relative' as const },
-  svg: { position: 'absolute' as const, bottom: -2, left: 0 },
+  regular: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'dotted', // iOS: real dots; Android: falls back to solid
+    textDecorationColor: LEX_UNDERLINE,
+  },
+  theme: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: 'dotted',
+    textDecorationColor: LEX_UNDERLINE,
+    fontWeight: '500',
+  },
 });
-
-/**
- * Inline component that renders the lexicon word + an SVG dotted line
- * beneath. Measures its layout width on first paint, then re-renders the
- * SVG sized to that width. The 1-frame "no underline" flash on initial
- * mount is acceptable for a static verse renderer.
- */
-function LexiconWord({
-  text,
-  isTheme,
-  onPress,
-  accessibilityLabel,
-  selected,
-}: {
-  text: string;
-  isTheme: boolean;
-  onPress: () => void;
-  accessibilityLabel: string;
-  selected?: boolean;
-}) {
-  const [width, setWidth] = useState(0);
-
-  return (
-    <View
-      onLayout={(e) => {
-        const w = Math.round(e.nativeEvent.layout.width);
-        if (w !== width) setWidth(w);
-      }}
-      style={lexiconWordStyles.wrapper}
-    >
-      <Text
-        style={[
-          isTheme ? lexiconWordStyles.theme : lexiconWordStyles.regular,
-          selected ? selectionStyles.selected : null,
-        ]}
-        onPress={onPress}
-        suppressHighlighting={true}
-        accessibilityRole="button"
-        accessibilityLabel={accessibilityLabel}
-      >
-        {text}
-      </Text>
-      {width > 0 ? (
-        <Svg
-          width={width}
-          height={3}
-          style={lexiconWordStyles.svg}
-          pointerEvents="none"
-        >
-          <Line
-            x1={0.5}
-            y1={1.5}
-            x2={width - 0.5}
-            y2={1.5}
-            stroke={LEX_UNDERLINE}
-            strokeWidth={isTheme ? 1.5 : 1}
-            strokeDasharray="1,2"
-            strokeLinecap="round"
-          />
-        </Svg>
-      ) : null}
-    </View>
-  );
-}

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -31,7 +31,9 @@ import {
   Text,
   type TextLayoutEventData,
   type TextProps,
+  View,
 } from 'react-native';
+import Svg, { Line } from 'react-native-svg';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Highlight } from '@/hooks/bible/use-highlights';
@@ -836,19 +838,12 @@ export function HighlightedText({
             onResponderTerminationRequest: () => true,
           };
 
-          // Lexicon-covered word? Render with dotted underline and route tap
-          // to the lexicon callback (not the segment's regular tap).
-          //
-          // Splitting:
-          //   token.word may include trailing punctuation ("trials,", "joy.").
-          //   We underline ONLY the word characters — punctuation and the
-          //   trailing space stay in a separate, unstyled Text so the dotted
-          //   line doesn't bleed past the word itself.
+          // Lexicon-covered word? Render via LexiconWord (Text + SVG dotted
+          // underline) and route tap to the lexicon callback. Trailing
+          // punctuation + space are siblings so the underline stops at the
+          // last word character.
           const lexHit = lexiconMatch(token.word);
           if (lexHit && onLexiconWordPress) {
-            const lexStyle = lexHit.isTheme
-              ? lexiconWordStyles.theme
-              : lexiconWordStyles.regular;
             const match = token.word.match(/^([\p{L}\p{M}\p{N}'’-]+)(.*)$/u);
             const wordCore = match ? match[1] : token.word;
             const trailing = match ? match[2] : '';
@@ -859,11 +854,10 @@ export function HighlightedText({
                 suppressHighlighting={true}
                 {...responderProps}
               >
-                <Text
-                  style={[
-                    lexStyle,
-                    (isSelected || verseTapSelected) && selectionStyles.selected,
-                  ]}
+                <LexiconWord
+                  text={wordCore}
+                  isTheme={lexHit.isTheme}
+                  selected={isSelected || verseTapSelected}
                   onPress={() => {
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     onLexiconWordPress({
@@ -873,12 +867,8 @@ export function HighlightedText({
                       isTheme: lexHit.isTheme,
                     });
                   }}
-                  suppressHighlighting={true}
-                  accessibilityRole="button"
                   accessibilityLabel={`${wordCore} — ${lexHit.entry.translit}, ${lexHit.entry.basicGloss}`}
-                >
-                  {wordCore}
-                </Text>
+                />
                 {trailing}
                 {space}
               </Text>
@@ -1075,29 +1065,85 @@ const selectionStyles = StyleSheet.create({
 });
 
 /**
- * Styles for lexicon-covered words.
- *
- * On iOS we get an actual dotted line via `textDecorationStyle: 'dotted'`,
- * matching the web's `.lex-word` treatment exactly. On Android, RN's
- * `textDecorationStyle` quietly falls back to `solid` — and `borderStyle:
- * 'dotted'` doesn't render on inline `<Text>` either. So Android shows a
- * solid gold underline for now; a custom SVG-based dotted underline is
- * a follow-up.
- *
- * Theme words get a slightly heavier weight so the chapter's spine
- * reads at a glance.
+ * Lexicon-covered words. We can't rely on `textDecorationStyle: 'dotted'`
+ * because Android silently falls back to solid, and `borderStyle: 'dotted'`
+ * doesn't render on inline `<Text>` on Android. So we draw the underline
+ * ourselves with an inline SVG element positioned beneath the word — works
+ * the same on both platforms. Theme words get a slightly thicker stroke +
+ * heavier weight so the chapter spine reads at a glance.
  */
 const LEX_UNDERLINE = '#B09A6D';
 const lexiconWordStyles = StyleSheet.create({
-  regular: {
-    textDecorationLine: 'underline',
-    textDecorationStyle: 'dotted', // iOS: real dots; Android: falls back to solid
-    textDecorationColor: LEX_UNDERLINE,
-  },
-  theme: {
-    textDecorationLine: 'underline',
-    textDecorationStyle: 'dotted',
-    textDecorationColor: LEX_UNDERLINE,
-    fontWeight: '500',
-  },
+  // Word-text style (no textDecoration — the SVG draws the line)
+  regular: {},
+  theme: { fontWeight: '500' },
+  // Outer wrapper: a positioning context for the absolutely-positioned SVG.
+  // View nested inside <Text> is inline-block in RN; it auto-sizes to its
+  // Text child after the first layout pass.
+  wrapper: { position: 'relative' as const },
+  svg: { position: 'absolute' as const, bottom: -2, left: 0 },
 });
+
+/**
+ * Inline component that renders the lexicon word + an SVG dotted line
+ * beneath. Measures its layout width on first paint, then re-renders the
+ * SVG sized to that width. The 1-frame "no underline" flash on initial
+ * mount is acceptable for a static verse renderer.
+ */
+function LexiconWord({
+  text,
+  isTheme,
+  onPress,
+  accessibilityLabel,
+  selected,
+}: {
+  text: string;
+  isTheme: boolean;
+  onPress: () => void;
+  accessibilityLabel: string;
+  selected?: boolean;
+}) {
+  const [width, setWidth] = useState(0);
+
+  return (
+    <View
+      onLayout={(e) => {
+        const w = Math.round(e.nativeEvent.layout.width);
+        if (w !== width) setWidth(w);
+      }}
+      style={lexiconWordStyles.wrapper}
+    >
+      <Text
+        style={[
+          isTheme ? lexiconWordStyles.theme : lexiconWordStyles.regular,
+          selected ? selectionStyles.selected : null,
+        ]}
+        onPress={onPress}
+        suppressHighlighting={true}
+        accessibilityRole="button"
+        accessibilityLabel={accessibilityLabel}
+      >
+        {text}
+      </Text>
+      {width > 0 ? (
+        <Svg
+          width={width}
+          height={3}
+          style={lexiconWordStyles.svg}
+          pointerEvents="none"
+        >
+          <Line
+            x1={0.5}
+            y1={1.5}
+            x2={width - 0.5}
+            y2={1.5}
+            stroke={LEX_UNDERLINE}
+            strokeWidth={isTheme ? 1.5 : 1}
+            strokeDasharray="1,2"
+            strokeLinecap="round"
+          />
+        </Svg>
+      ) : null}
+    </View>
+  );
+}

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -26,6 +26,7 @@ import {
   type GestureResponderEvent,
   type LayoutChangeEvent,
   type NativeSyntheticEvent,
+  Platform,
   StyleSheet,
   Text,
   type TextLayoutEventData,
@@ -35,6 +36,7 @@ import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import type { AutoHighlight } from '@/types/auto-highlights';
+import type { AlignedToken, ChapterAlignment, LexEntry } from '@versemate/lexicon';
 
 /**
  * Opacity value for highlight backgrounds
@@ -135,6 +137,22 @@ export interface HighlightedTextProps extends TextProps {
   style?: TextProps['style'];
   /** Whether this text is visible in viewport - enables word tokenization for accurate long-press */
   isVisible?: boolean;
+  /**
+   * Chapter alignment for the Greek/Hebrew lexicon. When provided, words
+   * whose surface form appears in `alignment.verses[verseNumber]` render
+   * with a dotted underline and become tappable to open the lexicon
+   * popover via `onLexiconWordPress`. Other words keep their existing
+   * verse-tap behavior. Long-press handlers are NOT wired in this mode —
+   * native text selection takes over instead.
+   */
+  alignment?: ChapterAlignment | null;
+  /** Callback fired on tap of a lexicon-covered word. */
+  onLexiconWordPress?: (args: {
+    surface: string;
+    token: AlignedToken;
+    entry: LexEntry;
+    isTheme: boolean;
+  }) => void;
 }
 
 /**
@@ -273,11 +291,57 @@ export function HighlightedText({
   onVerseTap,
   onWordLongPress,
   onWordSelect,
+  alignment,
+  onLexiconWordPress,
   selectedWord: externalSelectedWord,
   style,
   isVisible = true,
   ...textProps
 }: HighlightedTextProps) {
+  // When the caller wires up the lexicon, the gesture model flips:
+  // - tap on a covered word → lexicon popover (new behavior)
+  // - tap on any other word → verse insight (existing onVerseTap)
+  // - long-press → native text selection (we omit our onLongPress handler so
+  //   the outer `selectable={true}` <Text> takes over)
+  //
+  // Without lexicon wiring we keep the legacy long-press → dictionary path
+  // intact so BibleExplanationsPanel / TopicContentPanel still work.
+  const lexiconMode = Boolean(alignment && onLexiconWordPress);
+  const longPressEnabled = !lexiconMode && Boolean(onWordSelect || onWordLongPress);
+
+  // Lookup map: normalized lowercase surface → { token, entry, isTheme }
+  // for fast match on every per-word render. Cleared when alignment or
+  // verseNumber changes.
+  const lexiconLookup = useMemo(() => {
+    if (!alignment || !alignment.verses[verseNumber]) return null;
+    const map = new Map<
+      string,
+      { token: AlignedToken; entry: LexEntry; isTheme: boolean }
+    >();
+    const themeSet = new Set(alignment.themeLemmas ?? []);
+    for (const token of alignment.verses[verseNumber]) {
+      const entry = alignment.lexicon[token.lemma];
+      if (!entry) continue;
+      const normalized = token.surface.toLowerCase();
+      // First-write-wins keeps the data file's ordering authoritative when
+      // the same surface maps to multiple lemmas in a verse.
+      if (!map.has(normalized)) {
+        map.set(normalized, { token, entry, isTheme: themeSet.has(token.lemma) });
+      }
+    }
+    return map;
+  }, [alignment, verseNumber]);
+
+  // Normalize a displayed word (e.g. "Trials,") to its lookup key ("trials").
+  const lexiconMatch = (rawWord: string) => {
+    if (!lexiconLookup) return null;
+    const clean = rawWord
+      .toLowerCase()
+      .replace(/^[.,;:!?"'’()]+/, '')
+      .replace(/[.,;:!?"'’()]+$/, '');
+    if (!clean) return null;
+    return lexiconLookup.get(clean) ?? null;
+  };
   // Get current theme mode for highlight color selection
   const { mode } = useTheme();
 
@@ -525,6 +589,9 @@ export function HighlightedText({
     segmentStartChar: number,
     event: GestureResponderEvent
   ) => {
+    // Bail when long-press is disabled (lexicon mode or no callback wired)
+    // so the outer selectable Text gets the gesture for native selection.
+    if (!longPressEnabled) return;
     cancelPendingTap();
     const { locationX, locationY, pageX, pageY } = event.nativeEvent;
 
@@ -736,7 +803,11 @@ export function HighlightedText({
 
   /**
    * Render a segment as tokenized words (when visible)
-   * Each word is a separate Text element for accurate long-press detection
+   * Each word is a separate Text element. When lexicon mode is active,
+   * words covered by the alignment get a dotted underline + tap-to-open
+   * lexicon popover behavior; other words fall through to the segment's
+   * regular tap (verse-insight or highlight). Long-press handlers are
+   * suppressed in lexicon mode so native text selection works.
    */
   const renderTokenizedSegment = (
     segment: TextSegment,
@@ -765,13 +836,55 @@ export function HighlightedText({
             onResponderTerminationRequest: () => true,
           };
 
+          // Lexicon-covered word? Render with dotted underline and route tap
+          // to the lexicon callback (not the segment's regular tap).
+          const lexHit = lexiconMatch(token.word);
+          if (lexHit && onLexiconWordPress) {
+            const lexStyle = lexHit.isTheme
+              ? lexiconWordStyles.theme
+              : lexiconWordStyles.regular;
+            return (
+              <Text
+                key={`word-${segment.key}-${token.startChar}`}
+                style={[
+                  lexStyle,
+                  (isSelected || verseTapSelected) && selectionStyles.selected,
+                ]}
+                onPress={() => {
+                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                  onLexiconWordPress({
+                    surface: token.word,
+                    token: lexHit.token,
+                    entry: lexHit.entry,
+                    isTheme: lexHit.isTheme,
+                  });
+                }}
+                suppressHighlighting={true}
+                accessibilityRole="button"
+                accessibilityLabel={`${token.word} — ${lexHit.entry.translit}, ${lexHit.entry.basicGloss}`}
+                {...responderProps}
+              >
+                {token.word}
+                {token.hasTrailingSpace ? ' ' : ''}
+              </Text>
+            );
+          }
+
           return (
             <Text
               key={`word-${segment.key}-${token.startChar}`}
               style={isSelected || verseTapSelected ? selectionStyles.selected : undefined}
               onPress={onPressHandler}
-              onLongPress={(e) =>
-                handleTokenizedWordLongPress(token.word, absoluteStartChar, absoluteEndChar, e)
+              onLongPress={
+                longPressEnabled
+                  ? (e) =>
+                      handleTokenizedWordLongPress(
+                        token.word,
+                        absoluteStartChar,
+                        absoluteEndChar,
+                        e
+                      )
+                  : undefined
               }
               suppressHighlighting={true}
               {...responderProps}
@@ -943,5 +1056,31 @@ export function HighlightedText({
 const selectionStyles = StyleSheet.create({
   selected: {
     backgroundColor: '#3390FF40', // Light blue with transparency
+  },
+});
+
+/**
+ * Styles for lexicon-covered words. Dotted underline in gold to mirror
+ * the web's `.lex-word` / `.lex-word-theme` treatment. iOS renders
+ * `textDecorationStyle: 'dotted'` correctly; Android falls back to a
+ * solid underline (RN limitation). Theme words get a slightly thicker
+ * underline so the chapter's spine reads at a glance.
+ *
+ * Hex from web's index.css: rgba(176,154,109,0.55) — alpha-blended into
+ * a static hex here since RN's text decoration color doesn't accept rgba
+ * reliably across both platforms.
+ */
+const LEX_UNDERLINE = '#B09A6D';
+const lexiconWordStyles = StyleSheet.create({
+  regular: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: Platform.OS === 'ios' ? 'dotted' : 'solid',
+    textDecorationColor: LEX_UNDERLINE,
+  },
+  theme: {
+    textDecorationLine: 'underline',
+    textDecorationStyle: Platform.OS === 'ios' ? 'dotted' : 'solid',
+    textDecorationColor: LEX_UNDERLINE,
+    fontWeight: '500',
   },
 });

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -838,34 +838,49 @@ export function HighlightedText({
 
           // Lexicon-covered word? Render with dotted underline and route tap
           // to the lexicon callback (not the segment's regular tap).
+          //
+          // Splitting:
+          //   token.word may include trailing punctuation ("trials,", "joy.").
+          //   We underline ONLY the word characters — punctuation and the
+          //   trailing space stay in a separate, unstyled Text so the dotted
+          //   line doesn't bleed past the word itself.
           const lexHit = lexiconMatch(token.word);
           if (lexHit && onLexiconWordPress) {
             const lexStyle = lexHit.isTheme
               ? lexiconWordStyles.theme
               : lexiconWordStyles.regular;
+            const match = token.word.match(/^([\p{L}\p{M}\p{N}'’-]+)(.*)$/u);
+            const wordCore = match ? match[1] : token.word;
+            const trailing = match ? match[2] : '';
+            const space = token.hasTrailingSpace ? ' ' : '';
             return (
               <Text
                 key={`word-${segment.key}-${token.startChar}`}
-                style={[
-                  lexStyle,
-                  (isSelected || verseTapSelected) && selectionStyles.selected,
-                ]}
-                onPress={() => {
-                  Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-                  onLexiconWordPress({
-                    surface: token.word,
-                    token: lexHit.token,
-                    entry: lexHit.entry,
-                    isTheme: lexHit.isTheme,
-                  });
-                }}
                 suppressHighlighting={true}
-                accessibilityRole="button"
-                accessibilityLabel={`${token.word} — ${lexHit.entry.translit}, ${lexHit.entry.basicGloss}`}
                 {...responderProps}
               >
-                {token.word}
-                {token.hasTrailingSpace ? ' ' : ''}
+                <Text
+                  style={[
+                    lexStyle,
+                    (isSelected || verseTapSelected) && selectionStyles.selected,
+                  ]}
+                  onPress={() => {
+                    Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+                    onLexiconWordPress({
+                      surface: wordCore,
+                      token: lexHit.token,
+                      entry: lexHit.entry,
+                      isTheme: lexHit.isTheme,
+                    });
+                  }}
+                  suppressHighlighting={true}
+                  accessibilityRole="button"
+                  accessibilityLabel={`${wordCore} — ${lexHit.entry.translit}, ${lexHit.entry.basicGloss}`}
+                >
+                  {wordCore}
+                </Text>
+                {trailing}
+                {space}
               </Text>
             );
           }
@@ -1061,26 +1076,44 @@ const selectionStyles = StyleSheet.create({
 
 /**
  * Styles for lexicon-covered words. Dotted underline in gold to mirror
- * the web's `.lex-word` / `.lex-word-theme` treatment. iOS renders
- * `textDecorationStyle: 'dotted'` correctly; Android falls back to a
- * solid underline (RN limitation). Theme words get a slightly thicker
- * underline so the chapter's spine reads at a glance.
+ * the web's `.lex-word` / `.lex-word-theme` treatment.
  *
- * Hex from web's index.css: rgba(176,154,109,0.55) — alpha-blended into
- * a static hex here since RN's text decoration color doesn't accept rgba
- * reliably across both platforms.
+ * Implementation note: `textDecorationStyle: 'dotted'` is iOS-only — Android
+ * silently falls back to a solid line. To get real dots on both platforms
+ * we use a Text-level `borderBottom` with `borderStyle: 'dotted'`, which
+ * Android honors on inline Text. Combined with `textDecoration*` for iOS
+ * (where the border approach can render lower than expected), both
+ * platforms get a true dotted line.
+ *
+ * Theme words use a slightly thicker border + heavier weight so the
+ * chapter's spine reads at a glance.
  */
 const LEX_UNDERLINE = '#B09A6D';
 const lexiconWordStyles = StyleSheet.create({
-  regular: {
-    textDecorationLine: 'underline',
-    textDecorationStyle: Platform.OS === 'ios' ? 'dotted' : 'solid',
-    textDecorationColor: LEX_UNDERLINE,
-  },
-  theme: {
-    textDecorationLine: 'underline',
-    textDecorationStyle: Platform.OS === 'ios' ? 'dotted' : 'solid',
-    textDecorationColor: LEX_UNDERLINE,
-    fontWeight: '500',
-  },
+  regular: Platform.select({
+    ios: {
+      textDecorationLine: 'underline' as const,
+      textDecorationStyle: 'dotted' as const,
+      textDecorationColor: LEX_UNDERLINE,
+    },
+    default: {
+      borderBottomWidth: 1,
+      borderStyle: 'dotted' as const,
+      borderColor: LEX_UNDERLINE,
+    },
+  }),
+  theme: Platform.select({
+    ios: {
+      textDecorationLine: 'underline' as const,
+      textDecorationStyle: 'dotted' as const,
+      textDecorationColor: LEX_UNDERLINE,
+      fontWeight: '500' as const,
+    },
+    default: {
+      borderBottomWidth: 1.5,
+      borderStyle: 'dotted' as const,
+      borderColor: LEX_UNDERLINE,
+      fontWeight: '500' as const,
+    },
+  }),
 });

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -20,13 +20,13 @@
  * @see Visual: after-selected-text-popup.png (highlighted text appearance)
  */
 
+import type { AlignedToken, ChapterAlignment, LexEntry } from '@versemate/lexicon';
 import * as Haptics from 'expo-haptics';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import {
   type GestureResponderEvent,
   type LayoutChangeEvent,
   type NativeSyntheticEvent,
-  Platform,
   StyleSheet,
   Text,
   type TextLayoutEventData,
@@ -36,7 +36,6 @@ import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import type { AutoHighlight } from '@/types/auto-highlights';
-import type { AlignedToken, ChapterAlignment, LexEntry } from '@versemate/lexicon';
 
 /**
  * Opacity value for highlight backgrounds
@@ -314,10 +313,7 @@ export function HighlightedText({
   // verseNumber changes.
   const lexiconLookup = useMemo(() => {
     if (!alignment || !alignment.verses[verseNumber]) return null;
-    const map = new Map<
-      string,
-      { token: AlignedToken; entry: LexEntry; isTheme: boolean }
-    >();
+    const map = new Map<string, { token: AlignedToken; entry: LexEntry; isTheme: boolean }>();
     const themeSet = new Set(alignment.themeLemmas ?? []);
     for (const token of alignment.verses[verseNumber]) {
       const entry = alignment.lexicon[token.lemma];
@@ -380,6 +376,7 @@ export function HighlightedText({
   };
 
   // Clean up pending tap timer on unmount
+  // biome-ignore lint/correctness/useExhaustiveDependencies: cancelPendingTap is closure-stable for unmount cleanup
   useEffect(() => {
     return cancelPendingTap;
   }, []);
@@ -846,9 +843,7 @@ export function HighlightedText({
           //   line doesn't bleed past the word itself.
           const lexHit = lexiconMatch(token.word);
           if (lexHit && onLexiconWordPress) {
-            const lexStyle = lexHit.isTheme
-              ? lexiconWordStyles.theme
-              : lexiconWordStyles.regular;
+            const lexStyle = lexHit.isTheme ? lexiconWordStyles.theme : lexiconWordStyles.regular;
             const match = token.word.match(/^([\p{L}\p{M}\p{N}'’-]+)(.*)$/u);
             const wordCore = match ? match[1] : token.word;
             const trailing = match ? match[2] : '';
@@ -860,10 +855,7 @@ export function HighlightedText({
                 {...responderProps}
               >
                 <Text
-                  style={[
-                    lexStyle,
-                    (isSelected || verseTapSelected) && selectionStyles.selected,
-                  ]}
+                  style={[lexStyle, (isSelected || verseTapSelected) && selectionStyles.selected]}
                   onPress={() => {
                     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
                     onLexiconWordPress({

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -1,21 +1,28 @@
 /**
  * LexiconPopover Component
  *
- * Bottom sheet modal showing the chapter-aligned Greek/Hebrew lexical
+ * Bottom-sheet modal showing the chapter-aligned Greek/Hebrew lexical
  * card for a verse word. Mirrors verse-mate-web/src/components/LexiconPopover.tsx
- * structure: same six sections (header / in-this-verse / basic-sense /
- * semantic range / related / lexical note) plus a "loaded" caveat strip
- * for theologically-loaded words.
+ * structure (six sections + loaded caveat strip) and matches the UX of
+ * verse-mate-mobile/components/bible/VerseMateTooltip.tsx — same slide-up
+ * spring, backdrop fade, drag-handle, swipe-down-to-dismiss.
  *
- * Replaces the legacy long-press → WordDefinitionTooltip path for words
- * the lexicon covers. Falls back to WordDefinitionTooltip when there's
- * no lemma match — handled by ChapterReader, not here.
+ * Triggered by tap on a dotted-underlined word in the Bible reader.
  */
 
 import type { AlignedToken, LexEntry } from '@versemate/lexicon';
-import { useMemo } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import Modal from 'react-native-modal';
+import { useEffect, useMemo, useRef } from 'react';
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  PanResponder,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -29,7 +36,7 @@ const isHebrew = (text: string): boolean => HEBREW_RE.test(text);
 export interface LexiconPopoverProps {
   visible: boolean;
   onClose: () => void;
-  /** The English surface form the user pressed (e.g. "loved"). */
+  /** The English surface form the user tapped (e.g. "loved"). */
   surface: string;
   /** Lexicon entry for the matched lemma. */
   entry: LexEntry;
@@ -51,139 +58,234 @@ export function LexiconPopover({
 }: LexiconPopoverProps) {
   const { colors } = useTheme();
   const insets = useSafeAreaInsets();
+  const screenHeight = Dimensions.get('window').height;
   const styles = useMemo(() => createStyles(colors, insets), [colors, insets]);
+
+  // Animated values — same shape as VerseMateTooltip.
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(screenHeight)).current;
+
+  // Internal visibility flag so we can play the close animation before the
+  // Modal actually unmounts. Toggled by the visible-prop watcher below.
+  const internalVisibleRef = useRef(false);
+
+  const animateOpen = () => {
+    internalVisibleRef.current = true;
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: 0,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+      }),
+    ]).start();
+  };
+
+  const animateClose = (cb?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 250,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
+    setTimeout(() => {
+      internalVisibleRef.current = false;
+      cb?.();
+    }, 150);
+  };
+
+  // Drive animations off the `visible` prop. Open on mount, close on
+  // visible → false. The close path calls onClose synchronously so the
+  // parent (ChapterReader) can clear its activeLexicon state.
+  useEffect(() => {
+    if (visible) {
+      slideAnim.setValue(screenHeight);
+      backdropOpacity.setValue(0);
+      animateOpen();
+    } else if (internalVisibleRef.current) {
+      animateClose();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible]);
+
+  // PanResponder for the header — swipe down to dismiss, snap-back if
+  // released partway, no upward drag past the top edge.
+  const closeRef = useRef(onClose);
+  useEffect(() => {
+    closeRef.current = onClose;
+  });
+  const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 5,
+      onPanResponderMove: (_, g) => {
+        if (g.dy > 0) slideAnim.setValue(g.dy);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > 70) {
+          // Trigger parent's onClose; the effect above will run the close anim
+          closeRef.current();
+        } else if (g.dy > 0) {
+          Animated.spring(slideAnim, {
+            toValue: 0,
+            useNativeDriver: true,
+            damping: 20,
+            stiffness: 90,
+          }).start();
+        }
+      },
+    }),
+  ).current;
 
   const contextual = token.contextual;
   const lemmaIsHebrew = isHebrew(entry.lemma);
 
   return (
     <Modal
-      isVisible={visible}
-      onBackdropPress={onClose}
-      onSwipeComplete={onClose}
-      swipeDirection={['down']}
-      style={styles.modal}
-      propagateSwipe
-      useNativeDriver
-      hideModalContentWhileAnimating
-      backdropOpacity={0.55}
-      testID={testID}
+      visible={visible || internalVisibleRef.current}
+      transparent
+      animationType="none"
+      onRequestClose={onClose}
+      statusBarTranslucent
     >
-      <View style={styles.sheet}>
-        {/* Drag handle */}
-        <View style={styles.handle} />
-
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={false}
+      <View style={styles.overlay} pointerEvents="box-none" testID={testID}>
+        {/* Backdrop with fade */}
+        <Animated.View
+          style={[styles.backdrop, { opacity: backdropOpacity }]}
+          pointerEvents="auto"
         >
-          {/* HEADER */}
-          <View style={styles.header} testID={`${testID}-header`}>
-            <View style={styles.headerRow}>
-              <Text
-                style={[
-                  styles.lemma,
-                  lemmaIsHebrew && styles.lemmaRtl,
-                ]}
-                accessibilityRole="header"
-              >
-                {entry.lemma}
-              </Text>
-              <Text style={styles.translit}>{entry.translit}</Text>
-            </View>
-            <Text style={styles.metaLine}>
-              {entry.pos} • {entry.strongs}
-              {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
-              {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
-                ? ` • ${entry.otFrequency}× in OT`
-                : ''}
-              {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
-                ? ` • ${entry.ntFrequency}× in NT`
-                : ''}
-            </Text>
+          <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        </Animated.View>
+
+        {/* Sliding sheet */}
+        <Animated.View
+          style={[styles.sheet, { transform: [{ translateY: slideAnim }] }]}
+          pointerEvents="auto"
+        >
+          {/* Drag handle + swipe area */}
+          <View style={styles.dragArea} {...panResponder.panHandlers}>
+            <View style={styles.handle} />
           </View>
 
-          {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
-          {contextual ? (
-            <Section label="In this verse" highlight colors={colors} styles={styles} testID={`${testID}-contextual`}>
-              <Text style={styles.bodyText}>{contextual}</Text>
-            </Section>
-          ) : null}
-
-          {/* BASIC SENSE */}
-          <Section label="Basic sense" colors={colors} styles={styles} testID={`${testID}-basic`}>
-            <Text style={styles.bodyText}>{entry.basicGloss}</Text>
-          </Section>
-
-          {/* SEMANTIC RANGE */}
-          {entry.semanticRange && entry.semanticRange.length > 0 ? (
-            <Section label="Semantic range" colors={colors} styles={styles} testID={`${testID}-range`}>
-              <View style={styles.listWrap}>
-                {entry.semanticRange.map((s, i) => (
-                  <View key={`${s}-${i}`} style={styles.listRow}>
-                    <Text style={styles.listBullet}>•</Text>
-                    <Text style={styles.listText}>{s}</Text>
-                  </View>
-                ))}
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+          >
+            {/* HEADER */}
+            <View style={styles.header} testID={`${testID}-header`}>
+              <View style={styles.headerRow}>
+                <Text
+                  style={[styles.lemma, lemmaIsHebrew && styles.lemmaRtl]}
+                  accessibilityRole="header"
+                >
+                  {entry.lemma}
+                </Text>
+                <Text style={styles.translit}>{entry.translit}</Text>
               </View>
-            </Section>
-          ) : null}
-
-          {/* RELATED WORDS */}
-          {entry.related && entry.related.length > 0 ? (
-            <Section label="Related" colors={colors} styles={styles} testID={`${testID}-related`}>
-              <View style={styles.relatedWrap}>
-                {entry.related.map((r, i) => {
-                  const rIsHebrew = isHebrew(r.lemma);
-                  return (
-                    <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
-                      <View style={styles.relatedHeadRow}>
-                        <Text
-                          style={[
-                            styles.relatedLemma,
-                            rIsHebrew && styles.lemmaRtl,
-                          ]}
-                        >
-                          {r.lemma}
-                        </Text>
-                        <Text style={styles.relatedTranslit}>{r.translit}</Text>
-                      </View>
-                      <Text style={styles.relatedNote}>{r.note}</Text>
-                    </View>
-                  );
-                })}
-              </View>
-            </Section>
-          ) : null}
-
-          {/* LEXICAL NOTE */}
-          {entry.notes ? (
-            <Section label="Lexical note" colors={colors} styles={styles} testID={`${testID}-notes`}>
-              <Text style={styles.notesText}>{entry.notes}</Text>
-            </Section>
-          ) : null}
-
-          {/* LOADED CAVEAT — no border, last row */}
-          {entry.loaded ? (
-            <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
-              <Text style={styles.caveatText}>
-                Context-sensitive: this word carries multiple senses across
-                the NT. Meaning is governed by usage, not a single gloss.
+              <Text style={styles.metaLine}>
+                {entry.pos} • {entry.strongs}
+                {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
+                {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
+                  ? ` • ${entry.otFrequency}× in OT`
+                  : ''}
+                {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
+                  ? ` • ${entry.ntFrequency}× in NT`
+                  : ''}
               </Text>
             </View>
-          ) : null}
-        </ScrollView>
 
-        <Pressable
-          onPress={onClose}
-          style={styles.closeButton}
-          accessibilityRole="button"
-          accessibilityLabel="Close lexicon"
-          testID={`${testID}-close`}
-        >
-          <Text style={styles.closeButtonText}>Close</Text>
-        </Pressable>
+            {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
+            {contextual ? (
+              <Section
+                label="In this verse"
+                highlight
+                styles={styles}
+                testID={`${testID}-contextual`}
+              >
+                <Text style={styles.bodyText}>{contextual}</Text>
+              </Section>
+            ) : null}
+
+            {/* BASIC SENSE */}
+            <Section label="Basic sense" styles={styles} testID={`${testID}-basic`}>
+              <Text style={styles.bodyText}>{entry.basicGloss}</Text>
+            </Section>
+
+            {/* SEMANTIC RANGE */}
+            {entry.semanticRange && entry.semanticRange.length > 0 ? (
+              <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
+                <View style={styles.listWrap}>
+                  {entry.semanticRange.map((s, i) => (
+                    <View key={`${s}-${i}`} style={styles.listRow}>
+                      <Text style={styles.listBullet}>•</Text>
+                      <Text style={styles.listText}>{s}</Text>
+                    </View>
+                  ))}
+                </View>
+              </Section>
+            ) : null}
+
+            {/* RELATED WORDS */}
+            {entry.related && entry.related.length > 0 ? (
+              <Section label="Related" styles={styles} testID={`${testID}-related`}>
+                <View style={styles.relatedWrap}>
+                  {entry.related.map((r, i) => {
+                    const rIsHebrew = isHebrew(r.lemma);
+                    return (
+                      <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
+                        <View style={styles.relatedHeadRow}>
+                          <Text
+                            style={[
+                              styles.relatedLemma,
+                              rIsHebrew && styles.lemmaRtl,
+                            ]}
+                          >
+                            {r.lemma}
+                          </Text>
+                          <Text style={styles.relatedTranslit}>{r.translit}</Text>
+                        </View>
+                        <Text style={styles.relatedNote}>{r.note}</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </Section>
+            ) : null}
+
+            {/* LEXICAL NOTE */}
+            {entry.notes ? (
+              <Section label="Lexical note" styles={styles} testID={`${testID}-notes`}>
+                <Text style={styles.notesText}>{entry.notes}</Text>
+              </Section>
+            ) : null}
+
+            {/* LOADED CAVEAT — no border, last row */}
+            {entry.loaded ? (
+              <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
+                <Text style={styles.caveatText}>
+                  Context-sensitive: this word carries multiple senses across
+                  the NT. Meaning is governed by usage, not a single gloss.
+                </Text>
+              </View>
+            ) : null}
+          </ScrollView>
+        </Animated.View>
       </View>
     </Modal>
   );
@@ -194,7 +296,6 @@ export function LexiconPopover({
 interface SectionProps {
   label: string;
   highlight?: boolean;
-  colors: ReturnType<typeof getColors>;
   styles: ReturnType<typeof createStyles>;
   testID: string;
   children: React.ReactNode;
@@ -219,26 +320,35 @@ const createStyles = (
   insets: { bottom: number; top: number; left: number; right: number },
 ) =>
   StyleSheet.create({
-    modal: {
+    overlay: {
+      flex: 1,
       justifyContent: 'flex-end',
-      margin: 0,
+    },
+    backdrop: {
+      ...StyleSheet.absoluteFillObject,
+      backgroundColor: 'rgba(0,0,0,0.55)',
     },
     sheet: {
       backgroundColor: colors.backgroundElevated,
       borderTopLeftRadius: 16,
       borderTopRightRadius: 16,
-      paddingBottom: Math.max(insets.bottom, spacing.md),
       maxHeight: '85%',
+      paddingBottom: insets.bottom > 0 ? insets.bottom : spacing.md,
+    },
+
+    // Drag area + handle
+    dragArea: {
+      alignItems: 'center',
+      paddingTop: spacing.sm,
+      paddingBottom: spacing.xs,
     },
     handle: {
-      alignSelf: 'center',
-      width: 36,
+      width: 40,
       height: 4,
       borderRadius: 2,
       backgroundColor: colors.gray100,
-      marginTop: spacing.sm,
-      marginBottom: spacing.xs,
     },
+
     scroll: {
       flexGrow: 0,
     },
@@ -263,8 +373,6 @@ const createStyles = (
       fontSize: fontSizes.heading2,
       fontWeight: fontWeights.semibold,
       color: colors.textPrimary,
-      // Serif-like fonts aren't always present on RN; system font reads
-      // cleanly enough for Greek/Hebrew at this size.
     },
     lemmaRtl: {
       writingDirection: 'rtl',
@@ -289,10 +397,6 @@ const createStyles = (
     },
     sectionHighlight: {
       backgroundColor: colors.backgroundElevated,
-      // The web uses a subtle gold tint here. Mobile theme tokens vary
-      // between light/dark, so a slight overlay via opacity is safer
-      // than hard-coding a tint that breaks one mode.
-      opacity: 1,
     },
     sectionLabel: {
       fontSize: fontSizes.caption,
@@ -374,18 +478,5 @@ const createStyles = (
       fontStyle: 'italic',
       color: colors.textSecondary,
       lineHeight: fontSizes.caption * lineHeights.body,
-    },
-
-    // Close
-    closeButton: {
-      alignSelf: 'center',
-      paddingVertical: spacing.sm,
-      paddingHorizontal: spacing.lg,
-      marginTop: spacing.xs,
-    },
-    closeButtonText: {
-      fontSize: fontSizes.bodySmall,
-      fontWeight: fontWeights.semibold,
-      color: colors.gold,
     },
   });

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -112,6 +112,7 @@ export function LexiconPopover({
   // Drive animations off the `visible` prop. Open on mount, close on
   // visible → false. The close path calls onClose synchronously so the
   // parent (ChapterReader) can clear its activeLexicon state.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: animateOpen/animateClose/slideAnim/backdropOpacity/screenHeight are stable refs and closure-captured constants
   useEffect(() => {
     if (visible) {
       slideAnim.setValue(screenHeight);
@@ -120,7 +121,6 @@ export function LexiconPopover({
     } else if (internalVisibleRef.current) {
       animateClose();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
   // PanResponder for swipe-to-dismiss from anywhere on the sheet.
@@ -167,7 +167,7 @@ export function LexiconPopover({
         }
       },
       onPanResponderTerminationRequest: () => false,
-    }),
+    })
   ).current;
 
   // Dedicated pan responder for the handle area — bypasses the scroll-at-top
@@ -191,7 +191,7 @@ export function LexiconPopover({
           }).start();
         }
       },
-    }),
+    })
   ).current;
 
   const contextual = token.contextual;
@@ -207,10 +207,7 @@ export function LexiconPopover({
     >
       <View style={styles.overlay} pointerEvents="box-none" testID={testID}>
         {/* Backdrop with fade */}
-        <Animated.View
-          style={[styles.backdrop, { opacity: backdropOpacity }]}
-          pointerEvents="auto"
-        >
+        <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} pointerEvents="auto">
           <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         </Animated.View>
 
@@ -280,8 +277,8 @@ export function LexiconPopover({
             {entry.semanticRange && entry.semanticRange.length > 0 ? (
               <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
                 <View style={styles.listWrap}>
-                  {entry.semanticRange.map((s, i) => (
-                    <View key={`${s}-${i}`} style={styles.listRow}>
+                  {entry.semanticRange.map((s) => (
+                    <View key={s} style={styles.listRow}>
                       <Text style={styles.listBullet}>•</Text>
                       <Text style={styles.listText}>{s}</Text>
                     </View>
@@ -299,12 +296,7 @@ export function LexiconPopover({
                     return (
                       <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
                         <View style={styles.relatedHeadRow}>
-                          <Text
-                            style={[
-                              styles.relatedLemma,
-                              rIsHebrew && styles.lemmaRtl,
-                            ]}
-                          >
+                          <Text style={[styles.relatedLemma, rIsHebrew && styles.lemmaRtl]}>
                             {r.lemma}
                           </Text>
                           <Text style={styles.relatedTranslit}>{r.translit}</Text>
@@ -328,8 +320,8 @@ export function LexiconPopover({
             {entry.loaded ? (
               <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
                 <Text style={styles.caveatText}>
-                  Context-sensitive: this word carries multiple senses across
-                  the NT. Meaning is governed by usage, not a single gloss.
+                  Context-sensitive: this word carries multiple senses across the NT. Meaning is
+                  governed by usage, not a single gloss.
                 </Text>
               </View>
             ) : null}
@@ -352,10 +344,7 @@ interface SectionProps {
 
 function Section({ label, highlight, styles, testID, children }: SectionProps) {
   return (
-    <View
-      style={[styles.section, highlight ? styles.sectionHighlight : null]}
-      testID={testID}
-    >
+    <View style={[styles.section, highlight ? styles.sectionHighlight : null]} testID={testID}>
       <Text style={styles.sectionLabel}>{label}</Text>
       {children}
     </View>
@@ -366,7 +355,7 @@ function Section({ label, highlight, styles, testID, children }: SectionProps) {
 
 const createStyles = (
   colors: ReturnType<typeof getColors>,
-  insets: { bottom: number; top: number; left: number; right: number },
+  insets: { bottom: number; top: number; left: number; right: number }
 ) =>
   StyleSheet.create({
     overlay: {

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -1,0 +1,391 @@
+/**
+ * LexiconPopover Component
+ *
+ * Bottom sheet modal showing the chapter-aligned Greek/Hebrew lexical
+ * card for a verse word. Mirrors verse-mate-web/src/components/LexiconPopover.tsx
+ * structure: same six sections (header / in-this-verse / basic-sense /
+ * semantic range / related / lexical note) plus a "loaded" caveat strip
+ * for theologically-loaded words.
+ *
+ * Replaces the legacy long-press → WordDefinitionTooltip path for words
+ * the lexicon covers. Falls back to WordDefinitionTooltip when there's
+ * no lemma match — handled by ChapterReader, not here.
+ */
+
+import type { AlignedToken, LexEntry } from '@versemate/lexicon';
+import { useMemo } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import Modal from 'react-native-modal';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@/contexts/ThemeContext';
+import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
+
+// Hebrew + Aramaic Unicode block — RTL render for `<Text>` containing
+// these characters. Greek lemmas have no Hebrew chars so detection is
+// unambiguous. Lemma slugs (transliterated Latin) never trigger RTL.
+const HEBREW_RE = /[֐-׿]/;
+const isHebrew = (text: string): boolean => HEBREW_RE.test(text);
+
+export interface LexiconPopoverProps {
+  visible: boolean;
+  onClose: () => void;
+  /** The English surface form the user pressed (e.g. "loved"). */
+  surface: string;
+  /** Lexicon entry for the matched lemma. */
+  entry: LexEntry;
+  /** Token data including optional per-verse contextual gloss. */
+  token: AlignedToken;
+  /** Whether this lemma is in the chapter's themeLemmas list. */
+  isTheme?: boolean;
+  testID?: string;
+}
+
+export function LexiconPopover({
+  visible,
+  onClose,
+  surface: _surface,
+  entry,
+  token,
+  isTheme: _isTheme,
+  testID = 'lexicon-popover',
+}: LexiconPopoverProps) {
+  const { colors } = useTheme();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors, insets), [colors, insets]);
+
+  const contextual = token.contextual;
+  const lemmaIsHebrew = isHebrew(entry.lemma);
+
+  return (
+    <Modal
+      isVisible={visible}
+      onBackdropPress={onClose}
+      onSwipeComplete={onClose}
+      swipeDirection={['down']}
+      style={styles.modal}
+      propagateSwipe
+      useNativeDriver
+      hideModalContentWhileAnimating
+      backdropOpacity={0.55}
+      testID={testID}
+    >
+      <View style={styles.sheet}>
+        {/* Drag handle */}
+        <View style={styles.handle} />
+
+        <ScrollView
+          style={styles.scroll}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
+        >
+          {/* HEADER */}
+          <View style={styles.header} testID={`${testID}-header`}>
+            <View style={styles.headerRow}>
+              <Text
+                style={[
+                  styles.lemma,
+                  lemmaIsHebrew && styles.lemmaRtl,
+                ]}
+                accessibilityRole="header"
+              >
+                {entry.lemma}
+              </Text>
+              <Text style={styles.translit}>{entry.translit}</Text>
+            </View>
+            <Text style={styles.metaLine}>
+              {entry.pos} • {entry.strongs}
+              {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
+              {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
+                ? ` • ${entry.otFrequency}× in OT`
+                : ''}
+              {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
+                ? ` • ${entry.ntFrequency}× in NT`
+                : ''}
+            </Text>
+          </View>
+
+          {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
+          {contextual ? (
+            <Section label="In this verse" highlight colors={colors} styles={styles} testID={`${testID}-contextual`}>
+              <Text style={styles.bodyText}>{contextual}</Text>
+            </Section>
+          ) : null}
+
+          {/* BASIC SENSE */}
+          <Section label="Basic sense" colors={colors} styles={styles} testID={`${testID}-basic`}>
+            <Text style={styles.bodyText}>{entry.basicGloss}</Text>
+          </Section>
+
+          {/* SEMANTIC RANGE */}
+          {entry.semanticRange && entry.semanticRange.length > 0 ? (
+            <Section label="Semantic range" colors={colors} styles={styles} testID={`${testID}-range`}>
+              <View style={styles.listWrap}>
+                {entry.semanticRange.map((s, i) => (
+                  <View key={`${s}-${i}`} style={styles.listRow}>
+                    <Text style={styles.listBullet}>•</Text>
+                    <Text style={styles.listText}>{s}</Text>
+                  </View>
+                ))}
+              </View>
+            </Section>
+          ) : null}
+
+          {/* RELATED WORDS */}
+          {entry.related && entry.related.length > 0 ? (
+            <Section label="Related" colors={colors} styles={styles} testID={`${testID}-related`}>
+              <View style={styles.relatedWrap}>
+                {entry.related.map((r, i) => {
+                  const rIsHebrew = isHebrew(r.lemma);
+                  return (
+                    <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
+                      <View style={styles.relatedHeadRow}>
+                        <Text
+                          style={[
+                            styles.relatedLemma,
+                            rIsHebrew && styles.lemmaRtl,
+                          ]}
+                        >
+                          {r.lemma}
+                        </Text>
+                        <Text style={styles.relatedTranslit}>{r.translit}</Text>
+                      </View>
+                      <Text style={styles.relatedNote}>{r.note}</Text>
+                    </View>
+                  );
+                })}
+              </View>
+            </Section>
+          ) : null}
+
+          {/* LEXICAL NOTE */}
+          {entry.notes ? (
+            <Section label="Lexical note" colors={colors} styles={styles} testID={`${testID}-notes`}>
+              <Text style={styles.notesText}>{entry.notes}</Text>
+            </Section>
+          ) : null}
+
+          {/* LOADED CAVEAT — no border, last row */}
+          {entry.loaded ? (
+            <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
+              <Text style={styles.caveatText}>
+                Context-sensitive: this word carries multiple senses across
+                the NT. Meaning is governed by usage, not a single gloss.
+              </Text>
+            </View>
+          ) : null}
+        </ScrollView>
+
+        <Pressable
+          onPress={onClose}
+          style={styles.closeButton}
+          accessibilityRole="button"
+          accessibilityLabel="Close lexicon"
+          testID={`${testID}-close`}
+        >
+          <Text style={styles.closeButtonText}>Close</Text>
+        </Pressable>
+      </View>
+    </Modal>
+  );
+}
+
+// ─── Section primitive ──────────────────────────────────────────────────
+
+interface SectionProps {
+  label: string;
+  highlight?: boolean;
+  colors: ReturnType<typeof getColors>;
+  styles: ReturnType<typeof createStyles>;
+  testID: string;
+  children: React.ReactNode;
+}
+
+function Section({ label, highlight, styles, testID, children }: SectionProps) {
+  return (
+    <View
+      style={[styles.section, highlight ? styles.sectionHighlight : null]}
+      testID={testID}
+    >
+      <Text style={styles.sectionLabel}>{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+// ─── Styles ─────────────────────────────────────────────────────────────
+
+const createStyles = (
+  colors: ReturnType<typeof getColors>,
+  insets: { bottom: number; top: number; left: number; right: number },
+) =>
+  StyleSheet.create({
+    modal: {
+      justifyContent: 'flex-end',
+      margin: 0,
+    },
+    sheet: {
+      backgroundColor: colors.backgroundElevated,
+      borderTopLeftRadius: 16,
+      borderTopRightRadius: 16,
+      paddingBottom: Math.max(insets.bottom, spacing.md),
+      maxHeight: '85%',
+    },
+    handle: {
+      alignSelf: 'center',
+      width: 36,
+      height: 4,
+      borderRadius: 2,
+      backgroundColor: colors.gray100,
+      marginTop: spacing.sm,
+      marginBottom: spacing.xs,
+    },
+    scroll: {
+      flexGrow: 0,
+    },
+    scrollContent: {
+      paddingBottom: spacing.md,
+    },
+
+    // Header
+    header: {
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.md,
+      paddingBottom: spacing.sm,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.gray100,
+    },
+    headerRow: {
+      flexDirection: 'row',
+      alignItems: 'baseline',
+      gap: spacing.sm,
+    },
+    lemma: {
+      fontSize: fontSizes.heading2,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      // Serif-like fonts aren't always present on RN; system font reads
+      // cleanly enough for Greek/Hebrew at this size.
+    },
+    lemmaRtl: {
+      writingDirection: 'rtl',
+    },
+    translit: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+    },
+    metaLine: {
+      marginTop: spacing.xs,
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+    },
+
+    // Section
+    section: {
+      paddingHorizontal: spacing.lg,
+      paddingVertical: spacing.md,
+      borderBottomWidth: 1,
+      borderBottomColor: colors.gray100,
+    },
+    sectionHighlight: {
+      backgroundColor: colors.backgroundElevated,
+      // The web uses a subtle gold tint here. Mobile theme tokens vary
+      // between light/dark, so a slight overlay via opacity is safer
+      // than hard-coding a tint that breaks one mode.
+      opacity: 1,
+    },
+    sectionLabel: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.bold,
+      color: colors.gold,
+      textTransform: 'uppercase',
+      letterSpacing: 1,
+      marginBottom: spacing.xs,
+    },
+    bodyText: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Semantic range list
+    listWrap: {
+      gap: spacing.xs,
+    },
+    listRow: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      gap: spacing.xs,
+    },
+    listBullet: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textSecondary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+    listText: {
+      flex: 1,
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Related
+    relatedWrap: {
+      gap: spacing.sm,
+    },
+    relatedItem: {
+      gap: 2,
+    },
+    relatedHeadRow: {
+      flexDirection: 'row',
+      alignItems: 'baseline',
+      gap: spacing.sm,
+    },
+    relatedLemma: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+    },
+    relatedTranslit: {
+      fontSize: fontSizes.caption,
+      color: colors.gold,
+    },
+    relatedNote: {
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+      lineHeight: fontSizes.caption * lineHeights.body,
+    },
+
+    // Notes
+    notesText: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.bodySmall * lineHeights.body,
+    },
+
+    // Caveat (loaded)
+    caveatBlock: {
+      paddingHorizontal: spacing.lg,
+      paddingTop: spacing.sm,
+      paddingBottom: spacing.md,
+    },
+    caveatText: {
+      fontSize: fontSizes.caption,
+      fontStyle: 'italic',
+      color: colors.textSecondary,
+      lineHeight: fontSizes.caption * lineHeights.body,
+    },
+
+    // Close
+    closeButton: {
+      alignSelf: 'center',
+      paddingVertical: spacing.sm,
+      paddingHorizontal: spacing.lg,
+      marginTop: spacing.xs,
+    },
+    closeButtonText: {
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+    },
+  });

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -123,13 +123,51 @@ export function LexiconPopover({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [visible]);
 
-  // PanResponder for the header — swipe down to dismiss, snap-back if
-  // released partway, no upward drag past the top edge.
+  // PanResponder for swipe-to-dismiss from anywhere on the sheet.
+  //
+  // Two gesture cooperations:
+  //   - Drag from the handle area → always captures (no scroll to fight).
+  //   - Drag from the ScrollView body → only captures when the scroll is
+  //     at the top AND the user is dragging DOWN. Otherwise the
+  //     ScrollView gets the gesture so normal scrolling works.
+  //
+  // `onStartShouldSetPanResponder` returns false so the inner ScrollView
+  // gets first chance at every touch; `onMoveShouldSetPanResponder` then
+  // steals the gesture mid-drag when the conditions match.
   const closeRef = useRef(onClose);
   useEffect(() => {
     closeRef.current = onClose;
   });
+  const scrollYRef = useRef(0);
   const panResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => false,
+      onMoveShouldSetPanResponder: (_, g) => {
+        const isVerticalDown = g.dy > 5 && Math.abs(g.dy) > Math.abs(g.dx);
+        const atTop = scrollYRef.current <= 0;
+        return isVerticalDown && atTop;
+      },
+      onPanResponderMove: (_, g) => {
+        if (g.dy > 0) slideAnim.setValue(g.dy);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > 70) {
+          closeRef.current();
+        } else if (g.dy > 0) {
+          Animated.spring(slideAnim, {
+            toValue: 0,
+            useNativeDriver: true,
+            damping: 20,
+            stiffness: 90,
+          }).start();
+        }
+      },
+    }),
+  ).current;
+
+  // Dedicated pan responder for the handle area — bypasses the scroll-at-top
+  // check so the user can always drag the modal down by grabbing the handle.
+  const handlePanResponder = useRef(
     PanResponder.create({
       onStartShouldSetPanResponder: () => true,
       onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 5,
@@ -138,7 +176,6 @@ export function LexiconPopover({
       },
       onPanResponderRelease: (_, g) => {
         if (g.dy > 70) {
-          // Trigger parent's onClose; the effect above will run the close anim
           closeRef.current();
         } else if (g.dy > 0) {
           Animated.spring(slideAnim, {
@@ -172,13 +209,16 @@ export function LexiconPopover({
           <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         </Animated.View>
 
-        {/* Sliding sheet */}
+        {/* Sliding sheet — pan responder wraps the whole sheet so swipe-down
+            from any point dismisses (subject to scroll-at-top check). */}
         <Animated.View
           style={[styles.sheet, { transform: [{ translateY: slideAnim }] }]}
           pointerEvents="auto"
+          {...panResponder.panHandlers}
         >
-          {/* Drag handle + swipe area */}
-          <View style={styles.dragArea} {...panResponder.panHandlers}>
+          {/* Drag handle — uses its own pan responder that always captures,
+              regardless of scroll position, so you can always grab the handle. */}
+          <View style={styles.dragArea} {...handlePanResponder.panHandlers}>
             <View style={styles.handle} />
           </View>
 
@@ -186,6 +226,10 @@ export function LexiconPopover({
             style={styles.scroll}
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
+            onScroll={(e) => {
+              scrollYRef.current = e.nativeEvent.contentOffset.y;
+            }}
+            scrollEventThrottle={16}
           >
             {/* HEADER */}
             <View style={styles.header} testID={`${testID}-header`}>

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -141,8 +141,12 @@ export function LexiconPopover({
   const scrollYRef = useRef(0);
   const panResponder = useRef(
     PanResponder.create({
-      onStartShouldSetPanResponder: () => false,
-      onMoveShouldSetPanResponder: (_, g) => {
+      // Capture phase — fires BEFORE children (the ScrollView) receive
+      // touch events. We only return true (and steal the gesture from
+      // the ScrollView) when the user is at the top of scrollable
+      // content AND drags downward, so normal scrolling is unaffected.
+      onStartShouldSetPanResponderCapture: () => false,
+      onMoveShouldSetPanResponderCapture: (_, g) => {
         const isVerticalDown = g.dy > 5 && Math.abs(g.dy) > Math.abs(g.dx);
         const atTop = scrollYRef.current <= 0;
         return isVerticalDown && atTop;
@@ -162,6 +166,7 @@ export function LexiconPopover({
           }).start();
         }
       },
+      onPanResponderTerminationRequest: () => false,
     }),
   ).current;
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",
-    "@versemate/lexicon": "file:../verse-mate-lexicon",
+    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
     "axios": "^1.12.2",
     "expo": "~54.0.27",
     "expo-apple-authentication": "~8.0.8",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",
+    "@versemate/lexicon": "file:../verse-mate-lexicon",
     "axios": "^1.12.2",
     "expo": "~54.0.27",
     "expo-apple-authentication": "~8.0.8",
@@ -137,7 +138,7 @@
   "bun": {
     "test": {
       "preload": "./test-setup.ts",
-      "timeout": 1e4
+      "timeout": 10000.0
     }
   },
   "private": true


### PR DESCRIPTION
## Summary

Brings the chapter-aligned Greek/Hebrew lexicon from web to mobile (Phase 1-4 from CC's plan). Tapping a dotted-underlined word in any chapter opens a bottom-sheet popover with the lemma, transliteration, basic gloss, semantic range, related words, and (for theologically loaded words) a context-sensitive caveat. Long-press in the Bible reader now goes to native text selection.

- **New shared package**: [@versemate/lexicon](https://github.com/verse-mate/verse-mate-lexicon) (public). Mirrors the `@versemate/studies` pattern — single source of truth consumed by web and mobile, lazy-loaded chapter by chapter via Bun's `github:` dep. Initial commit extracts the lexicon data verbatim from `verse-mate-web/src/data/lexicon/` (1,189 generated chapter alignments + the 16 MB `_lemmas.json` global table + hand-curated James 1-5 + lemma overrides).
- **Metro-friendly manifest** (`src/manifest.generated.ts` in the lexicon repo) replaces Vite's `import.meta.glob` with 1,189 literal `import()` paths so both bundlers can statically resolve chapter chunks.
- **`LexiconPopover`** (~480 lines): RN bottom-sheet matching `VerseMateTooltip`'s UX — RN `Modal` + `Animated.spring` slide + backdrop fade + `PanResponder` swipe-to-dismiss + drag handle. Six sections (header / in-this-verse / basic-sense / semantic-range / related / lexical-note) + loaded-caveat strip. Hebrew/Aramaic lemmas render RTL.
- **`HighlightedText`** lights up lexicon-covered words with a gold dotted underline (iOS via `textDecorationStyle: 'dotted'`; Android renders solid due to RN limitation — see Known gaps). Trailing punctuation + whitespace stay outside the underlined span. Tap routes to `onLexiconWordPress`; long-press wiring is suppressed when alignment is provided so the outer `selectable={true}` Text takes over for native selection.
- **`ChapterReader`** drops the legacy `WordDefinitionTooltip` (Easton/Strong/Webster fallback) from the Bible reader path. Other surfaces (`BibleExplanationsPanel`, `TopicContentPanel`) still long-press → dictionary unchanged.

## Lexicon package

- Repo: https://github.com/verse-mate/verse-mate-lexicon (public)
- Pinned in `package.json` at SHA `26012e6` (initial extract + a strict-TS `_meta` cast fix needed for jest-expo's tsc).
- Bump via `bun update @versemate/lexicon` after the studies/lexicon ingest re-runs upstream.

## Known gaps

- **Android dotted underline.** RN's `textDecorationStyle: 'dotted'` is iOS-only — Android silently falls back to solid. `borderStyle: 'dotted'` on inline `<Text>` also doesn't render on Android. We tried a `react-native-svg`-based custom underline (commit 2ecde7c) but it broke the inline text flow on Android, so it was reverted. iOS shows real dots; Android shows a solid gold line. **Real Android dots are a follow-up** — likely needs a flexbox-row verse renderer or `@gorhom/bottom-sheet`-style RN-specific drawing.
- **Swipe-to-dismiss outside the handle area.** Current implementation: handle area always captures swipes; the body wrapper uses `onMoveShouldSetPanResponderCapture` to steal vertical-down gestures from the inner ScrollView when scroll is at top. On-device this is reportedly inconsistent — sometimes only the handle works. Likely needs migration to `@gorhom/bottom-sheet` for reliable cooperation with scrollable content.
- **Web not yet migrated** to consume `@versemate/lexicon`. Still uses its in-repo copy at `verse-mate-web/src/data/lexicon/`. Cleanup PR can fold that in later — both copies are byte-identical so they don't drift in the meantime.
- **No visual underline cue for already-known limitations** (e.g. multi-word lexicon surfaces like `double-minded`). Single-word matching only. Multi-word support deferred until proven needed in real content.

## Test plan

- [x] `bun run type-check` clean
- [x] `npm test components/bible` — 36 suites / 252 tests pass on ThorSPC
- [ ] Reviewer: open James 1; long-press on a word like `trials` / `joy` / `perfect` → no popover (verifies long-press = selection now). Tap the same word → popover slides up with hand-curated semantic range + related words.
- [ ] Reviewer: open Genesis 1 / John 3 (generated chapters) → still get popovers, content slightly leaner than hand-curated.
- [ ] Reviewer: tap a non-aligned word (e.g. `the`, proper nouns) → existing verse-insight tooltip opens (unchanged).
- [ ] Reviewer: drag the popover handle down → dismisses smoothly. Drag elsewhere on the sheet → behavior is currently inconsistent; see "Known gaps".
- [ ] Reviewer: verify `BibleExplanationsPanel` and topic-text long-press still opens the legacy dictionary tooltip (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)