### PR TITLE
fix(router): resolve Bible book URL slugs to bookId (VER-117)

### DIFF
--- a/__tests__/hooks/bible/use-chapter-state.test.ts
+++ b/__tests__/hooks/bible/use-chapter-state.test.ts
@@ -161,6 +161,9 @@ describe('useChapterState', () => {
 
   /**
    * Test: Debounced URL sync occurs after delay
+   *
+   * URL writer emits the canonical slug form (matches generate-chapter-share-url)
+   * so deep-link / share URLs round-trip through the screen unchanged.
    */
   it('syncs URL with debounce after navigateToChapter', async () => {
     const { result } = renderHook(() => useChapterState());
@@ -177,10 +180,10 @@ describe('useChapterState', () => {
       jest.advanceTimersByTime(1100);
     });
 
-    // URL should now be updated (with verse params cleared)
+    // URL should now be updated (slug form, verse params cleared)
     await waitFor(() => {
       expect(mockSetParams).toHaveBeenCalledWith({
-        bookId: '5',
+        bookId: 'deuteronomy',
         chapterNumber: '10',
         verse: undefined,
         endVerse: undefined,
@@ -210,10 +213,10 @@ describe('useChapterState', () => {
       jest.advanceTimersByTime(1100);
     });
 
-    // URL sync should only happen once with final values (with verse params cleared)
+    // URL sync should only happen once with final values (slug form, verse params cleared)
     expect(mockSetParams).toHaveBeenCalledTimes(1);
     expect(mockSetParams).toHaveBeenCalledWith({
-      bookId: '1',
+      bookId: 'genesis',
       chapterNumber: '5',
       verse: undefined,
       endVerse: undefined,
@@ -265,6 +268,96 @@ describe('useChapterState', () => {
     // Genesis has 50 chapters, so 999 should be clamped to 1
     expect(result.current.chapterNumber).toBe(1);
     expect(result.current.bookId).toBe(1);
+  });
+
+  /**
+   * Regression: slug URL params resolve to the correct book (VER-117).
+   *
+   * Before the fix, `Number(params.bookId)` returned NaN for non-numeric slugs
+   * and fell back to Genesis, so /bible/galatians/6 served Genesis 6 content.
+   */
+  describe('slug URL params (VER-117 regression)', () => {
+    it('resolves "galatians" slug to bookId 48', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: 'galatians',
+        chapterNumber: '6',
+      });
+
+      const { result } = renderHook(() => useChapterState());
+
+      expect(result.current.bookId).toBe(48);
+      expect(result.current.chapterNumber).toBe(6);
+      expect(result.current.bookName).toBe('Galatians');
+    });
+
+    it('resolves "john" slug to bookId 43', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: 'john',
+        chapterNumber: '3',
+      });
+
+      const { result } = renderHook(() => useChapterState());
+
+      expect(result.current.bookId).toBe(43);
+      expect(result.current.chapterNumber).toBe(3);
+      expect(result.current.bookName).toBe('John');
+    });
+
+    it('resolves multi-word slugs like "1-corinthians" to bookId 46', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: '1-corinthians',
+        chapterNumber: '13',
+      });
+
+      const { result } = renderHook(() => useChapterState());
+
+      expect(result.current.bookId).toBe(46);
+      expect(result.current.chapterNumber).toBe(13);
+      expect(result.current.bookName).toBe('1 Corinthians');
+    });
+
+    it('still accepts numeric bookId for backward compatibility', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: '48',
+        chapterNumber: '6',
+      });
+
+      const { result } = renderHook(() => useChapterState());
+
+      expect(result.current.bookId).toBe(48);
+      expect(result.current.chapterNumber).toBe(6);
+      expect(result.current.bookName).toBe('Galatians');
+    });
+
+    it('falls back to Genesis 1 when the slug is unknown', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: 'not-a-book',
+        chapterNumber: '5',
+      });
+
+      const { result } = renderHook(() => useChapterState());
+
+      expect(result.current.bookId).toBe(1);
+      // Chapter is preserved (still a valid number) — only the book defaulted
+      expect(result.current.chapterNumber).toBe(5);
+    });
+
+    it('does not rewrite the URL when params already match state in slug form', () => {
+      mockUseLocalSearchParams.mockReturnValue({
+        bookId: 'galatians',
+        chapterNumber: '6',
+      });
+
+      renderHook(() => useChapterState());
+
+      // Fast-forward past the debounce window — URL must NOT churn from
+      // 'galatians' to '48' just because the writer formatted bookId differently.
+      act(() => {
+        jest.advanceTimersByTime(1100);
+      });
+
+      expect(mockSetParams).not.toHaveBeenCalled();
+    });
   });
 
   /**

--- a/hooks/bible/use-chapter-state.ts
+++ b/hooks/bible/use-chapter-state.ts
@@ -40,6 +40,7 @@ import { router, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react';
 import type { TestamentBook } from '@/src/api';
 import { useBibleTestaments } from '@/src/api';
+import { getBookSlug, parseBookParam } from '@/utils/bookSlugs';
 
 /**
  * State shape for chapter navigation
@@ -121,8 +122,12 @@ export function useChapterState(): ChapterStateResult {
     chapterNumber: string;
   }>();
 
-  // Parse initial values from params
-  const initialBookId = Number(params.bookId) || 1;
+  // Parse initial values from params.
+  // bookId may arrive as a slug ("galatians") or numeric id ("48") — share URLs
+  // are slug-based per generate-chapter-share-url.ts. Without parseBookParam,
+  // any non-numeric slug becomes NaN and falls back to Genesis, silently
+  // serving wrong chapter content for every non-Genesis deep link.
+  const initialBookId = parseBookParam(params.bookId ?? '') ?? 1;
   const initialChapter = Number(params.chapterNumber) || 1;
 
   // Use reducer for state management
@@ -168,10 +173,10 @@ export function useChapterState(): ChapterStateResult {
    * while the screen is already mounted.
    */
   useEffect(() => {
-    const paramBookId = Number(params.bookId);
+    const paramBookId = parseBookParam(params.bookId ?? '');
     const paramChapter = Number(params.chapterNumber);
 
-    if (Number.isNaN(paramBookId) || Number.isNaN(paramChapter)) {
+    if (paramBookId === null || Number.isNaN(paramChapter)) {
       return;
     }
 
@@ -245,13 +250,16 @@ export function useChapterState(): ChapterStateResult {
 
     // Set new timer
     urlSyncTimerRef.current = setTimeout(() => {
-      // Only update if URL differs from current state
-      const currentParamBookId = Number(params.bookId);
+      // Only update if URL differs from current state.
+      // Compare via parseBookParam so a valid slug URL ("galatians") does not
+      // get rewritten to its numeric form on every navigation; write the slug
+      // form back so the URL stays in the canonical share-link shape.
+      const currentParamBookId = parseBookParam(params.bookId ?? '');
       const currentParamChapter = Number(params.chapterNumber);
 
       if (currentParamBookId !== state.bookId || currentParamChapter !== state.chapterNumber) {
         router.setParams({
-          bookId: state.bookId.toString(),
+          bookId: getBookSlug(state.bookId) ?? state.bookId.toString(),
           chapterNumber: state.chapterNumber.toString(),
           // Clear verse params when chapter changes to prevent "sticky" highlighting
           verse: undefined,


### PR DESCRIPTION
## Summary

Deep links and shared URLs like `/bible/galatians/6` or `/bible/john/3` served Genesis content because `useChapterState` read the URL `bookId` segment with `Number(params.bookId) || 1` — non-numeric slugs became `NaN`, fell back to `1`, and rendered Genesis at whatever chapter number the URL carried. This was the broadest-impact bug in the andytryba March 2026 backlog (VER-117, migrated from GitHub #199).

Outbound share URLs (`utils/sharing/generate-chapter-share-url.ts`) already use slugs (`/bible/john/3`), and `utils/bookSlugs.ts` already exposes `parseBookParam` that resolves both `"48"` and `"galatians"` → `48`. The chapter-state hook just wasn't using it. Three call sites in one hook:

- **Initial parse:** `parseBookParam(params.bookId ?? '') ?? 1` instead of `Number(params.bookId) || 1`.
- **Deep-link sync effect:** `parseBookParam(...)` + `=== null` invalid-sentinel (was `Number.isNaN`), so unknown slugs still bail cleanly.
- **URL writer effect:** compare via `parseBookParam` so a valid slug URL is not silently rewritten to its numeric form, and write the slug form back via `getBookSlug(state.bookId)` so the URL stays in the canonical share-link shape after in-screen navigation.

Nothing else changes — `[bookId]/[chapterNumber].tsx`, `BibleNavigationModal`, prefetch hooks, and analytics all see the same numeric `bookId` they always did.

## Tests

Added 6 regression tests for the VER-117 reproduction matrix:

- `galatians` slug → bookId 48
- `john` slug → bookId 43
- multi-word slug `1-corinthians` → bookId 46
- numeric `"48"` → bookId 48 (backward compat)
- unknown slug (`"not-a-book"`) → falls back to Genesis 1
- no URL churn when params already match state in slug form

Updated 2 existing URL-sync tests to assert the canonical slug form (`bookId: 'genesis'`, `bookId: 'deuteronomy'`) — they previously hardcoded numeric output, which would have masked the slug-write regression.

## Test plan

- [x] Pre-commit hooks green (`lint-staged` → biome + eslint, `bun tsc --noEmit --skipLibCheck`).
- [ ] CI: full Jest suite passes (`bun run test:ci`).
- [ ] CI: Cloudflare Workers web preview deploy publishes.
- [ ] QA on the preview: open `/bible/galatians/5`, `/bible/galatians/6`, `/bible/john/3` and confirm each renders its own book's content (not Genesis). Then `/bible/48/6` (numeric backward-compat) and `/bible/not-a-book/5` (falls back to Genesis 1).
- [ ] QA cross-check on `app.versemate.org` after merge (per VER-117 acceptance criteria).

## Notes for reviewers

- Scope strictly matches the VER-117 acceptance criteria — router resolution before content fetch. Sibling routes (`app/notes/[bookId]/[chapterNumber]`, `app/highlights/[bookId]/[chapterNumber]`) use `parseInt` but are only entered via internal `router.push` with numeric ids, not via public deep links; out of scope here, can be hardened in a follow-up if we want consistent intake.
- Two URL-sync test expectations changed from numeric to slug — intentional. The writer now emits the canonical slug form so the URL bar stays in the share-link shape; this is consistent with `generateChapterShareUrl`'s convention and avoids a visible URL churn after the first in-screen chapter swipe when the user originally arrived via a slug deep-link.

Refs: VER-117, [VER-111#document-classification](https://paperclip.versemate.org/VER/issues/VER-111#document-classification), [VER-108#document-plan](https://paperclip.versemate.org/VER/issues/VER-108#document-plan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)