### PR TITLE
fix(bible): chapter-swipe — overshoot, teleport, header lag, scroll hiccups

### DIFF
--- a/.maestro/regression/swipe-debug-flow.yaml
+++ b/.maestro/regression/swipe-debug-flow.yaml
@@ -1,0 +1,85 @@
+appId: org.versemate.app
+tags:
+  - regression
+  - swipe-debug
+env:
+  TARGET_BOOK: Genesis
+  TARGET_CHAPTER: '1'
+---
+# swipe-debug-flow.yaml
+#
+# Reproduces the three swipe bugs Andy reported (chapter skipping,
+# scroll-teleport, brief wrong-chapter flash) while capturing the
+# instrumented [SWIPE-DBG] logs from `adb logcat`.
+#
+# Companion: run `adb logcat -c && adb logcat -s ReactNativeJS:V > /tmp/swipe.log &`
+# BEFORE this flow, then `pkill adb logcat` after, then read the log to see the
+# event sequence per phase.
+
+- launchApp:
+    clearState: false
+- waitForAnimationToEnd
+- takeScreenshot: 01-app-launched
+
+# Navigate to Genesis 1 if we're not already there. The chapter screen
+# is reached via the home → Bible → Genesis → chapter 1 path.
+- runFlow:
+    when:
+      visible: 'Get Started'
+    commands:
+      - tapOn: 'Get Started'
+
+# Open the chapter selector and ensure we're on Genesis 1
+- runFlow:
+    when:
+      visible:
+        id: 'chapter-header-dropdown'
+    commands:
+      - tapOn:
+          id: 'chapter-header-dropdown'
+      - tapOn: 'Genesis'
+      - tapOn: '1'
+
+- waitForAnimationToEnd: 2000
+- takeScreenshot: 02-genesis-1-loaded
+
+# ─── Bug A: rapid double swipe → expect chapter 3, not skip to 4 ──────
+- evalScript: 'output.phase = "A_rapid_double_swipe_start"'
+- swipe:
+    start: 80%, 50%
+    end: 20%, 50%
+    duration: 200
+- swipe:
+    start: 80%, 50%
+    end: 20%, 50%
+    duration: 200
+- waitForAnimationToEnd: 3000
+- takeScreenshot: 03-after-rapid-double-swipe
+- evalScript: 'output.phase = "A_rapid_double_swipe_end"'
+
+# ─── Bug B: swipe → immediate vertical scroll → check for teleport ────
+- evalScript: 'output.phase = "B_swipe_then_scroll_start"'
+- swipe:
+    start: 80%, 50%
+    end: 20%, 50%
+    duration: 250
+- swipe:
+    start: 50%, 75%
+    end: 50%, 25%
+    duration: 250
+- waitForAnimationToEnd: 2000
+- takeScreenshot: 04-after-swipe-then-scroll
+- evalScript: 'output.phase = "B_swipe_then_scroll_end"'
+
+# ─── Bug C: swipe back, watch the dropdown for ghost flash ────────────
+- evalScript: 'output.phase = "C_swipe_back_start"'
+- swipe:
+    start: 20%, 50%
+    end: 80%, 50%
+    duration: 300
+- waitForAnimationToEnd: 1500
+- takeScreenshot: 05-after-swipe-back
+- evalScript: 'output.phase = "C_swipe_back_end"'
+
+# Final state — confirm the dropdown shows the expected chapter
+- takeScreenshot: 06-final-state

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -19,7 +19,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
@@ -110,6 +110,14 @@ export default function ChapterScreen() {
     totalChapters,
     chapterCount,
   } = useChapterState();
+
+  // Defer the chapter passed to the pager so its expensive remount + ChapterPage layout
+  // runs at lower React priority. The header reads the urgent value and updates within
+  // one fast commit; the pager catches up in a background render. The user doesn't see
+  // the pager lag because the native swipe animation already moved it to the next
+  // chapter's content before navFire ever fired.
+  const deferredBookId = useDeferredValue(bookId);
+  const deferredChapterNumber = useDeferredValue(chapterNumber);
 
   // Extract verse/tab params (not managed by useChapterState)
   const params = useLocalSearchParams<{
@@ -590,10 +598,12 @@ export default function ChapterScreen() {
               />
             </View>
 
-            {/* SimpleChapterPager - V3 3-page window with linear navigation */}
+            {/* SimpleChapterPager - V3 3-page window with linear navigation.
+                Uses deferred chapter so the heavy pager re-render (pages-array swap +
+                ChapterPage commits) doesn't block the urgent header update commit. */}
             <SimpleChapterPager
-              bookId={bookId}
-              chapterNumber={chapterNumber}
+              bookId={deferredBookId}
+              chapterNumber={deferredChapterNumber}
               bookName={bookName}
               booksMetadata={booksMetadata}
               onChapterChange={handlePageChange}

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -390,9 +390,19 @@ export function ChapterPage({
 
   const { deleteNote, isDeletingNote } = useNotes();
 
-  // Trigger staggered delayed render — only for the active page, not buffer pages
+  // Trigger staggered delayed render — only for the active page, not buffer pages,
+  // and only while the user is actually in Explanations view.
+  //
+  // Why gated on activeView: each TabContent (Summary, Byline) takes 500-700ms of
+  // JS-thread time to mount (full chapter ScrollView with verses). Pre-warming them
+  // while the user is on Bible view caused visible scroll hiccups exactly at the
+  // stage-3 / stage-4 timer firings (T+1.6s and T+2.1s after a chapter swipe). With
+  // this gate, the staged mounts only happen once the user actually switches to
+  // Insight — when they're not scrolling Bible content. The active Insight tab still
+  // mounts immediately on the switch; the staggered stages pre-warm the OTHER tabs
+  // so switching between Summary and Byline within Insight is instant.
   useEffect(() => {
-    if (isPreloading) {
+    if (isPreloading || activeView !== 'explanations') {
       setDelayedRenderStage(0);
       return;
     }
@@ -400,14 +410,13 @@ export function ChapterPage({
     const t2 = setTimeout(() => setDelayedRenderStage(2), 1100);
     const t3 = setTimeout(() => setDelayedRenderStage(3), 1600);
     const t4 = setTimeout(() => setDelayedRenderStage(4), 2100);
-
     return () => {
       clearTimeout(t1);
       clearTimeout(t2);
       clearTimeout(t3);
       clearTimeout(t4);
     };
-  }, [isPreloading]);
+  }, [isPreloading, activeView]);
 
   // Track explanation tab content heights for scroll syncing
   const tabContentHeightsRef = useRef<
@@ -1039,7 +1048,7 @@ export function ChapterPage({
       >
         <TextVisibilityContext.Provider value={textVisibilityContextValue}>
           <View style={styles.readerContainer} collapsable={false}>
-            {displayChapter ? (
+            {displayChapter && !isPreloading ? (
               <ChapterReader
                 chapter={displayChapter}
                 activeTab={activeTab}

--- a/components/bible/SimpleChapterPager.tsx
+++ b/components/bible/SimpleChapterPager.tsx
@@ -46,7 +46,14 @@
  * @see Spec: agent-os/specs/2026-02-01-chapter-header-slide-sync-v3/spec.md
  */
 
-import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from 'react';
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from 'react';
 import { StyleSheet, View } from 'react-native';
 import PagerView from '@/components/common/PagerView';
 import { useChapterNavigation } from '@/hooks/bible/use-chapter-navigation';
@@ -117,9 +124,34 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
     // Pending navigation target — set by onPageSelected, processed when pager reaches idle
     const pendingNavRef = useRef<{ bookId: number; chapterNumber: number } | null>(null);
 
-    // When props change (parent navigated), reset pager to the current page index
-    // without remounting the entire component
-    useEffect(() => {
+    // Fallback timer for cases where onPageScrollStateChanged never fires `idle` after a
+    // pageSelected (observed after setPageWithoutAnimation repositions — the native event queue
+    // swallows the trailing idle). Without this, pendingNavRef stays stale and gets consumed by
+    // the next swipe's idle event, producing the chapter-skip bug.
+    const pendingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const clearPendingTimer = () => {
+      if (pendingTimerRef.current !== null) {
+        clearTimeout(pendingTimerRef.current);
+        pendingTimerRef.current = null;
+      }
+    };
+
+    // Stable refs for the latest props so the fallback timer (created inside handlePageSelected)
+    // doesn't capture stale `bookId`/`chapterNumber`/`onChapterChange` closures.
+    const onChapterChangeRef = useRef(onChapterChange);
+    onChapterChangeRef.current = onChapterChange;
+    const currentKeyRef = useRef(`${bookId}-${chapterNumber}`);
+    currentKeyRef.current = `${bookId}-${chapterNumber}`;
+
+    useEffect(() => clearPendingTimer, []);
+
+    // Reset pager position to center after props change (parent navigated). Runs in
+    // useLayoutEffect so the setPageWithoutAnimation lands in the same paint frame as
+    // the children-array swap. With useDeferredValue on the parent, the heavy commit
+    // happens in the background priority — by the time this effect fires here, the
+    // commit is done and the next paint reflects the new children at the recentered
+    // index, so the user never sees the overshoot.
+    useLayoutEffect(() => {
       const currentKey = `${bookId}-${chapterNumber}`;
       if (prevChapterKey.current === currentKey) return;
       prevChapterKey.current = currentKey;
@@ -186,6 +218,19 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
           };
         }
       }
+
+      // Arm fallback: if `idle` never fires within 500ms, force-fire navigation from pending and
+      // clear it so the next swipe starts clean. The natural idle path cancels this timer.
+      clearPendingTimer();
+      if (pendingNavRef.current) {
+        pendingTimerRef.current = setTimeout(() => {
+          pendingTimerRef.current = null;
+          if (!pendingNavRef.current) return;
+          const { bookId: navBookId, chapterNumber: navChapter } = pendingNavRef.current;
+          pendingNavRef.current = null;
+          onChapterChangeRef.current(navBookId, navChapter);
+        }, 500);
+      }
     };
 
     /**
@@ -194,7 +239,9 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
      * we trigger the state update and reposition.
      */
     const handlePageScrollStateChanged = (event: { nativeEvent: { pageScrollState: string } }) => {
-      if (event.nativeEvent.pageScrollState === 'idle' && pendingNavRef.current) {
+      const state = event.nativeEvent.pageScrollState;
+      if (state === 'idle' && pendingNavRef.current) {
+        clearPendingTimer();
         const { bookId: navBookId, chapterNumber: navChapter } = pendingNavRef.current;
         pendingNavRef.current = null;
         onChapterChange(navBookId, navChapter);
@@ -210,26 +257,37 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
     const pages = useMemo(() => {
       const result: React.ReactNode[] = [];
 
-      // Add previous page if available
+      // Keys are chapter-based, NOT slot-based ("page-prev/current/next").
+      // Why: after a swipe, React's pages-array shifts so the chapter the user just
+      // swiped to ends up in a different slot (was at the right edge, now in the
+      // center). Slot-based keys would have React reuse the right-edge instance and
+      // mutate it to a different chapter, then setPageWithoutAnimation moves the pager
+      // to a different instance with scroll=0 — that's the "teleport back to top" bug.
+      // Chapter-based keys make React migrate the user's actual chapter instance
+      // between slots, preserving its ScrollView position.
       if (canGoPrevious && prevChapter) {
         result.push(
-          <View key="page-prev" style={styles.page}>
+          <View
+            key={`chapter-${prevChapter.bookId}-${prevChapter.chapterNumber}`}
+            style={styles.page}
+          >
             {renderChapterPage(prevChapter.bookId, prevChapter.chapterNumber)}
           </View>
         );
       }
 
-      // Always add current page
       result.push(
-        <View key="page-current" style={styles.page}>
+        <View key={`chapter-${bookId}-${chapterNumber}`} style={styles.page}>
           {renderChapterPage(bookId, chapterNumber)}
         </View>
       );
 
-      // Add next page if available
       if (canGoNext && nextChapter) {
         result.push(
-          <View key="page-next" style={styles.page}>
+          <View
+            key={`chapter-${nextChapter.bookId}-${nextChapter.chapterNumber}`}
+            style={styles.page}
+          >
             {renderChapterPage(nextChapter.bookId, nextChapter.chapterNumber)}
           </View>
         );


### PR DESCRIPTION
## Summary

Fixes four user-reported bugs in chapter swiping that Andy flagged after the PR #328 preview build. Built on top of `claude/visuals-polish` so it stacks behind that PR. All fixes are evidence-driven — a 16ms JS-thread heartbeat detector + `[SWIPE-DBG]` instrumentation on Sebas's Xperia 5 V via wireless ADB drove the diagnosis. Instrumentation has been stripped from this commit.

## Bugs fixed

### Overshoot ("chapter +2 flash")
After navFire, React's pages-array rebuild placed the chapter the user just swiped to in a different slot than it was during the swipe. With slot-based View keys (`page-prev/current/next`), React reused the right-edge instance and mutated its chapter prop — so the recenter `setPage(1)` moved the pager to a **different** (mid-slot, scroll=0) instance, and during the gap the right-edge briefly showed chapter+2 content. Fixed by keying the page Views on `chapter-${bookId}-${chapterNumber}` so React migrates the user's actual chapter instance between slots, preserving its scroll position.

### Teleport-back-to-top after scrolling
The first fix attempt used a `key` prop on `PagerView` to force-remount on chapter change. That eliminated the overshoot but caused a new bug: the entire native PagerView unmounted, which destroyed the `ChapterPage` the user was scrolled into — they got teleported back to the top of the new chapter ~1-2s after swiping. The chapter-keyed View-slot fix above replaces this approach entirely; no remount needed.

### Header lag (header shows old chapter for ~1-2s)
Header text and the heavy `ChapterPage` re-render were committing in the same React pass. The commit phase stretched to ~500ms because of `ChapterReader` laying out all verses + lex + highlights. Native didn't repaint until commit finished, so the header text appeared to lag the visible page change by 1-2s. Wrapping the chapter passed to `SimpleChapterPager` in `useDeferredValue` puts the header on the urgent render path (fast commit) while the pager re-renders in a lower-priority background pass.

### Scroll hiccups (~500-700ms each, post-swipe)
`ChapterPage` had staggered timers at 600/1100/1600/2100ms that mounted the `Explanations` container + Summary tab + Byline tab (offscreen, hidden) to pre-warm them for when the user taps Insight. JS-thread heartbeat instrumentation proved 500-700ms blocks at exactly those timestamps. Now gated on `activeView === 'explanations'` so the staged mounts only run when the user is actually in Insight view, not while they're scrolling Bible content.

### Bonus: pendingNavRef stale leak (chapter-skip bug)
After `setPageWithoutAnimation`, `onPageScrollStateChanged` sometimes never fired `idle`. Without the trailing idle, `pendingNavRef` stayed set; the next swipe's idle event then consumed the stale value and navigated to the wrong chapter (the user saw "Genesis 1 → Genesis 3 skip"). Added a 500ms fallback timer armed in `handlePageSelected` that force-fires the pending navigation if natural idle never arrives.

## Files touched

- `app/bible/[bookId]/[chapterNumber].tsx` — `useDeferredValue` for the pager's chapter
- `components/bible/SimpleChapterPager.tsx` — chapter-keyed View slots, `useLayoutEffect` recenter, 500ms idle-fallback timer
- `components/bible/ChapterPage.tsx` — staged renders gated on `activeView === 'explanations'`, `ChapterReader` gated on `!isPreloading`
- `.maestro/regression/swipe-debug-flow.yaml` — regression flow to repro the three swipe bugs

## Trade-off accepted (documented in commit)

`ChapterReader` is gated on `!isPreloading` so buffer chapters render `SkeletonLoader` instead of their full verse layout. This eliminated the buffer-mount JS-blocks at the cost of a brief skeleton on swipe-to-new-chapter. A follow-up will virtualize `ChapterReader` so we can have both (plan saved in memory).

## Test plan

- [ ] Swipe forward to next chapter — header text updates within ~200ms (synced with haptic)
- [ ] Swipe + scroll vertically within ~1s — no teleport back to top, no frame drops
- [ ] Watch for chapter+2 flash during swipe — should be gone
- [ ] Rapid double-swipe — first chapter advance succeeds, header stays in sync
- [ ] Switch to Insight view — Summary tab loads (one-time mount cost on first switch)
- [ ] Boundary chapters (Genesis 1, Revelation 22) — swipe still respects boundary
- [ ] Bookmark, notes, lex tooltip, highlights, verse-jump still functional
- [ ] EAS Preview Build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)