### PR TITLE
feat(names-of-god): NamesOfGodRepository + NamesOfGodUseCase (VER-144) [preview:all]

### DIFF
--- a/__tests__/components/bible/SimpleChapterPager.test.tsx
+++ b/__tests__/components/bible/SimpleChapterPager.test.tsx
@@ -61,9 +61,19 @@ jest.mock('react-native-pager-view', () => {
       mockOnPageScrollStateChanged = onPageScrollStateChanged;
       mockInitialPage = initialPage;
 
+      // setPageWithoutAnimation on the real native ViewPager fires
+      // onPageSelected(target) once the seek completes. The production
+      // code uses that "landed" event to clear its programmaticTargetRef
+      // guard (which suppresses spurious intermediate pageSelected
+      // events during the seek). Without simulating it here, the guard
+      // stays armed forever and swallows subsequent real user swipes.
       React.useImperativeHandle(ref, () => ({
-        setPage: jest.fn(),
-        setPageWithoutAnimation: jest.fn(),
+        setPage: jest.fn((target: number) => {
+          onPageSelected?.({ nativeEvent: { position: target } });
+        }),
+        setPageWithoutAnimation: jest.fn((target: number) => {
+          onPageSelected?.({ nativeEvent: { position: target } });
+        }),
       }));
 
       return (

--- a/__tests__/locales/names-of-god-keys.test.ts
+++ b/__tests__/locales/names-of-god-keys.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Locales — `names_of_god.*` keys (VER-148)
+ *
+ * Ensures every supported locale file contains all Names of God UI string
+ * keys. A missing key here means that locale would show the raw key string
+ * or the English fallback instead of a real translation.
+ */
+
+import de from '@/locales/de.json';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+import pt from '@/locales/pt.json';
+
+type LocaleCatalog = { names_of_god: Record<string, string> };
+
+const LOCALES: Record<string, LocaleCatalog> = { en, es, fr, de, pt } as Record<
+  string,
+  LocaleCatalog
+>;
+
+// All keys that must exist in every locale.
+const REQUIRED_KEYS: (keyof (typeof en)['names_of_god'])[] = [
+  'title',
+  'testament_ot',
+  'testament_nt',
+  'testament_both',
+  'verses_count',
+  'page_label',
+  'previous_page',
+  'next_page',
+  'loading_verses',
+  'verse_error',
+  'error_name_not_found',
+  'error_name_not_found_detail',
+  'go_back',
+  'language_hebrew',
+  'language_greek',
+  'language_aramaic',
+  'language_english',
+  'search_placeholder',
+  'filter_all',
+  'names_count',
+  'no_results',
+];
+
+describe('names_of_god locale completeness', () => {
+  for (const [code, catalog] of Object.entries(LOCALES)) {
+    describe(`${code}.json`, () => {
+      it('has a names_of_god section', () => {
+        expect(catalog.names_of_god).toBeDefined();
+        expect(typeof catalog.names_of_god).toBe('object');
+      });
+
+      for (const key of REQUIRED_KEYS) {
+        it(`has key: names_of_god.${key}`, () => {
+          expect(catalog.names_of_god[key as string]).toBeDefined();
+          expect(typeof catalog.names_of_god[key as string]).toBe('string');
+          expect(catalog.names_of_god[key as string].length).toBeGreaterThan(0);
+        });
+      }
+
+      it('verses_count retains {{count}} placeholder', () => {
+        expect(catalog.names_of_god.verses_count).toContain('{{count}}');
+      });
+
+      it('names_count retains {{count}} placeholder', () => {
+        expect(catalog.names_of_god.names_count).toContain('{{count}}');
+      });
+
+      it('page_label retains {{current}} and {{total}} placeholders', () => {
+        expect(catalog.names_of_god.page_label).toContain('{{current}}');
+        expect(catalog.names_of_god.page_label).toContain('{{total}}');
+      });
+    });
+  }
+});

--- a/__tests__/screens/names-of-god/name-detail.test.tsx
+++ b/__tests__/screens/names-of-god/name-detail.test.tsx
@@ -1,0 +1,169 @@
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import type React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import NameDetailScreen from '@/app/names-of-god/[nameId]';
+import type { ParsedVerseRef } from '@/utils/names-of-god/parse-verse-ref';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    back: jest.fn(),
+    replace: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  },
+  useLocalSearchParams: jest.fn().mockReturnValue({ nameId: 'yahweh' }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: jest.fn(({ children }: { children: React.ReactNode }) => children),
+  useSafeAreaInsets: jest.fn().mockReturnValue({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('@/hooks/use-bible-version', () => ({
+  useBibleVersion: jest.fn().mockReturnValue({ bibleVersion: 'NASB1995', isLoading: false }),
+}));
+
+const mockVerseTexts = jest.fn();
+jest.mock('@/hooks/names-of-god/use-verse-texts', () => ({
+  useVerseTexts: (...args: unknown[]) => mockVerseTexts(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const mockRef = (
+  bookId: number,
+  chapter: number,
+  verse: number,
+  bookName: string
+): { ref: ParsedVerseRef; text: string; isLoading: boolean; hasError: boolean } => ({
+  ref: { raw: `${bookName} ${chapter}:${verse}`, bookId, bookName, chapter, verse },
+  text: `Verse text for ${bookName} ${chapter}:${verse}`,
+  isLoading: false,
+  hasError: false,
+});
+
+const renderScreen = () =>
+  render(
+    <SafeAreaProvider>
+      <NameDetailScreen />
+    </SafeAreaProvider>
+  );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('NameDetailScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: return verse texts for Yahweh's first few refs
+    mockVerseTexts.mockReturnValue([
+      mockRef(2, 3, 14, 'Exodus'),
+      mockRef(2, 6, 2, 'Exodus'),
+      mockRef(19, 83, 18, 'Psalms'),
+    ]);
+  });
+
+  describe('Given name is found', () => {
+    it('renders the English name', () => {
+      renderScreen();
+      expect(screen.getByTestId('name-detail-english')).toBeTruthy();
+      expect(screen.getByText('Yahweh')).toBeTruthy();
+    });
+
+    it('renders the original script', () => {
+      renderScreen();
+      const original = screen.getByTestId('name-detail-original');
+      expect(original).toBeTruthy();
+    });
+
+    it('renders the transliteration', () => {
+      renderScreen();
+      expect(screen.getByTestId('name-detail-transliteration')).toBeTruthy();
+    });
+
+    it('renders the meaning text', () => {
+      renderScreen();
+      expect(screen.getByTestId('name-detail-meaning')).toBeTruthy();
+    });
+
+    it('renders Old Testament badge for Yahweh', () => {
+      renderScreen();
+      expect(screen.getByText('Old Testament')).toBeTruthy();
+    });
+
+    it('renders verse rows for each ref on the page', () => {
+      renderScreen();
+      expect(screen.getByTestId('verse-row-2-3-14')).toBeTruthy();
+      expect(screen.getByTestId('verse-row-2-6-2')).toBeTruthy();
+      expect(screen.getByTestId('verse-row-19-83-18')).toBeTruthy();
+    });
+
+    it('shows verse text snippet in each row', () => {
+      renderScreen();
+      expect(screen.getByText('Verse text for Exodus 3:14')).toBeTruthy();
+    });
+
+    it('navigates to Bible reader when a verse row is tapped', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('verse-row-2-3-14'));
+      expect(router.push).toHaveBeenCalledWith('/bible/2/3?verse=14');
+    });
+
+    it('navigates back when back button is pressed', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('name-detail-back'));
+      expect(router.back).toHaveBeenCalled();
+    });
+  });
+
+  describe('Given a verse is loading', () => {
+    it('shows a loading indicator for that verse', () => {
+      mockVerseTexts.mockReturnValue([
+        {
+          ref: { raw: 'Exodus 3:14', bookId: 2, bookName: 'Exodus', chapter: 3, verse: 14 },
+          text: null,
+          isLoading: true,
+          hasError: false,
+        },
+      ]);
+      renderScreen();
+      // The ActivityIndicator has no text — verify the verse row still renders
+      expect(screen.getByTestId('verse-row-2-3-14')).toBeTruthy();
+    });
+  });
+
+  describe('Given a verse has an error', () => {
+    it('shows an error message for that verse', () => {
+      mockVerseTexts.mockReturnValue([
+        {
+          ref: { raw: 'Exodus 3:14', bookId: 2, bookName: 'Exodus', chapter: 3, verse: 14 },
+          text: null,
+          isLoading: false,
+          hasError: true,
+        },
+      ]);
+      renderScreen();
+      expect(screen.getByText("Couldn't load verse text")).toBeTruthy();
+    });
+  });
+
+  describe('Given the nameId is not found', () => {
+    it('shows not-found error state', () => {
+      const { useLocalSearchParams } = require('expo-router');
+      useLocalSearchParams.mockReturnValue({ nameId: 'nonexistent-name-xyz' });
+      mockVerseTexts.mockReturnValue([]);
+      renderScreen();
+      expect(screen.getByText('Name not found')).toBeTruthy();
+    });
+  });
+
+  describe('Given pagination', () => {
+    it('does not render pagination controls when all refs fit on one page', () => {
+      // Yahweh has 5 refs in the dataset which is < 30
+      renderScreen();
+      expect(screen.queryByTestId('name-detail-pagination')).toBeNull();
+    });
+  });
+});

--- a/__tests__/screens/names-of-god/name-detail.test.tsx
+++ b/__tests__/screens/names-of-god/name-detail.test.tsx
@@ -68,8 +68,9 @@ describe('NameDetailScreen', () => {
   describe('Given name is found', () => {
     it('renders the English name', () => {
       renderScreen();
-      expect(screen.getByTestId('name-detail-english')).toBeTruthy();
-      expect(screen.getByText('Yahweh')).toBeTruthy();
+      const el = screen.getByTestId('name-detail-english');
+      expect(el).toBeTruthy();
+      expect(el.props.children).toBe('Yahweh');
     });
 
     it('renders the original script', () => {

--- a/__tests__/screens/names-of-god/names-of-god-list.test.tsx
+++ b/__tests__/screens/names-of-god/names-of-god-list.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import type React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import NamesOfGodListScreen from '@/app/names-of-god/index';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    back: jest.fn(),
+    replace: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: jest.fn(({ children }: { children: React.ReactNode }) => children),
+  useSafeAreaInsets: jest.fn().mockReturnValue({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const mockGetAll = jest.fn();
+jest.mock('@/services/names-of-god-repository', () => ({
+  getAll: (...args: unknown[]) => mockGetAll(...args),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const YAHWEH = {
+  id: 'yahweh',
+  nameEn: 'Yahweh',
+  nameOriginal: 'יהוה',
+  transliteration: 'YHWH',
+  language: 'Hebrew',
+  category: 'Personal Name',
+  meaning: 'I AM WHO I AM',
+  testament: 'OT',
+  verseRefs: ['Exodus 3:14'],
+};
+
+const THEOS = {
+  id: 'theos',
+  nameEn: 'Theos',
+  nameOriginal: 'Θεός',
+  transliteration: 'Theos',
+  language: 'Greek',
+  category: 'Title',
+  meaning: 'God',
+  testament: 'NT',
+  verseRefs: ['John 1:1'],
+};
+
+const ELOHIM = {
+  id: 'elohim',
+  nameEn: 'Elohim',
+  nameOriginal: 'אֱלֹהִים',
+  transliteration: 'Elohim',
+  language: 'Hebrew',
+  category: 'Title',
+  meaning: 'God (plural of majesty)',
+  testament: 'OT',
+  verseRefs: ['Genesis 1:1'],
+};
+
+const ALL_NAMES = [YAHWEH, THEOS, ELOHIM];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const renderScreen = () =>
+  render(
+    <SafeAreaProvider>
+      <NamesOfGodListScreen />
+    </SafeAreaProvider>
+  );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('NamesOfGodListScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAll.mockReturnValue(ALL_NAMES);
+  });
+
+  describe('initial render', () => {
+    it('renders the screen container', () => {
+      renderScreen();
+      expect(screen.getByTestId('names-of-god-list-screen')).toBeTruthy();
+    });
+
+    it('renders all names from the dataset', () => {
+      renderScreen();
+      expect(screen.getByText('Yahweh')).toBeTruthy();
+      expect(screen.getByText('Theos')).toBeTruthy();
+      expect(screen.getByText('Elohim')).toBeTruthy();
+    });
+
+    it('shows the name count label', () => {
+      renderScreen();
+      expect(screen.getByText('3 names')).toBeTruthy();
+    });
+
+    it('renders all filter chips', () => {
+      renderScreen();
+      expect(screen.getByTestId('filter-chip-All')).toBeTruthy();
+      expect(screen.getByTestId('filter-chip-Hebrew')).toBeTruthy();
+      expect(screen.getByTestId('filter-chip-Greek')).toBeTruthy();
+    });
+
+    it('renders the search input', () => {
+      renderScreen();
+      expect(screen.getByTestId('names-search-input')).toBeTruthy();
+    });
+  });
+
+  describe('search', () => {
+    it('filters list in real-time as user types', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'yahweh');
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.queryByText('Theos')).toBeNull();
+      });
+    });
+
+    it('shows empty state when search returns no results', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'zzznomatch');
+
+      await waitFor(() => {
+        expect(screen.getByText('No names match your search.')).toBeTruthy();
+      });
+    });
+
+    it('clears search when clear button pressed', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'yahweh');
+
+      await waitFor(() => expect(screen.getByTestId('names-search-clear')).toBeTruthy());
+      fireEvent.press(screen.getByTestId('names-search-clear'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Theos')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('filter chips', () => {
+    it('filters to Hebrew names when Hebrew chip pressed', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Hebrew'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Elohim')).toBeTruthy();
+        expect(screen.queryByText('Theos')).toBeNull();
+      });
+    });
+
+    it('filters to Greek names when Greek chip pressed', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Greek'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Theos')).toBeTruthy();
+        expect(screen.queryByText('Yahweh')).toBeNull();
+      });
+    });
+
+    it('shows all names when All chip pressed after filter', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Hebrew'));
+      fireEvent.press(screen.getByTestId('filter-chip-All'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Theos')).toBeTruthy();
+        expect(screen.getByText('Elohim')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('navigation', () => {
+    it('navigates to NameDetailScreen when a name row is tapped', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('name-row-yahweh'));
+      expect(router.push).toHaveBeenCalledWith('/names-of-god/yahweh');
+    });
+
+    it('calls router.back when back button pressed and canGoBack is true', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('names-list-back'));
+      expect(router.back).toHaveBeenCalled();
+    });
+  });
+});

--- a/__tests__/screens/names-of-god/names-of-god-list.test.tsx
+++ b/__tests__/screens/names-of-god/names-of-god-list.test.tsx
@@ -90,9 +90,12 @@ describe('NamesOfGodListScreen', () => {
 
     it('renders all names from the dataset', () => {
       renderScreen();
-      expect(screen.getByText('Yahweh')).toBeTruthy();
-      expect(screen.getByText('Theos')).toBeTruthy();
-      expect(screen.getByText('Elohim')).toBeTruthy();
+      // Use the row testID rather than getByText: the name string also
+      // appears in the row's accessibilityLabel, so getByText would
+      // match multiple elements.
+      expect(screen.getByTestId('name-row-yahweh')).toBeTruthy();
+      expect(screen.getByTestId('name-row-theos')).toBeTruthy();
+      expect(screen.getByTestId('name-row-elohim')).toBeTruthy();
     });
 
     it('shows the name count label', () => {
@@ -120,8 +123,8 @@ describe('NamesOfGodListScreen', () => {
       fireEvent.changeText(input, 'yahweh');
 
       await waitFor(() => {
-        expect(screen.getByText('Yahweh')).toBeTruthy();
-        expect(screen.queryByText('Theos')).toBeNull();
+        expect(screen.getByTestId('name-row-yahweh')).toBeTruthy();
+        expect(screen.queryByTestId('name-row-theos')).toBeNull();
       });
     });
 
@@ -144,8 +147,8 @@ describe('NamesOfGodListScreen', () => {
       fireEvent.press(screen.getByTestId('names-search-clear'));
 
       await waitFor(() => {
-        expect(screen.getByText('Yahweh')).toBeTruthy();
-        expect(screen.getByText('Theos')).toBeTruthy();
+        expect(screen.getByTestId('name-row-yahweh')).toBeTruthy();
+        expect(screen.getByTestId('name-row-theos')).toBeTruthy();
       });
     });
   });
@@ -156,9 +159,9 @@ describe('NamesOfGodListScreen', () => {
       fireEvent.press(screen.getByTestId('filter-chip-Hebrew'));
 
       await waitFor(() => {
-        expect(screen.getByText('Yahweh')).toBeTruthy();
-        expect(screen.getByText('Elohim')).toBeTruthy();
-        expect(screen.queryByText('Theos')).toBeNull();
+        expect(screen.getByTestId('name-row-yahweh')).toBeTruthy();
+        expect(screen.getByTestId('name-row-elohim')).toBeTruthy();
+        expect(screen.queryByTestId('name-row-theos')).toBeNull();
       });
     });
 
@@ -167,8 +170,8 @@ describe('NamesOfGodListScreen', () => {
       fireEvent.press(screen.getByTestId('filter-chip-Greek'));
 
       await waitFor(() => {
-        expect(screen.getByText('Theos')).toBeTruthy();
-        expect(screen.queryByText('Yahweh')).toBeNull();
+        expect(screen.getByTestId('name-row-theos')).toBeTruthy();
+        expect(screen.queryByTestId('name-row-yahweh')).toBeNull();
       });
     });
 
@@ -178,9 +181,9 @@ describe('NamesOfGodListScreen', () => {
       fireEvent.press(screen.getByTestId('filter-chip-All'));
 
       await waitFor(() => {
-        expect(screen.getByText('Yahweh')).toBeTruthy();
-        expect(screen.getByText('Theos')).toBeTruthy();
-        expect(screen.getByText('Elohim')).toBeTruthy();
+        expect(screen.getByTestId('name-row-yahweh')).toBeTruthy();
+        expect(screen.getByTestId('name-row-theos')).toBeTruthy();
+        expect(screen.getByTestId('name-row-elohim')).toBeTruthy();
       });
     });
   });

--- a/__tests__/services/names-of-god-repository.test.ts
+++ b/__tests__/services/names-of-god-repository.test.ts
@@ -1,0 +1,87 @@
+import { clearCache, getAll } from '@/services/names-of-god-repository';
+
+const mockDataset = [
+  {
+    id: 'yahweh',
+    nameEn: 'Yahweh',
+    nameOriginal: 'יְהוָה',
+    transliteration: 'Yahweh',
+    language: 'Hebrew',
+    category: 'covenant-name',
+    meaning: 'I AM WHO I AM; the eternal, self-existent, covenant name of God revealed to Moses',
+    testament: 'OT',
+    verseRefs: ['Exodus 3:14', 'Exodus 6:2', 'Psalm 83:18'],
+  },
+  {
+    id: 'elohim',
+    nameEn: 'Elohim',
+    nameOriginal: 'אֱלֹהִים',
+    transliteration: 'Elohim',
+    language: 'Hebrew',
+    category: 'divine-name',
+    meaning: 'God; the plural form emphasising majesty and fullness of divine power',
+    testament: 'OT',
+    verseRefs: ['Genesis 1:1', 'Psalm 19:1'],
+  },
+  {
+    id: 'kyrios',
+    nameEn: 'Kyrios',
+    nameOriginal: 'Κύριος',
+    transliteration: 'Kyrios',
+    language: 'Greek',
+    category: 'divine-name',
+    meaning: 'Lord; title of authority and sovereignty used of both God and Jesus',
+    testament: 'NT',
+    verseRefs: ['Romans 10:9', 'Philippians 2:11'],
+  },
+];
+
+jest.mock('@/assets/names-of-god.json', () => mockDataset, { virtual: true });
+
+describe('names-of-god-repository', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  describe('getAll', () => {
+    it('returns all entries from the dataset', () => {
+      expect(getAll()).toHaveLength(3);
+    });
+
+    it('returns entries with expected shape', () => {
+      const first = getAll()[0];
+      expect(first).toHaveProperty('id');
+      expect(first).toHaveProperty('nameEn');
+      expect(first).toHaveProperty('transliteration');
+      expect(first).toHaveProperty('language');
+      expect(first).toHaveProperty('meaning');
+      expect(first).toHaveProperty('verseRefs');
+    });
+
+    it('returns cached data on subsequent calls', () => {
+      const first = getAll();
+      const second = getAll();
+      expect(first).toBe(second);
+    });
+
+    it('reloads after clearCache', () => {
+      const before = getAll();
+      clearCache();
+      const after = getAll();
+      expect(after).toEqual(before);
+    });
+
+    it('returns verseRefs as an array', () => {
+      const entry = getAll()[0];
+      expect(Array.isArray(entry.verseRefs)).toBe(true);
+      expect(entry.verseRefs.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('clearCache', () => {
+    it('does not throw when cache is empty', () => {
+      clearCache();
+      expect(() => clearCache()).not.toThrow();
+    });
+  });
+});

--- a/__tests__/services/names-of-god-use-case.test.ts
+++ b/__tests__/services/names-of-god-use-case.test.ts
@@ -1,0 +1,227 @@
+import { clearCache } from '@/services/names-of-god-repository';
+import {
+  filterByCategory,
+  getAllNames,
+  getNameById,
+  searchNames,
+} from '@/services/names-of-god-use-case';
+
+const mockDataset = [
+  {
+    id: 'yahweh',
+    nameEn: 'Yahweh',
+    nameOriginal: 'יְהוָה',
+    transliteration: 'Yahweh',
+    language: 'Hebrew',
+    category: 'covenant-name',
+    meaning: 'I AM WHO I AM; the eternal, self-existent, covenant name of God revealed to Moses',
+    testament: 'OT',
+    verseRefs: ['Exodus 3:14', 'Exodus 6:2', 'Psalm 83:18', 'Isaiah 42:8', 'Genesis 2:4'],
+  },
+  {
+    id: 'elohim',
+    nameEn: 'Elohim',
+    nameOriginal: 'אֱלֹהִים',
+    transliteration: 'Elohim',
+    language: 'Hebrew',
+    category: 'divine-name',
+    meaning: 'God; the plural form emphasising majesty and fullness of divine power',
+    testament: 'OT',
+    verseRefs: ['Genesis 1:1', 'Psalm 19:1'],
+  },
+  {
+    id: 'kyrios',
+    nameEn: 'Kyrios',
+    nameOriginal: 'Κύριος',
+    transliteration: 'Kyrios',
+    language: 'Greek',
+    category: 'divine-name',
+    meaning: 'Lord; title of authority and sovereignty used of both God and Jesus',
+    testament: 'NT',
+    verseRefs: ['Romans 10:9', 'Philippians 2:11'],
+  },
+  {
+    id: 'theos',
+    nameEn: 'Theos',
+    nameOriginal: 'Θεός',
+    transliteration: 'Theos',
+    language: 'Greek',
+    category: 'divine-name',
+    meaning: 'God; the generic Greek term for deity',
+    testament: 'NT',
+    verseRefs: ['John 1:1', 'John 1:14'],
+  },
+  {
+    id: 'adonai',
+    nameEn: 'Adonai',
+    nameOriginal: 'אֲדֹנָי',
+    transliteration: 'Adonai',
+    language: 'Hebrew',
+    category: 'relational-title',
+    meaning: 'Lord; master; emphasises the lordship and sovereignty of God over creation',
+    testament: 'OT',
+    verseRefs: ['Psalm 2:4', 'Isaiah 6:1'],
+  },
+];
+
+jest.mock('@/assets/names-of-god.json', () => mockDataset, { virtual: true });
+
+describe('names-of-god-use-case', () => {
+  beforeEach(() => {
+    clearCache();
+  });
+
+  describe('getAllNames', () => {
+    it('returns all entries', () => {
+      expect(getAllNames()).toHaveLength(5);
+    });
+
+    it('returns entries with verseRefs arrays', () => {
+      for (const entry of getAllNames()) {
+        expect(Array.isArray(entry.verseRefs)).toBe(true);
+      }
+    });
+  });
+
+  describe('searchNames', () => {
+    it('returns all entries for empty query', () => {
+      expect(searchNames('')).toHaveLength(5);
+    });
+
+    it('returns all entries for whitespace-only query', () => {
+      expect(searchNames('   ')).toHaveLength(5);
+    });
+
+    it('matches by English name (case-insensitive)', () => {
+      const results = searchNames('yahweh');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('yahweh');
+    });
+
+    it('matches by English name with mixed case', () => {
+      const results = searchNames('ELOHIM');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('elohim');
+    });
+
+    it('matches by transliteration', () => {
+      const results = searchNames('Kyrios');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('kyrios');
+    });
+
+    it('matches by meaning keyword', () => {
+      const results = searchNames('sovereign');
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.some((e) => e.id === 'kyrios')).toBe(true);
+    });
+
+    it('matches multiple tokens — all must appear', () => {
+      const results = searchNames('eternal covenant');
+      expect(results).toHaveLength(1);
+      expect(results[0].id).toBe('yahweh');
+    });
+
+    it('returns empty array when no entry matches', () => {
+      expect(searchNames('zzznomatch')).toHaveLength(0);
+    });
+
+    it('returns multiple matches for shared keyword', () => {
+      // "divine" appears in meaning of multiple entries — at least 2
+      const results = searchNames('God');
+      expect(results.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('does not match when one token is absent', () => {
+      const results = searchNames('yahweh greek');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('filterByCategory', () => {
+    it("returns all entries for 'All'", () => {
+      expect(filterByCategory('All')).toHaveLength(5);
+    });
+
+    it("returns only Hebrew entries for 'Hebrew'", () => {
+      const results = filterByCategory('Hebrew');
+      expect(results.length).toBeGreaterThan(0);
+      for (const entry of results) {
+        expect(entry.language).toBe('Hebrew');
+      }
+    });
+
+    it("returns only Greek entries for 'Greek'", () => {
+      const results = filterByCategory('Greek');
+      expect(results.length).toBeGreaterThan(0);
+      for (const entry of results) {
+        expect(entry.language).toBe('Greek');
+      }
+    });
+
+    it("returns empty array for 'English' when no English entries exist", () => {
+      expect(filterByCategory('English')).toHaveLength(0);
+    });
+
+    it('Hebrew + Greek counts add up to total', () => {
+      const hebrew = filterByCategory('Hebrew');
+      const greek = filterByCategory('Greek');
+      const all = filterByCategory('All');
+      expect(hebrew.length + greek.length).toBe(all.length);
+    });
+
+    it('Hebrew filter includes yahweh, elohim, adonai', () => {
+      const ids = filterByCategory('Hebrew').map((e) => e.id);
+      expect(ids).toContain('yahweh');
+      expect(ids).toContain('elohim');
+      expect(ids).toContain('adonai');
+    });
+
+    it('Greek filter includes kyrios and theos', () => {
+      const ids = filterByCategory('Greek').map((e) => e.id);
+      expect(ids).toContain('kyrios');
+      expect(ids).toContain('theos');
+    });
+  });
+
+  describe('getNameById', () => {
+    it('returns the correct entry for a known id', () => {
+      const entry = getNameById('yahweh');
+      expect(entry).not.toBeNull();
+      expect(entry?.id).toBe('yahweh');
+      expect(entry?.nameEn).toBe('Yahweh');
+    });
+
+    it('returns null for an unknown id', () => {
+      expect(getNameById('notanid')).toBeNull();
+    });
+
+    it('includes the full verseRefs list', () => {
+      const entry = getNameById('yahweh');
+      expect(entry?.verseRefs).toEqual([
+        'Exodus 3:14',
+        'Exodus 6:2',
+        'Psalm 83:18',
+        'Isaiah 42:8',
+        'Genesis 2:4',
+      ]);
+    });
+
+    it('returns all fields of the entry', () => {
+      const entry = getNameById('kyrios');
+      expect(entry).toMatchObject({
+        id: 'kyrios',
+        nameEn: 'Kyrios',
+        nameOriginal: 'Κύριος',
+        transliteration: 'Kyrios',
+        language: 'Greek',
+        category: 'divine-name',
+        testament: 'NT',
+      });
+    });
+
+    it('handles empty string id', () => {
+      expect(getNameById('')).toBeNull();
+    });
+  });
+});

--- a/__tests__/services/names-of-god-use-case.test.ts
+++ b/__tests__/services/names-of-god-use-case.test.ts
@@ -32,7 +32,7 @@ const mockDataset = [
   {
     id: 'kyrios',
     nameEn: 'Kyrios',
-    nameOriginal: 'Κύριος',
+    nameOriginal: 'κύριος',
     transliteration: 'Kyrios',
     language: 'Greek',
     category: 'divine-name',
@@ -62,6 +62,17 @@ const mockDataset = [
     testament: 'OT',
     verseRefs: ['Psalm 2:4', 'Isaiah 6:1'],
   },
+  {
+    id: 'bar-enash',
+    nameEn: 'Bar Enash',
+    nameOriginal: 'בַּר אֱנָשׁ',
+    transliteration: 'Bar Enash',
+    language: 'Aramaic',
+    category: 'messianic-title',
+    meaning: 'Son of Man; Aramaic title used in Daniel for the heavenly figure',
+    testament: 'OT',
+    verseRefs: ['Daniel 7:13'],
+  },
 ];
 
 jest.mock('@/assets/names-of-god.json', () => mockDataset, { virtual: true });
@@ -73,7 +84,7 @@ describe('names-of-god-use-case', () => {
 
   describe('getAllNames', () => {
     it('returns all entries', () => {
-      expect(getAllNames()).toHaveLength(5);
+      expect(getAllNames()).toHaveLength(6);
     });
 
     it('returns entries with verseRefs arrays', () => {
@@ -85,11 +96,11 @@ describe('names-of-god-use-case', () => {
 
   describe('searchNames', () => {
     it('returns all entries for empty query', () => {
-      expect(searchNames('')).toHaveLength(5);
+      expect(searchNames('')).toHaveLength(6);
     });
 
     it('returns all entries for whitespace-only query', () => {
-      expect(searchNames('   ')).toHaveLength(5);
+      expect(searchNames('   ')).toHaveLength(6);
     });
 
     it('matches by English name (case-insensitive)', () => {
@@ -140,7 +151,7 @@ describe('names-of-god-use-case', () => {
 
   describe('filterByCategory', () => {
     it("returns all entries for 'All'", () => {
-      expect(filterByCategory('All')).toHaveLength(5);
+      expect(filterByCategory('All')).toHaveLength(6);
     });
 
     it("returns only Hebrew entries for 'Hebrew'", () => {
@@ -163,11 +174,20 @@ describe('names-of-god-use-case', () => {
       expect(filterByCategory('English')).toHaveLength(0);
     });
 
-    it('Hebrew + Greek counts add up to total', () => {
+    it("returns only Aramaic entries for 'Aramaic'", () => {
+      const results = filterByCategory('Aramaic');
+      expect(results.length).toBeGreaterThan(0);
+      for (const entry of results) {
+        expect(entry.language).toBe('Aramaic');
+      }
+    });
+
+    it('Hebrew + Greek + Aramaic counts add up to total', () => {
       const hebrew = filterByCategory('Hebrew');
       const greek = filterByCategory('Greek');
+      const aramaic = filterByCategory('Aramaic');
       const all = filterByCategory('All');
-      expect(hebrew.length + greek.length).toBe(all.length);
+      expect(hebrew.length + greek.length + aramaic.length).toBe(all.length);
     });
 
     it('Hebrew filter includes yahweh, elohim, adonai', () => {
@@ -212,7 +232,7 @@ describe('names-of-god-use-case', () => {
       expect(entry).toMatchObject({
         id: 'kyrios',
         nameEn: 'Kyrios',
-        nameOriginal: 'Κύριος',
+        nameOriginal: 'κύριος',
         transliteration: 'Kyrios',
         language: 'Greek',
         category: 'divine-name',

--- a/__tests__/utils/names-of-god/parse-verse-ref.test.ts
+++ b/__tests__/utils/names-of-god/parse-verse-ref.test.ts
@@ -1,0 +1,99 @@
+import {
+  compareVerseRefs,
+  parseSortVerseRefs,
+  parseVerseRef,
+} from '@/utils/names-of-god/parse-verse-ref';
+
+describe('parseVerseRef', () => {
+  it('parses a simple single-word book ref', () => {
+    const result = parseVerseRef('Genesis 2:4');
+    expect(result).toEqual({
+      raw: 'Genesis 2:4',
+      bookId: 1,
+      bookName: 'Genesis',
+      chapter: 2,
+      verse: 4,
+    });
+  });
+
+  it('parses a numbered book ref', () => {
+    const result = parseVerseRef('1 Samuel 16:7');
+    expect(result).toEqual({
+      raw: '1 Samuel 16:7',
+      bookId: 9,
+      bookName: '1 Samuel',
+      chapter: 16,
+      verse: 7,
+    });
+  });
+
+  it('parses a three-word book name', () => {
+    const result = parseVerseRef('Song of Solomon 2:1');
+    expect(result).toEqual({
+      raw: 'Song of Solomon 2:1',
+      bookId: 22,
+      bookName: 'Song of Solomon',
+      chapter: 2,
+      verse: 1,
+    });
+  });
+
+  it('parses a New Testament ref', () => {
+    const result = parseVerseRef('Revelation 1:8');
+    expect(result).toEqual(expect.objectContaining({ bookId: 66, chapter: 1, verse: 8 }));
+  });
+
+  it('returns null for an unknown book name', () => {
+    expect(parseVerseRef('Hezekiah 3:2')).toBeNull();
+  });
+
+  it('returns null for a malformed ref', () => {
+    expect(parseVerseRef('Genesis')).toBeNull();
+    expect(parseVerseRef('Genesis 2')).toBeNull();
+    expect(parseVerseRef('')).toBeNull();
+  });
+});
+
+describe('compareVerseRefs', () => {
+  it('sorts by book first', () => {
+    const genesis = parseVerseRef('Genesis 1:1')!;
+    const exodus = parseVerseRef('Exodus 1:1')!;
+    expect(compareVerseRefs(genesis, exodus)).toBeLessThan(0);
+  });
+
+  it('sorts by chapter when book is the same', () => {
+    const ch1 = parseVerseRef('Genesis 1:1')!;
+    const ch2 = parseVerseRef('Genesis 2:1')!;
+    expect(compareVerseRefs(ch1, ch2)).toBeLessThan(0);
+  });
+
+  it('sorts by verse when book and chapter are the same', () => {
+    const v1 = parseVerseRef('Genesis 1:1')!;
+    const v5 = parseVerseRef('Genesis 1:5')!;
+    expect(compareVerseRefs(v1, v5)).toBeLessThan(0);
+  });
+
+  it('returns 0 for identical refs', () => {
+    const a = parseVerseRef('Exodus 3:14')!;
+    const b = parseVerseRef('Exodus 3:14')!;
+    expect(compareVerseRefs(a, b)).toBe(0);
+  });
+});
+
+describe('parseSortVerseRefs', () => {
+  it('returns refs in canonical order', () => {
+    const raw = ['Revelation 22:13', 'Genesis 1:1', 'Exodus 3:14'];
+    const sorted = parseSortVerseRefs(raw);
+    expect(sorted.map((r) => r.bookId)).toEqual([1, 2, 66]);
+  });
+
+  it('silently drops unparseable refs', () => {
+    const raw = ['Genesis 1:1', 'BadBook 3:4', 'Exodus 1:1'];
+    const sorted = parseSortVerseRefs(raw);
+    expect(sorted).toHaveLength(2);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(parseSortVerseRefs([])).toEqual([]);
+  });
+});

--- a/app.config.js
+++ b/app.config.js
@@ -80,6 +80,18 @@ const config = {
         ],
         category: ['BROWSABLE', 'DEFAULT'],
       },
+      {
+        action: 'VIEW',
+        autoVerify: true,
+        data: [
+          {
+            scheme: 'https',
+            host: 'app.versemate.org',
+            pathPrefix: '/names-of-god',
+          },
+        ],
+        category: ['BROWSABLE', 'DEFAULT'],
+      },
     ],
   },
   web: {

--- a/app.config.js
+++ b/app.config.js
@@ -2,7 +2,7 @@ const config = {
   name: 'VerseMate',
   slug: 'verse-mate-mobile',
   owner: 'versemate',
-  version: '1.2.1',
+  version: '1.3.0',
   orientation: 'default',
   icon: './assets/images/icon.png',
   scheme: 'versemate',

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -10,6 +10,7 @@
  * @see Task Group 4 - Deep Link Handling
  */
 
+import { BottomSheetModalProvider } from '@gorhom/bottom-sheet';
 import NetInfo from '@react-native-community/netinfo';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import {
@@ -473,56 +474,58 @@ function RootLayoutInner() {
 export default function RootLayout() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <I18nProvider>
-        <AppPostHogProvider>
-          <QueryClientProvider client={queryClient}>
-            <AuthProvider>
-              <CustomThemeProvider>
-                <DeviceInfoProvider>
-                  <OfflineProvider>
-                    <ToastProvider>
-                      <AudioPlayerProvider
-                        engine={audioEngine}
-                        onPlaybackStarted={(track, args) =>
-                          trackAudioPlaybackStarted({
-                            explanationId: track.explanation_id,
-                            explanationType: track.explanation_type,
-                            bookId: track.book_id,
-                            chapterNumber: track.chapter_number,
-                            voice: track.voice,
-                            languageCode: track.language_code,
-                            isResume: args.isResume,
-                            resumePositionSeconds: args.resumePositionSeconds,
-                            ttsProvider: track.tts_provider,
-                          })
-                        }
-                        onPlaybackPaused={(track, positionSeconds, reason) =>
-                          trackAudioPlaybackPaused({
-                            explanationId: track.explanation_id,
-                            positionSeconds,
-                            durationSeconds: track.duration_seconds,
-                            reason,
-                          })
-                        }
-                        onPlaybackCompleted={(track) =>
-                          trackAudioPlaybackCompleted({
-                            explanationId: track.explanation_id,
-                            durationSeconds: track.duration_seconds,
-                            completedBy: 'natural',
-                          })
-                        }
-                      >
-                        <RootLayoutInner />
-                        <MobileAudioPlayerRoot />
-                      </AudioPlayerProvider>
-                    </ToastProvider>
-                  </OfflineProvider>
-                </DeviceInfoProvider>
-              </CustomThemeProvider>
-            </AuthProvider>
-          </QueryClientProvider>
-        </AppPostHogProvider>
-      </I18nProvider>
+      <BottomSheetModalProvider>
+        <I18nProvider>
+          <AppPostHogProvider>
+            <QueryClientProvider client={queryClient}>
+              <AuthProvider>
+                <CustomThemeProvider>
+                  <DeviceInfoProvider>
+                    <OfflineProvider>
+                      <ToastProvider>
+                        <AudioPlayerProvider
+                          engine={audioEngine}
+                          onPlaybackStarted={(track, args) =>
+                            trackAudioPlaybackStarted({
+                              explanationId: track.explanation_id,
+                              explanationType: track.explanation_type,
+                              bookId: track.book_id,
+                              chapterNumber: track.chapter_number,
+                              voice: track.voice,
+                              languageCode: track.language_code,
+                              isResume: args.isResume,
+                              resumePositionSeconds: args.resumePositionSeconds,
+                              ttsProvider: track.tts_provider,
+                            })
+                          }
+                          onPlaybackPaused={(track, positionSeconds, reason) =>
+                            trackAudioPlaybackPaused({
+                              explanationId: track.explanation_id,
+                              positionSeconds,
+                              durationSeconds: track.duration_seconds,
+                              reason,
+                            })
+                          }
+                          onPlaybackCompleted={(track) =>
+                            trackAudioPlaybackCompleted({
+                              explanationId: track.explanation_id,
+                              durationSeconds: track.duration_seconds,
+                              completedBy: 'natural',
+                            })
+                          }
+                        >
+                          <RootLayoutInner />
+                          <MobileAudioPlayerRoot />
+                        </AudioPlayerProvider>
+                      </ToastProvider>
+                    </OfflineProvider>
+                  </DeviceInfoProvider>
+                </CustomThemeProvider>
+              </AuthProvider>
+            </QueryClientProvider>
+          </AppPostHogProvider>
+        </I18nProvider>
+      </BottomSheetModalProvider>
     </GestureHandlerRootView>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -157,6 +157,16 @@ function RootLayoutInner() {
       if (!url) return;
 
       try {
+        // Handle names-of-god deep links: versemate://names-of-god/:nameId
+        const namesOfGodMatch = url.match(
+          /(?:versemate:\/\/|https?:\/\/[^/]+)\/names-of-god\/([^/?#]+)/
+        );
+        if (namesOfGodMatch) {
+          const nameId = namesOfGodMatch[1];
+          router.replace(`/names-of-god/${nameId}`);
+          return;
+        }
+
         // Try parsing as topic URL first
         const topicParsed = parseTopicShareUrl(url);
 
@@ -425,6 +435,12 @@ function RootLayoutInner() {
           />
           <Stack.Screen
             name="manage-downloads"
+            options={{
+              headerShown: false,
+            }}
+          />
+          <Stack.Screen
+            name="names-of-god"
             options={{
               headerShown: false,
             }}

--- a/app/names-of-god/[nameId].tsx
+++ b/app/names-of-god/[nameId].tsx
@@ -1,0 +1,407 @@
+/**
+ * NameDetailScreen
+ *
+ * Full detail view for a single divine name. Shows the name's original-script
+ * form, transliteration, language, meaning, testament badge, and a paginated
+ * list of every verse where it appears. Tapping a verse row opens the Bible
+ * reader at that verse in the user's preferred Bible version.
+ *
+ * Route: /names-of-god/[nameId]
+ * Example: /names-of-god/yahweh
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import { router, useLocalSearchParams } from 'expo-router';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useVerseTexts } from '@/hooks/names-of-god/use-verse-texts';
+import { useBibleVersion } from '@/hooks/use-bible-version';
+import { getNameById } from '@/services/names-of-god-use-case';
+import { fontSizes, fontWeights, type getColors, spacing } from '@/theme/tokens';
+import { type ParsedVerseRef, parseSortVerseRefs } from '@/utils/names-of-god/parse-verse-ref';
+
+const PAGE_SIZE = 30;
+const SNIPPET_LENGTH = 80;
+
+export default function NameDetailScreen() {
+  const { nameId } = useLocalSearchParams<{ nameId: string }>();
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const name = useMemo(() => getNameById(nameId ?? ''), [nameId]);
+  const sortedRefs = useMemo(() => (name ? parseSortVerseRefs(name.verseRefs) : []), [name]);
+  const totalPages = Math.max(1, Math.ceil(sortedRefs.length / PAGE_SIZE));
+  const [page, setPage] = useState(0);
+
+  const pageRefs = useMemo(
+    () => sortedRefs.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE),
+    [sortedRefs, page]
+  );
+
+  const { bibleVersion } = useBibleVersion();
+  const verseTexts = useVerseTexts(pageRefs, bibleVersion);
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/');
+  };
+
+  const handleVersePress = (ref: ParsedVerseRef) => {
+    router.push(`/bible/${ref.bookId}/${ref.chapter}?verse=${ref.verse}`);
+  };
+
+  if (!name) {
+    return (
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          <Pressable onPress={handleBack} style={styles.backButton} testID="name-detail-back">
+            <Ionicons name="chevron-back" size={24} color={colors.textPrimary} />
+          </Pressable>
+        </View>
+        <View style={styles.centeredMessage}>
+          <Text style={styles.errorTitle}>{t('names_of_god.error_name_not_found')}</Text>
+          <Text style={styles.errorBody}>{t('names_of_god.error_name_not_found_detail')}</Text>
+          <Pressable onPress={handleBack} style={styles.backButtonPill}>
+            <Text style={styles.backButtonPillText}>{t('names_of_god.go_back')}</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  const testamentLabel = (() => {
+    switch (name.testament) {
+      case 'OT':
+        return t('names_of_god.testament_ot');
+      case 'NT':
+        return t('names_of_god.testament_nt');
+      default:
+        return t('names_of_god.testament_both');
+    }
+  })();
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]} testID="name-detail-screen">
+      {/* Sticky header */}
+      <View style={styles.header}>
+        <Pressable onPress={handleBack} style={styles.backButton} testID="name-detail-back">
+          <Ionicons name="chevron-back" size={24} color={colors.textPrimary} />
+        </Pressable>
+        <Text style={styles.headerTitle} numberOfLines={1}>
+          {name.nameEn}
+        </Text>
+      </View>
+
+      <ScrollView contentContainerStyle={styles.scrollContent} showsVerticalScrollIndicator={false}>
+        {/* ── Header block ────────────────────────────────────────────── */}
+        <View style={styles.nameBlock} testID="name-detail-header">
+          <Text style={styles.nameEn} testID="name-detail-english">
+            {name.nameEn}
+          </Text>
+          <Text style={styles.nameOriginal} testID="name-detail-original">
+            {name.nameOriginal}
+          </Text>
+          <Text style={styles.transliteration} testID="name-detail-transliteration">
+            {name.transliteration}
+          </Text>
+          <View style={styles.badges}>
+            <View style={styles.languageBadge}>
+              <Text style={styles.languageBadgeText}>{name.language}</Text>
+            </View>
+            <View style={styles.testamentBadge}>
+              <Text style={styles.testamentBadgeText}>{testamentLabel}</Text>
+            </View>
+          </View>
+        </View>
+
+        {/* ── Meaning block ───────────────────────────────────────────── */}
+        <View style={styles.meaningBlock} testID="name-detail-meaning">
+          <Text style={styles.meaningText}>{name.meaning}</Text>
+        </View>
+
+        {/* ── Verse list ──────────────────────────────────────────────── */}
+        <View style={styles.verseSection}>
+          <Text style={styles.versesHeader}>
+            {t('names_of_god.verses_count', { count: sortedRefs.length })}
+          </Text>
+
+          {verseTexts.map(({ ref, text, isLoading, hasError }) => (
+            <Pressable
+              key={ref.raw}
+              onPress={() => handleVersePress(ref)}
+              style={({ pressed }) => [styles.verseRow, pressed && styles.verseRowPressed]}
+              testID={`verse-row-${ref.bookId}-${ref.chapter}-${ref.verse}`}
+              accessibilityRole="button"
+              accessibilityLabel={`${ref.bookName} ${ref.chapter}:${ref.verse}`}
+            >
+              <Text style={styles.verseRef}>
+                {ref.bookName} {ref.chapter}:{ref.verse}
+              </Text>
+              {isLoading ? (
+                <ActivityIndicator size="small" color={colors.gold} style={styles.verseLoader} />
+              ) : hasError ? (
+                <Text style={styles.verseError}>{t('names_of_god.verse_error')}</Text>
+              ) : text ? (
+                <Text style={styles.verseSnippet} numberOfLines={2}>
+                  {text.length > SNIPPET_LENGTH
+                    ? `${text.slice(0, SNIPPET_LENGTH).trimEnd()}…`
+                    : text}
+                </Text>
+              ) : (
+                <Text style={styles.verseError}>{t('names_of_god.verse_error')}</Text>
+              )}
+              <Ionicons
+                name="chevron-forward"
+                size={14}
+                color={colors.textSecondary}
+                style={styles.verseChevron}
+              />
+            </Pressable>
+          ))}
+
+          {/* ── Pagination controls ─────────────────────────────────────── */}
+          {totalPages > 1 && (
+            <View style={styles.paginationRow} testID="name-detail-pagination">
+              <Pressable
+                onPress={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+                style={[styles.pageButton, page === 0 && styles.pageButtonDisabled]}
+                accessibilityLabel={t('names_of_god.previous_page')}
+                testID="page-prev-button"
+              >
+                <Ionicons
+                  name="chevron-back"
+                  size={18}
+                  color={page === 0 ? colors.textSecondary : colors.gold}
+                />
+              </Pressable>
+
+              <Text style={styles.pageLabel}>
+                {t('names_of_god.page_label', { current: page + 1, total: totalPages })}
+              </Text>
+
+              <Pressable
+                onPress={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                disabled={page === totalPages - 1}
+                style={[styles.pageButton, page === totalPages - 1 && styles.pageButtonDisabled]}
+                accessibilityLabel={t('names_of_god.next_page')}
+                testID="page-next-button"
+              >
+                <Ionicons
+                  name="chevron-forward"
+                  size={18}
+                  color={page === totalPages - 1 ? colors.textSecondary : colors.gold}
+                />
+              </Pressable>
+            </View>
+          )}
+        </View>
+
+        {/* Bottom safe area padding */}
+        <View style={{ height: insets.bottom + spacing.xl }} />
+      </ScrollView>
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.gray200,
+      backgroundColor: colors.background,
+    },
+    backButton: {
+      padding: spacing.xs,
+      marginRight: spacing.sm,
+    },
+    headerTitle: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.medium,
+      color: colors.textPrimary,
+      flex: 1,
+    },
+    scrollContent: {
+      paddingHorizontal: spacing.lg,
+    },
+    // Name block
+    nameBlock: {
+      paddingTop: spacing.xl,
+      paddingBottom: spacing.md,
+      gap: spacing.xs,
+    },
+    nameEn: {
+      fontSize: fontSizes.heading1,
+      fontWeight: fontWeights.bold,
+      color: colors.textPrimary,
+    },
+    nameOriginal: {
+      fontSize: 32,
+      color: colors.gold,
+      lineHeight: 44,
+    },
+    transliteration: {
+      fontSize: fontSizes.bodyLarge,
+      fontStyle: 'italic',
+      color: colors.textSecondary,
+    },
+    badges: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing.sm,
+      marginTop: spacing.sm,
+    },
+    languageBadge: {
+      backgroundColor: colors.gold,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 3,
+      borderRadius: 100,
+    },
+    languageBadgeText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.medium,
+      color: colors.black,
+    },
+    testamentBadge: {
+      backgroundColor: colors.backgroundSecondary,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 3,
+      borderRadius: 100,
+    },
+    testamentBadgeText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.medium,
+      color: colors.textSecondary,
+    },
+    // Meaning block
+    meaningBlock: {
+      paddingVertical: spacing.lg,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: colors.gray200,
+    },
+    meaningText: {
+      fontSize: fontSizes.body,
+      lineHeight: fontSizes.body * 1.6,
+      color: colors.textPrimary,
+    },
+    // Verse list
+    verseSection: {
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: colors.gray200,
+      paddingTop: spacing.md,
+    },
+    versesHeader: {
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.medium,
+      color: colors.textSecondary,
+      textTransform: 'uppercase',
+      letterSpacing: 0.8,
+      marginBottom: spacing.sm,
+    },
+    verseRow: {
+      paddingVertical: spacing.md,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.gray100,
+      flexDirection: 'column',
+      gap: spacing.xs,
+    },
+    verseRowPressed: {
+      backgroundColor: colors.backgroundSecondary,
+      marginHorizontal: -spacing.lg,
+      paddingHorizontal: spacing.lg,
+    },
+    verseRef: {
+      fontSize: fontSizes.bodySmall,
+      fontWeight: fontWeights.semibold,
+      color: colors.gold,
+    },
+    verseSnippet: {
+      fontSize: fontSizes.body,
+      color: colors.textPrimary,
+      lineHeight: fontSizes.body * 1.5,
+    },
+    verseLoader: {
+      alignSelf: 'flex-start',
+      marginVertical: spacing.xs,
+    },
+    verseError: {
+      fontSize: fontSizes.bodySmall,
+      color: colors.textSecondary,
+      fontStyle: 'italic',
+    },
+    verseChevron: {
+      alignSelf: 'flex-end',
+    },
+    // Pagination
+    paginationRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      paddingVertical: spacing.lg,
+      gap: spacing.xl,
+    },
+    pageButton: {
+      padding: spacing.sm,
+      borderRadius: 8,
+      backgroundColor: colors.backgroundSecondary,
+    },
+    pageButtonDisabled: {
+      opacity: 0.4,
+    },
+    pageLabel: {
+      fontSize: fontSizes.body,
+      color: colors.textSecondary,
+    },
+    // Error / not-found
+    centeredMessage: {
+      flex: 1,
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: spacing.xxl,
+      gap: spacing.md,
+    },
+    errorTitle: {
+      fontSize: fontSizes.heading2,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+      textAlign: 'center',
+    },
+    errorBody: {
+      fontSize: fontSizes.body,
+      color: colors.textSecondary,
+      textAlign: 'center',
+    },
+    backButtonPill: {
+      backgroundColor: colors.gold,
+      paddingHorizontal: spacing.xl,
+      paddingVertical: spacing.md,
+      borderRadius: 8,
+      marginTop: spacing.sm,
+    },
+    backButtonPillText: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.medium,
+      color: colors.black,
+    },
+  });

--- a/app/names-of-god/_layout.tsx
+++ b/app/names-of-god/_layout.tsx
@@ -1,0 +1,10 @@
+import { Stack } from 'expo-router';
+
+export default function NamesOfGodLayout() {
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Screen name="index" />
+      <Stack.Screen name="[nameId]" />
+    </Stack>
+  );
+}

--- a/app/names-of-god/index.tsx
+++ b/app/names-of-god/index.tsx
@@ -1,0 +1,273 @@
+/**
+ * NamesOfGodListScreen
+ *
+ * Browsable, searchable list of all divine names with language-filter chips.
+ * Tapping a name navigates to the NameDetailScreen (/names-of-god/[nameId]).
+ *
+ * Route: /names-of-god
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FlatList, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useTheme } from '@/contexts/ThemeContext';
+import { filterByCategory, searchNames } from '@/services/names-of-god-use-case';
+import { fontSizes, fontWeights, type getColors, spacing } from '@/theme/tokens';
+import type { LanguageFilter, NameOfGod } from '@/types/names-of-god';
+
+const LANGUAGE_FILTERS: LanguageFilter[] = ['All', 'Hebrew', 'Greek', 'Aramaic', 'English'];
+
+export default function NamesOfGodListScreen() {
+  const { colors } = useTheme();
+  const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
+  const styles = useMemo(() => createStyles(colors), [colors]);
+
+  const [query, setQuery] = useState('');
+  const [languageFilter, setLanguageFilter] = useState<LanguageFilter>('All');
+
+  const names = useMemo<NameOfGod[]>(() => {
+    const byLanguage = filterByCategory(languageFilter);
+    if (!query.trim()) return byLanguage;
+    const bySearch = searchNames(query);
+    const searchIds = new Set(bySearch.map((n) => n.id));
+    return byLanguage.filter((n) => searchIds.has(n.id));
+  }, [query, languageFilter]);
+
+  const handleBack = () => {
+    if (router.canGoBack()) router.back();
+    else router.replace('/');
+  };
+
+  const handleNamePress = (name: NameOfGod) => {
+    router.push(`/names-of-god/${name.id}`);
+  };
+
+  const renderItem = ({ item }: { item: NameOfGod }) => (
+    <Pressable
+      style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
+      onPress={() => handleNamePress(item)}
+      testID={`name-row-${item.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={item.nameEn}
+    >
+      <View style={styles.rowContent}>
+        <Text style={styles.nameEn}>{item.nameEn}</Text>
+        <Text style={styles.transliteration}>{item.transliteration}</Text>
+        <Text style={styles.meaning} numberOfLines={1}>
+          {item.meaning}
+        </Text>
+      </View>
+      <View style={styles.rowMeta}>
+        <View style={styles.langBadge}>
+          <Text style={styles.langBadgeText}>{item.language}</Text>
+        </View>
+        <Ionicons name="chevron-forward" size={14} color={colors.textSecondary} />
+      </View>
+    </Pressable>
+  );
+
+  return (
+    <View style={[styles.container, { paddingTop: insets.top }]} testID="names-of-god-list-screen">
+      {/* Header */}
+      <View style={styles.header}>
+        <Pressable onPress={handleBack} style={styles.backButton} testID="names-list-back">
+          <Ionicons name="chevron-back" size={24} color={colors.textPrimary} />
+        </Pressable>
+        <Text style={styles.headerTitle}>{t('names_of_god.title')}</Text>
+      </View>
+
+      {/* Search */}
+      <View style={styles.searchRow}>
+        <Ionicons name="search" size={16} color={colors.textSecondary} style={styles.searchIcon} />
+        <TextInput
+          style={styles.searchInput}
+          value={query}
+          onChangeText={setQuery}
+          placeholder={t('names_of_god.search_placeholder')}
+          placeholderTextColor={colors.textSecondary}
+          autoCapitalize="none"
+          autoCorrect={false}
+          testID="names-search-input"
+        />
+        {query.length > 0 && (
+          <Pressable onPress={() => setQuery('')} testID="names-search-clear">
+            <Ionicons name="close-circle" size={16} color={colors.textSecondary} />
+          </Pressable>
+        )}
+      </View>
+
+      {/* Language filter chips */}
+      <View style={styles.filterRow}>
+        {LANGUAGE_FILTERS.map((lang) => (
+          <Pressable
+            key={lang}
+            style={[styles.chip, languageFilter === lang && styles.chipActive]}
+            onPress={() => setLanguageFilter(lang)}
+            testID={`filter-chip-${lang}`}
+          >
+            <Text style={[styles.chipText, languageFilter === lang && styles.chipTextActive]}>
+              {lang === 'All'
+                ? t('names_of_god.filter_all')
+                : t(`names_of_god.language_${lang.toLowerCase()}`)}
+            </Text>
+          </Pressable>
+        ))}
+      </View>
+
+      {/* Count */}
+      <Text style={styles.countLabel}>
+        {t('names_of_god.names_count', { count: names.length })}
+      </Text>
+
+      {/* List */}
+      <FlatList
+        data={names}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + spacing.xl }]}
+        showsVerticalScrollIndicator={false}
+        testID="names-list"
+        ListEmptyComponent={
+          <View style={styles.empty}>
+            <Text style={styles.emptyText}>{t('names_of_god.no_results')}</Text>
+          </View>
+        }
+      />
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+      backgroundColor: colors.background,
+    },
+    header: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.gray200,
+    },
+    backButton: {
+      padding: spacing.xs,
+      marginRight: spacing.sm,
+    },
+    headerTitle: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.medium,
+      color: colors.textPrimary,
+      flex: 1,
+    },
+    searchRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      margin: spacing.md,
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.sm,
+      backgroundColor: colors.backgroundSecondary,
+      borderRadius: 10,
+    },
+    searchIcon: {
+      marginRight: spacing.sm,
+    },
+    searchInput: {
+      flex: 1,
+      fontSize: fontSizes.body,
+      color: colors.textPrimary,
+    },
+    filterRow: {
+      flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: spacing.sm,
+      paddingHorizontal: spacing.md,
+      marginBottom: spacing.sm,
+    },
+    chip: {
+      paddingHorizontal: spacing.md,
+      paddingVertical: spacing.xs,
+      borderRadius: 100,
+      backgroundColor: colors.backgroundSecondary,
+    },
+    chipActive: {
+      backgroundColor: colors.gold,
+    },
+    chipText: {
+      fontSize: fontSizes.caption,
+      fontWeight: fontWeights.medium,
+      color: colors.textSecondary,
+    },
+    chipTextActive: {
+      color: colors.black,
+    },
+    countLabel: {
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+      paddingHorizontal: spacing.md,
+      marginBottom: spacing.sm,
+      textTransform: 'uppercase',
+      letterSpacing: 0.6,
+    },
+    listContent: {
+      paddingHorizontal: spacing.md,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingVertical: spacing.md,
+      borderBottomWidth: StyleSheet.hairlineWidth,
+      borderBottomColor: colors.gray100,
+    },
+    rowPressed: {
+      backgroundColor: colors.backgroundSecondary,
+      marginHorizontal: -spacing.md,
+      paddingHorizontal: spacing.md,
+    },
+    rowContent: {
+      flex: 1,
+      gap: 2,
+    },
+    nameEn: {
+      fontSize: fontSizes.body,
+      fontWeight: fontWeights.semibold,
+      color: colors.textPrimary,
+    },
+    transliteration: {
+      fontSize: fontSizes.bodySmall,
+      fontStyle: 'italic',
+      color: colors.gold,
+    },
+    meaning: {
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+    },
+    rowMeta: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: spacing.xs,
+    },
+    langBadge: {
+      backgroundColor: colors.backgroundSecondary,
+      paddingHorizontal: spacing.sm,
+      paddingVertical: 2,
+      borderRadius: 100,
+    },
+    langBadgeText: {
+      fontSize: fontSizes.caption,
+      color: colors.textSecondary,
+    },
+    empty: {
+      paddingTop: spacing.xxl,
+      alignItems: 'center',
+    },
+    emptyText: {
+      fontSize: fontSizes.body,
+      color: colors.textSecondary,
+    },
+  });

--- a/assets/names-of-god.json
+++ b/assets/names-of-god.json
@@ -1,0 +1,2212 @@
+[
+  {
+    "id": "yahweh",
+    "nameEn": "Yahweh",
+    "nameOriginal": "יְהוָה",
+    "transliteration": "Yahweh",
+    "language": "Hebrew",
+    "category": "covenant-name",
+    "meaning": "I AM WHO I AM; the eternal, self-existent, covenant name of God revealed to Moses",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 3:14",
+      "Exodus 6:2",
+      "Psalm 83:18",
+      "Isaiah 42:8",
+      "Genesis 2:4"
+    ]
+  },
+  {
+    "id": "elohim",
+    "nameEn": "Elohim",
+    "nameOriginal": "אֱלֹהִים",
+    "transliteration": "Elohim",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "God; the Creator; plural of majesty emphasizing the fullness and power of God",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 1:1",
+      "Genesis 1:26",
+      "Deuteronomy 6:4",
+      "Psalm 19:1",
+      "Genesis 17:7"
+    ]
+  },
+  {
+    "id": "adonai",
+    "nameEn": "Adonai",
+    "nameOriginal": "אֲדֹנָי",
+    "transliteration": "Adonai",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "My Lord; emphasizes God's absolute sovereignty and ownership over all creation",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 110:1",
+      "Isaiah 6:1",
+      "Isaiah 6:8",
+      "Genesis 15:2",
+      "Ezekiel 2:4"
+    ]
+  },
+  {
+    "id": "yah",
+    "nameEn": "Yah",
+    "nameOriginal": "יָהּ",
+    "transliteration": "Yah",
+    "language": "Hebrew",
+    "category": "covenant-name",
+    "meaning": "Shortened form of Yahweh; used in praise expressions (Hallelu-Yah = Praise the LORD)",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 15:2",
+      "Psalm 68:4",
+      "Psalm 118:14",
+      "Isaiah 12:2",
+      "Psalm 150:6"
+    ]
+  },
+  {
+    "id": "el",
+    "nameEn": "El",
+    "nameOriginal": "אֵל",
+    "transliteration": "El",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "God; the Mighty One; the strong and powerful deity",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 33:20",
+      "Numbers 23:19",
+      "Deuteronomy 32:4",
+      "Psalm 22:10",
+      "Isaiah 9:6"
+    ]
+  },
+  {
+    "id": "eloah",
+    "nameEn": "Eloah",
+    "nameOriginal": "אֱלוֹהַּ",
+    "transliteration": "Eloah",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "God; singular poetic form emphasizing the uniqueness and majesty of God",
+    "testament": "OT",
+    "verseRefs": [
+      "Deuteronomy 32:15",
+      "Job 3:4",
+      "Job 6:4",
+      "Psalm 50:22",
+      "Habakkuk 3:3"
+    ]
+  },
+  {
+    "id": "el-shaddai",
+    "nameEn": "El Shaddai",
+    "nameOriginal": "אֵל שַׁדַּי",
+    "transliteration": "El Shaddai",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "God Almighty; the all-sufficient, all-powerful God who is more than enough",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 17:1",
+      "Genesis 28:3",
+      "Genesis 35:11",
+      "Exodus 6:3",
+      "Psalm 91:1"
+    ]
+  },
+  {
+    "id": "el-elyon",
+    "nameEn": "El Elyon",
+    "nameOriginal": "אֵל עֶלְיוֹן",
+    "transliteration": "El Elyon",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "God Most High; the supreme deity exalted above all other powers and beings",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 14:18",
+      "Genesis 14:19",
+      "Psalm 78:35",
+      "Psalm 91:1",
+      "Daniel 7:18"
+    ]
+  },
+  {
+    "id": "el-roi",
+    "nameEn": "El Roi",
+    "nameOriginal": "אֵל רֳאִי",
+    "transliteration": "El Roi",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The God Who Sees Me; given by Hagar when God saw her in her distress",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 16:13",
+      "Genesis 16:14",
+      "Psalm 139:1",
+      "Psalm 139:7",
+      "Proverbs 15:3"
+    ]
+  },
+  {
+    "id": "el-olam",
+    "nameEn": "El Olam",
+    "nameOriginal": "אֵל עוֹלָם",
+    "transliteration": "El Olam",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The Eternal God; the God of eternity whose purposes and nature never change",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 21:33",
+      "Isaiah 40:28",
+      "Psalm 90:2",
+      "Psalm 93:2",
+      "Isaiah 26:4"
+    ]
+  },
+  {
+    "id": "el-gibbor",
+    "nameEn": "El Gibbor",
+    "nameOriginal": "אֵל גִּבּוֹר",
+    "transliteration": "El Gibbor",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "Mighty God; the powerful, warrior God; a title of the Messiah in Isaiah's prophecy",
+    "testament": "OT",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "Jeremiah 32:18",
+      "Deuteronomy 10:17",
+      "Psalm 24:8",
+      "Isaiah 10:21"
+    ]
+  },
+  {
+    "id": "el-elohe-israel",
+    "nameEn": "El Elohe Israel",
+    "nameOriginal": "אֵל אֱלֹהֵי יִשְׂרָאֵל",
+    "transliteration": "El Elohe Israel",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "God, the God of Israel; emphasizing the covenant relationship between God and His people",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 33:20",
+      "Psalm 68:8",
+      "Ezra 5:1",
+      "Psalm 41:13",
+      "1 Chronicles 4:10"
+    ]
+  },
+  {
+    "id": "el-emeth",
+    "nameEn": "El Emeth",
+    "nameOriginal": "אֵל אֱמֶת",
+    "transliteration": "El Emeth",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "God of Truth; the faithful God whose word is completely trustworthy and reliable",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 31:5",
+      "Deuteronomy 32:4",
+      "Isaiah 65:16",
+      "John 14:6",
+      "Titus 1:2"
+    ]
+  },
+  {
+    "id": "el-chanun",
+    "nameEn": "El Chanun",
+    "nameOriginal": "אֵל חַנּוּן",
+    "transliteration": "El Chanun",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "Gracious God; the merciful deity who shows undeserved favor",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 34:6",
+      "Nehemiah 9:17",
+      "Jonah 4:2",
+      "Psalm 86:15",
+      "Joel 2:13"
+    ]
+  },
+  {
+    "id": "yahweh-yireh",
+    "nameEn": "Yahweh Yireh",
+    "nameOriginal": "יְהוָה יִרְאֶה",
+    "transliteration": "Yahweh Yireh",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD Will Provide; named by Abraham when God provided a ram at the place of sacrifice",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 22:14",
+      "Philippians 4:19",
+      "Matthew 6:31",
+      "Psalm 23:1",
+      "Luke 12:24"
+    ]
+  },
+  {
+    "id": "yahweh-nissi",
+    "nameEn": "Yahweh Nissi",
+    "nameOriginal": "יְהוָה נִסִּי",
+    "transliteration": "Yahweh Nissi",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is My Banner; named by Moses after victory over Amalek, God is our rallying point",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 17:15",
+      "Psalm 60:4",
+      "Song of Solomon 2:4",
+      "Isaiah 11:10",
+      "Psalm 20:5"
+    ]
+  },
+  {
+    "id": "yahweh-shalom",
+    "nameEn": "Yahweh Shalom",
+    "nameOriginal": "יְהוָה שָׁלוֹם",
+    "transliteration": "Yahweh Shalom",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is Peace; named by Gideon after God granted peace in a time of fear",
+    "testament": "OT",
+    "verseRefs": [
+      "Judges 6:24",
+      "Isaiah 9:6",
+      "Romans 15:33",
+      "Philippians 4:7",
+      "2 Thessalonians 3:16"
+    ]
+  },
+  {
+    "id": "yahweh-rapha",
+    "nameEn": "Yahweh Rapha",
+    "nameOriginal": "יְהוָה רָפָא",
+    "transliteration": "Yahweh Rapha",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD Who Heals; God's declaration that He is the divine physician for body and soul",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 15:26",
+      "Psalm 103:3",
+      "Isaiah 53:5",
+      "Jeremiah 17:14",
+      "1 Peter 2:24"
+    ]
+  },
+  {
+    "id": "yahweh-tsidkenu",
+    "nameEn": "Yahweh Tsidkenu",
+    "nameOriginal": "יְהוָה צִדְקֵנוּ",
+    "transliteration": "Yahweh Tsidkenu",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD Our Righteousness; the Messianic name declaring God provides the righteousness we need",
+    "testament": "OT",
+    "verseRefs": [
+      "Jeremiah 23:6",
+      "Jeremiah 33:16",
+      "Romans 3:22",
+      "1 Corinthians 1:30",
+      "2 Corinthians 5:21"
+    ]
+  },
+  {
+    "id": "yahweh-shammah",
+    "nameEn": "Yahweh Shammah",
+    "nameOriginal": "יְהוָה שָׁמָּה",
+    "transliteration": "Yahweh Shammah",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is There; the name for the restored city of Jerusalem, God's abiding presence",
+    "testament": "OT",
+    "verseRefs": [
+      "Ezekiel 48:35",
+      "Revelation 21:3",
+      "Psalm 46:5",
+      "Matthew 28:20",
+      "John 14:17"
+    ]
+  },
+  {
+    "id": "yahweh-sabaoth",
+    "nameEn": "Yahweh Sabaoth",
+    "nameOriginal": "יְהוָה צְבָאוֹת",
+    "transliteration": "Yahweh Sabaoth",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD of Hosts / LORD Almighty; commander of the heavenly armies and all creation",
+    "testament": "OT",
+    "verseRefs": [
+      "1 Samuel 1:3",
+      "Isaiah 6:3",
+      "Psalm 46:7",
+      "Romans 9:29",
+      "James 5:4"
+    ]
+  },
+  {
+    "id": "yahweh-mekoddishkem",
+    "nameEn": "Yahweh Mekoddishkem",
+    "nameOriginal": "יְהוָה מְקַדִּשְׁכֶם",
+    "transliteration": "Yahweh Mekoddishkem",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD Who Sanctifies You; God sets apart and consecrates His people for Himself",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 31:13",
+      "Leviticus 20:8",
+      "Leviticus 21:8",
+      "1 Thessalonians 5:23",
+      "Hebrews 13:12"
+    ]
+  },
+  {
+    "id": "yahweh-rohi",
+    "nameEn": "Yahweh Rohi",
+    "nameOriginal": "יְהוָה רֹעִי",
+    "transliteration": "Yahweh Rohi",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is My Shepherd; God leads, feeds, protects, and guides His flock",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 23:1",
+      "John 10:11",
+      "Hebrews 13:20",
+      "1 Peter 5:4",
+      "Ezekiel 34:15"
+    ]
+  },
+  {
+    "id": "yahweh-ori",
+    "nameEn": "Yahweh Ori",
+    "nameOriginal": "יְהוָה אוֹרִי",
+    "transliteration": "Yahweh Ori",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is My Light; God dispels darkness and illuminates our path",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 27:1",
+      "Micah 7:8",
+      "Isaiah 60:19",
+      "John 8:12",
+      "Revelation 21:23"
+    ]
+  },
+  {
+    "id": "yahweh-ozi",
+    "nameEn": "Yahweh Ozi",
+    "nameOriginal": "יְהוָה עֻזִּי",
+    "transliteration": "Yahweh Ozi",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "The LORD is My Strength; God empowers those who trust in Him",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 15:2",
+      "Psalm 28:7",
+      "Psalm 118:14",
+      "Isaiah 12:2",
+      "Habakkuk 3:19"
+    ]
+  },
+  {
+    "id": "shaddai",
+    "nameEn": "Shaddai",
+    "nameOriginal": "שַׁדַּי",
+    "transliteration": "Shaddai",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The Almighty; the all-sufficient God who is more than enough for every need",
+    "testament": "OT",
+    "verseRefs": [
+      "Job 5:17",
+      "Psalm 91:1",
+      "Ruth 1:20",
+      "Job 6:4",
+      "Numbers 24:16"
+    ]
+  },
+  {
+    "id": "elyon",
+    "nameEn": "Elyon",
+    "nameOriginal": "עֶלְיוֹן",
+    "transliteration": "Elyon",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "Most High; the God who is exalted above all other gods and beings",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 7:17",
+      "Psalm 9:2",
+      "Psalm 47:2",
+      "Daniel 7:25",
+      "Numbers 24:16"
+    ]
+  },
+  {
+    "id": "adon",
+    "nameEn": "Adon",
+    "nameOriginal": "אָדוֹן",
+    "transliteration": "Adon",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "Lord, Master; the sovereign ruler to whom everything belongs",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 23:17",
+      "Joshua 3:13",
+      "Psalm 97:5",
+      "Malachi 3:1",
+      "Psalm 8:1"
+    ]
+  },
+  {
+    "id": "qanna",
+    "nameEn": "El Qanna",
+    "nameOriginal": "אֵל קַנָּא",
+    "transliteration": "El Qanna",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "Jealous God; God's passionate commitment to exclusive relationship with His people",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 20:5",
+      "Exodus 34:14",
+      "Deuteronomy 4:24",
+      "Deuteronomy 6:15",
+      "Joshua 24:19"
+    ]
+  },
+  {
+    "id": "tsur",
+    "nameEn": "Tsur",
+    "nameOriginal": "צוּר",
+    "transliteration": "Tsur",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "The Rock; God's unchanging, stable, and reliable nature as our foundation",
+    "testament": "OT",
+    "verseRefs": [
+      "Deuteronomy 32:4",
+      "2 Samuel 22:32",
+      "Psalm 18:2",
+      "Psalm 62:2",
+      "Isaiah 26:4"
+    ]
+  },
+  {
+    "id": "kadosh-israel",
+    "nameEn": "Kadosh Yisrael",
+    "nameOriginal": "קְדוֹשׁ יִשְׂרָאֵל",
+    "transliteration": "Kadosh Yisrael",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "Holy One of Israel; God's absolute moral perfection and otherness from creation",
+    "testament": "OT",
+    "verseRefs": [
+      "Isaiah 1:4",
+      "Isaiah 5:19",
+      "Isaiah 12:6",
+      "Isaiah 41:14",
+      "Psalm 71:22"
+    ]
+  },
+  {
+    "id": "goel",
+    "nameEn": "Go'el",
+    "nameOriginal": "גֹּאֵל",
+    "transliteration": "Go'el",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "Redeemer; the kinsman-redeemer who buys back what was lost and restores covenant relationship",
+    "testament": "OT",
+    "verseRefs": [
+      "Isaiah 41:14",
+      "Isaiah 44:6",
+      "Isaiah 47:4",
+      "Isaiah 54:5",
+      "Job 19:25"
+    ]
+  },
+  {
+    "id": "shaphat",
+    "nameEn": "Shaphat",
+    "nameOriginal": "שֹׁפֵט",
+    "transliteration": "Shaphat",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "Judge; God's righteous and impartial administration of justice for all people",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 18:25",
+      "Psalm 94:2",
+      "Isaiah 33:22",
+      "Psalm 75:7",
+      "Hebrews 12:23"
+    ]
+  },
+  {
+    "id": "melech",
+    "nameEn": "Melech",
+    "nameOriginal": "מֶלֶךְ",
+    "transliteration": "Melech",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "King; God's sovereign reign over all creation, nations, and history",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 47:7",
+      "Psalm 98:6",
+      "Isaiah 6:5",
+      "Isaiah 43:15",
+      "Zephaniah 3:15"
+    ]
+  },
+  {
+    "id": "avinu",
+    "nameEn": "Avinu",
+    "nameOriginal": "אָבִינוּ",
+    "transliteration": "Avinu",
+    "language": "Hebrew",
+    "category": "relational-title",
+    "meaning": "Our Father; God's tender, parental relationship with His covenant people",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 63:16",
+      "Isaiah 64:8",
+      "Matthew 6:9",
+      "John 20:17",
+      "Romans 8:15"
+    ]
+  },
+  {
+    "id": "elohim-chayyim",
+    "nameEn": "Elohim Chayyim",
+    "nameOriginal": "אֱלֹהִים חַיִּים",
+    "transliteration": "Elohim Chayyim",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The Living God; God who is alive, active, and the source of all life",
+    "testament": "Both",
+    "verseRefs": [
+      "Joshua 3:10",
+      "1 Samuel 17:26",
+      "Matthew 16:16",
+      "Hebrews 10:31",
+      "2 Corinthians 6:16"
+    ]
+  },
+  {
+    "id": "magen",
+    "nameEn": "Magen",
+    "nameOriginal": "מָגֵן",
+    "transliteration": "Magen",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "Shield; God's protective covering over those who take refuge in Him",
+    "testament": "OT",
+    "verseRefs": [
+      "Genesis 15:1",
+      "Psalm 3:3",
+      "Psalm 18:2",
+      "Proverbs 30:5",
+      "Psalm 28:7"
+    ]
+  },
+  {
+    "id": "misgab",
+    "nameEn": "Misgab",
+    "nameOriginal": "מִשְׂגָּב",
+    "transliteration": "Misgab",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "High Fortress / Stronghold; God as a high, inaccessible place of safety and refuge",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 9:9",
+      "Psalm 18:2",
+      "Psalm 46:7",
+      "Psalm 59:9",
+      "Psalm 62:2"
+    ]
+  },
+  {
+    "id": "tsur-yisrael",
+    "nameEn": "Tsur Yisrael",
+    "nameOriginal": "צוּר יִשְׂרָאֵל",
+    "transliteration": "Tsur Yisrael",
+    "language": "Hebrew",
+    "category": "compound-name",
+    "meaning": "Rock of Israel; God as the immovable foundation and protector of the nation Israel",
+    "testament": "OT",
+    "verseRefs": [
+      "2 Samuel 23:3",
+      "Isaiah 30:29",
+      "Genesis 49:24",
+      "Isaiah 17:10",
+      "1 Samuel 2:2"
+    ]
+  },
+  {
+    "id": "kyrios",
+    "nameEn": "Kyrios",
+    "nameOriginal": "κύριος",
+    "transliteration": "Kyrios",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Lord; the Greek equivalent of Yahweh/Adonai; supreme authority and ownership",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 3:3",
+      "Luke 1:46",
+      "Acts 2:36",
+      "Philippians 2:11",
+      "Romans 10:9"
+    ]
+  },
+  {
+    "id": "theos",
+    "nameEn": "Theos",
+    "nameOriginal": "θεός",
+    "transliteration": "Theos",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "God; the supreme divine being; used for the Father, and remarkably for Jesus (John 1:1)",
+    "testament": "NT",
+    "verseRefs": [
+      "John 1:1",
+      "John 20:28",
+      "Acts 17:29",
+      "Romans 1:1",
+      "Hebrews 1:8"
+    ]
+  },
+  {
+    "id": "pantokrator",
+    "nameEn": "Pantokrator",
+    "nameOriginal": "παντοκράτωρ",
+    "transliteration": "Pantokrator",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Almighty / All-Ruling; the God who holds all power and rules over everything",
+    "testament": "NT",
+    "verseRefs": [
+      "2 Corinthians 6:18",
+      "Revelation 1:8",
+      "Revelation 4:8",
+      "Revelation 11:17",
+      "Revelation 19:6"
+    ]
+  },
+  {
+    "id": "soter",
+    "nameEn": "Soter",
+    "nameOriginal": "σωτήρ",
+    "transliteration": "Soter",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Savior; the one who delivers from sin, death, and judgment",
+    "testament": "NT",
+    "verseRefs": [
+      "Luke 2:11",
+      "John 4:42",
+      "Titus 2:13",
+      "1 Timothy 4:10",
+      "Philippians 3:20"
+    ]
+  },
+  {
+    "id": "christos",
+    "nameEn": "Christos",
+    "nameOriginal": "Χριστός",
+    "transliteration": "Christos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Christ / Anointed One; the Greek equivalent of Messiah; the one anointed by God for redemption",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 1:1",
+      "John 1:41",
+      "Acts 2:36",
+      "Romans 5:8",
+      "Philippians 2:11"
+    ]
+  },
+  {
+    "id": "logos",
+    "nameEn": "Logos",
+    "nameOriginal": "Λόγος",
+    "transliteration": "Logos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The Word; the eternal divine reason and expression of God incarnated in Jesus Christ",
+    "testament": "NT",
+    "verseRefs": [
+      "John 1:1",
+      "John 1:14",
+      "1 John 1:1",
+      "Revelation 19:13",
+      "John 1:18"
+    ]
+  },
+  {
+    "id": "emanouel",
+    "nameEn": "Emmanuel",
+    "nameOriginal": "Ἐμμανουήλ",
+    "transliteration": "Emanouel",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "God with Us; the Messianic name fulfilled in the incarnation of Jesus Christ",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 7:14",
+      "Matthew 1:23",
+      "John 1:14",
+      "Matthew 28:20",
+      "Revelation 21:3"
+    ]
+  },
+  {
+    "id": "poimen-kalos",
+    "nameEn": "Poimen Kalos",
+    "nameOriginal": "ποιμὴν καλός",
+    "transliteration": "Poimen Kalos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Good Shepherd; the one who lays down His life for the sheep",
+    "testament": "NT",
+    "verseRefs": [
+      "John 10:11",
+      "John 10:14",
+      "Hebrews 13:20",
+      "1 Peter 5:4",
+      "Psalm 23:1"
+    ]
+  },
+  {
+    "id": "arnion",
+    "nameEn": "Arnion",
+    "nameOriginal": "ἀρνίον",
+    "transliteration": "Arnion",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Lamb; the sacrificial lamb of God who takes away the sin of the world",
+    "testament": "NT",
+    "verseRefs": [
+      "John 1:29",
+      "John 1:36",
+      "Revelation 5:6",
+      "Revelation 7:17",
+      "Revelation 21:22"
+    ]
+  },
+  {
+    "id": "archiereus",
+    "nameEn": "Archiereus",
+    "nameOriginal": "ἀρχιερεύς",
+    "transliteration": "Archiereus",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "High Priest; the perfect and eternal high priest who intercedes on behalf of humanity",
+    "testament": "NT",
+    "verseRefs": [
+      "Hebrews 4:14",
+      "Hebrews 4:15",
+      "Hebrews 9:11",
+      "Hebrews 7:26",
+      "Hebrews 2:17"
+    ]
+  },
+  {
+    "id": "parakletos",
+    "nameEn": "Parakletos",
+    "nameOriginal": "Παράκλητος",
+    "transliteration": "Parakletos",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Advocate / Comforter / Helper; title of the Holy Spirit and of Jesus as our intercessor",
+    "testament": "NT",
+    "verseRefs": [
+      "John 14:16",
+      "John 14:26",
+      "John 15:26",
+      "1 John 2:1",
+      "John 16:7"
+    ]
+  },
+  {
+    "id": "pneuma-hagion",
+    "nameEn": "Pneuma Hagion",
+    "nameOriginal": "Πνεῦμα Ἅγιον",
+    "transliteration": "Pneuma Hagion",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Holy Spirit; the third person of the Trinity, the Spirit of God who indwells believers",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 3:16",
+      "John 14:26",
+      "Acts 1:8",
+      "Acts 2:4",
+      "Romans 8:9"
+    ]
+  },
+  {
+    "id": "hagios",
+    "nameEn": "Ho Hagios",
+    "nameOriginal": "ὁ Ἅγιος",
+    "transliteration": "Ho Hagios",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "The Holy One; perfectly set apart from sin; used of Jesus as the one consecrated by God",
+    "testament": "NT",
+    "verseRefs": [
+      "Mark 1:24",
+      "Acts 3:14",
+      "1 John 2:20",
+      "Revelation 3:7",
+      "Luke 4:34"
+    ]
+  },
+  {
+    "id": "despotes",
+    "nameEn": "Despotes",
+    "nameOriginal": "Δεσπότης",
+    "transliteration": "Despotes",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Sovereign Lord / Master; the absolute owner and ruler who has authority over life and death",
+    "testament": "NT",
+    "verseRefs": [
+      "Luke 2:29",
+      "Acts 4:24",
+      "2 Peter 2:1",
+      "Jude 1:4",
+      "Revelation 6:10"
+    ]
+  },
+  {
+    "id": "iesous",
+    "nameEn": "Iesous",
+    "nameOriginal": "Ἰησοῦς",
+    "transliteration": "Iesous",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Jesus; from Hebrew Yeshua, meaning 'Yahweh saves'; the personal name of the incarnate Son of God",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 1:21",
+      "Luke 2:21",
+      "Acts 4:12",
+      "Philippians 2:10",
+      "Revelation 1:9"
+    ]
+  },
+  {
+    "id": "basileus",
+    "nameEn": "Basileus",
+    "nameOriginal": "βασιλεύς",
+    "transliteration": "Basileus",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "King; Jesus as the divinely appointed ruler over all kingdoms and peoples",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 21:5",
+      "Matthew 27:37",
+      "1 Timothy 1:17",
+      "Revelation 15:3",
+      "Revelation 19:16"
+    ]
+  },
+  {
+    "id": "arche",
+    "nameEn": "He Arche",
+    "nameOriginal": "ἡ ἀρχή",
+    "transliteration": "He Arche",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "The Beginning; the source and origin of all creation; the first cause of everything",
+    "testament": "NT",
+    "verseRefs": [
+      "Colossians 1:18",
+      "Revelation 1:8",
+      "Revelation 3:14",
+      "Revelation 21:6",
+      "John 1:1"
+    ]
+  },
+  {
+    "id": "huios-theou",
+    "nameEn": "Huios Theou",
+    "nameOriginal": "Υἱὸς Θεοῦ",
+    "transliteration": "Huios Theou",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Son of God; the eternal, divine Son in unique relationship with the Father",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 3:17",
+      "John 1:34",
+      "John 3:16",
+      "Romans 8:3",
+      "Galatians 4:4"
+    ]
+  },
+  {
+    "id": "huios-anthropou",
+    "nameEn": "Huios tou Anthropou",
+    "nameOriginal": "Υἱὸς τοῦ ἀνθρώπου",
+    "transliteration": "Huios tou Anthropou",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Son of Man; Jesus's most common self-designation, linking His humanity with the Danielic heavenly figure",
+    "testament": "NT",
+    "verseRefs": [
+      "Daniel 7:13",
+      "Matthew 8:20",
+      "Matthew 16:13",
+      "John 1:51",
+      "Revelation 1:13"
+    ]
+  },
+  {
+    "id": "ego-eimi",
+    "nameEn": "Ego Eimi",
+    "nameOriginal": "Ἐγώ εἰμι",
+    "transliteration": "Ego Eimi",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "I AM; Jesus's claim to the divine name of Exodus 3:14, asserting His eternal deity",
+    "testament": "NT",
+    "verseRefs": [
+      "John 8:58",
+      "John 6:35",
+      "John 8:12",
+      "John 10:9",
+      "John 11:25"
+    ]
+  },
+  {
+    "id": "anastasis",
+    "nameEn": "He Anastasis",
+    "nameOriginal": "ἡ ἀνάστασις",
+    "transliteration": "He Anastasis",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The Resurrection; Jesus as the source and guarantee of resurrection life over death",
+    "testament": "NT",
+    "verseRefs": [
+      "John 11:25",
+      "John 11:26",
+      "Acts 4:33",
+      "Philippians 3:10",
+      "1 Corinthians 15:20"
+    ]
+  },
+  {
+    "id": "ho-poimen-ho-megas",
+    "nameEn": "Ho Poimen Ho Megas",
+    "nameOriginal": "ὁ ποιμὴν ὁ μέγας",
+    "transliteration": "Ho Poimen Ho Megas",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The Great Shepherd; Jesus brought back from the dead as the shepherd who tends His flock eternally",
+    "testament": "NT",
+    "verseRefs": [
+      "Hebrews 13:20",
+      "1 Peter 5:4",
+      "John 10:11",
+      "Ezekiel 34:15",
+      "Psalm 23:1"
+    ]
+  },
+  {
+    "id": "mashiach",
+    "nameEn": "Mashiach",
+    "nameOriginal": "מָשִׁיחַ",
+    "transliteration": "Mashiach",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Messiah / Anointed One; the promised deliverer who would be anointed with the Spirit of God",
+    "testament": "Both",
+    "verseRefs": [
+      "Daniel 9:25",
+      "Daniel 9:26",
+      "John 1:41",
+      "John 4:25",
+      "Acts 2:36"
+    ]
+  },
+  {
+    "id": "tsemach",
+    "nameEn": "Tsemach",
+    "nameOriginal": "צֶמַח",
+    "transliteration": "Tsemach",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The Branch; the Messianic title for the righteous shoot of David who will reign as king",
+    "testament": "OT",
+    "verseRefs": [
+      "Jeremiah 23:5",
+      "Jeremiah 33:15",
+      "Zechariah 3:8",
+      "Zechariah 6:12",
+      "Isaiah 11:1"
+    ]
+  },
+  {
+    "id": "shoresh-yishai",
+    "nameEn": "Shoresh Yishai",
+    "nameOriginal": "שֹׁרֶשׁ יִשַׁי",
+    "transliteration": "Shoresh Yishai",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Root of Jesse; the Messiah who springs from David's lineage as a banner for all nations",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 11:1",
+      "Isaiah 11:10",
+      "Romans 15:12",
+      "Revelation 5:5",
+      "Revelation 22:16"
+    ]
+  },
+  {
+    "id": "ben-david",
+    "nameEn": "Ben David",
+    "nameOriginal": "בֶּן דָּוִד",
+    "transliteration": "Ben David",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Son of David; the Messianic heir to David's eternal throne and covenant",
+    "testament": "Both",
+    "verseRefs": [
+      "Matthew 1:1",
+      "Matthew 9:27",
+      "Matthew 15:22",
+      "Matthew 21:9",
+      "Romans 1:3"
+    ]
+  },
+  {
+    "id": "sar-shalom",
+    "nameEn": "Sar Shalom",
+    "nameOriginal": "שַׂר שָׁלוֹם",
+    "transliteration": "Sar Shalom",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Prince of Peace; the Messianic name for the one who establishes everlasting peace",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "Micah 5:5",
+      "Romans 5:1",
+      "Ephesians 2:14",
+      "John 14:27"
+    ]
+  },
+  {
+    "id": "pele-yoets",
+    "nameEn": "Pele Yoets",
+    "nameOriginal": "פֶּלֶא יוֹעֵץ",
+    "transliteration": "Pele Yoets",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Wonderful Counselor; the Messianic ruler whose counsel is supernatural and beyond human wisdom",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "1 Corinthians 1:30",
+      "Isaiah 28:29",
+      "Proverbs 8:14",
+      "Colossians 2:3"
+    ]
+  },
+  {
+    "id": "avi-ad",
+    "nameEn": "Avi Ad",
+    "nameOriginal": "אֲבִי עַד",
+    "transliteration": "Avi Ad",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Everlasting Father; the Messianic title expressing His eternal care and fatherly provision",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "John 10:30",
+      "John 14:9",
+      "Hebrews 7:3",
+      "Micah 5:2"
+    ]
+  },
+  {
+    "id": "eved-yahweh",
+    "nameEn": "Eved Yahweh",
+    "nameOriginal": "עֶבֶד יְהוָה",
+    "transliteration": "Eved Yahweh",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Servant of the LORD; the suffering servant who bears the sin of many",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 42:1",
+      "Isaiah 49:5",
+      "Isaiah 52:13",
+      "Isaiah 53:11",
+      "Matthew 12:18"
+    ]
+  },
+  {
+    "id": "ariel-yehudah",
+    "nameEn": "Ariel Yehudah",
+    "nameOriginal": "אֲרִי יְהוּדָה",
+    "transliteration": "Ariel Yehudah",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Lion of Judah; the triumphant Messiah who overcomes through sacrifice",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 49:9",
+      "Revelation 5:5",
+      "Hosea 11:10",
+      "Numbers 23:24",
+      "Micah 5:8"
+    ]
+  },
+  {
+    "id": "kohen-gadol",
+    "nameEn": "Kohen Gadol",
+    "nameOriginal": "כֹּהֵן גָּדוֹל",
+    "transliteration": "Kohen Gadol",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "High Priest; the Messianic mediator who makes atonement and intercedes for the people",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 110:4",
+      "Hebrews 2:17",
+      "Hebrews 4:14",
+      "Hebrews 9:11",
+      "Zechariah 6:13"
+    ]
+  },
+  {
+    "id": "bar-enash",
+    "nameEn": "Bar Enash",
+    "nameOriginal": "בַּר אֱנָשׁ",
+    "transliteration": "Bar Enash",
+    "language": "Aramaic",
+    "category": "messianic-title",
+    "meaning": "Son of Man (Aramaic); the heavenly figure in Daniel given dominion over all peoples and nations",
+    "testament": "Both",
+    "verseRefs": [
+      "Daniel 7:13",
+      "Daniel 7:14",
+      "Matthew 24:30",
+      "Mark 14:62",
+      "Revelation 1:13"
+    ]
+  },
+  {
+    "id": "shoresh-david",
+    "nameEn": "Shoresh David",
+    "nameOriginal": "שֹׁרֶשׁ דָּוִד",
+    "transliteration": "Shoresh David",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Root and Offspring of David; the Messiah who is both ancestor and descendant of David",
+    "testament": "Both",
+    "verseRefs": [
+      "Revelation 5:5",
+      "Revelation 22:16",
+      "Isaiah 11:1",
+      "Romans 1:3",
+      "Matthew 1:1"
+    ]
+  },
+  {
+    "id": "kochav-boker",
+    "nameEn": "Kochav HaBokher",
+    "nameOriginal": "כּוֹכַב הַבֹּקֶר",
+    "transliteration": "Kochav HaBokher",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Bright Morning Star; the Messiah as the harbinger of a new dawn who outshines all darkness",
+    "testament": "Both",
+    "verseRefs": [
+      "Numbers 24:17",
+      "Revelation 22:16",
+      "2 Peter 1:19",
+      "Isaiah 14:12",
+      "Revelation 2:28"
+    ]
+  },
+  {
+    "id": "nasi",
+    "nameEn": "Nasi",
+    "nameOriginal": "נָשִׂיא",
+    "transliteration": "Nasi",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "Prince / Ruler; the divinely appointed leader and ruler over Israel",
+    "testament": "Both",
+    "verseRefs": [
+      "Ezekiel 34:24",
+      "Ezekiel 37:25",
+      "Daniel 9:25",
+      "Isaiah 9:6",
+      "Matthew 2:6"
+    ]
+  },
+  {
+    "id": "creator",
+    "nameEn": "Creator",
+    "nameOriginal": "בּוֹרֵא",
+    "transliteration": "Bore",
+    "language": "Hebrew",
+    "category": "descriptive-title",
+    "meaning": "The Creator of all things; the one who brought the universe into existence ex nihilo",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 1:1",
+      "Isaiah 40:28",
+      "Isaiah 43:15",
+      "Colossians 1:16",
+      "Romans 1:25"
+    ]
+  },
+  {
+    "id": "ancient-of-days",
+    "nameEn": "Ancient of Days",
+    "nameOriginal": "עַתִּיק יוֹמַיָּא",
+    "transliteration": "Attiq Yomayya",
+    "language": "Aramaic",
+    "category": "descriptive-title",
+    "meaning": "The Eternal Judge; the divine figure of immeasurable age and glory who renders ultimate judgment",
+    "testament": "OT",
+    "verseRefs": [
+      "Daniel 7:9",
+      "Daniel 7:13",
+      "Daniel 7:22",
+      "Revelation 1:14",
+      "Psalm 90:2"
+    ]
+  },
+  {
+    "id": "judge-of-all-earth",
+    "nameEn": "Judge of All the Earth",
+    "nameOriginal": "שֹׁפֵט כָּל הָאָרֶץ",
+    "transliteration": "Shophet Kol HaAretz",
+    "language": "Hebrew",
+    "category": "descriptive-title",
+    "meaning": "The righteous judge who will render perfect justice to all peoples everywhere",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 18:25",
+      "Psalm 94:2",
+      "Acts 17:31",
+      "Hebrews 12:23",
+      "Romans 3:6"
+    ]
+  },
+  {
+    "id": "god-of-abraham",
+    "nameEn": "God of Abraham, Isaac and Jacob",
+    "nameOriginal": "אֱלֹהֵי אַבְרָהָם יִצְחָק וְיַעֲקֹב",
+    "transliteration": "Elohe Avraham Yitschak veYaakov",
+    "language": "Hebrew",
+    "category": "relational-title",
+    "meaning": "The covenant-keeping God who identifies Himself by relationship with the patriarchs",
+    "testament": "Both",
+    "verseRefs": [
+      "Exodus 3:6",
+      "Matthew 22:32",
+      "Acts 3:13",
+      "Acts 7:32",
+      "Mark 12:26"
+    ]
+  },
+  {
+    "id": "holy-spirit",
+    "nameEn": "Holy Spirit",
+    "nameOriginal": "רוּחַ הַקֹּדֶשׁ",
+    "transliteration": "Ruach HaKodesh",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The Holy Spirit; the third person of the Trinity who sanctifies, comforts, and empowers",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 51:11",
+      "Isaiah 63:10",
+      "Matthew 3:16",
+      "John 14:26",
+      "Acts 1:8"
+    ]
+  },
+  {
+    "id": "deliverer",
+    "nameEn": "Deliverer",
+    "nameOriginal": "מְפַלֵּט",
+    "transliteration": "Mephalat",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "The one who rescues and delivers from enemies, danger, and bondage",
+    "testament": "Both",
+    "verseRefs": [
+      "2 Samuel 22:2",
+      "Psalm 18:2",
+      "Psalm 40:17",
+      "Romans 11:26",
+      "Isaiah 49:26"
+    ]
+  },
+  {
+    "id": "refuge",
+    "nameEn": "Refuge",
+    "nameOriginal": "מַחֲסֶה",
+    "transliteration": "Machaseh",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "A safe haven and shelter; God as the one to whom we flee in times of trouble",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 46:1",
+      "Psalm 62:8",
+      "Psalm 91:2",
+      "Deuteronomy 33:27",
+      "Nahum 1:7"
+    ]
+  },
+  {
+    "id": "strong-tower",
+    "nameEn": "Strong Tower",
+    "nameOriginal": "מִגְדַּל עֹז",
+    "transliteration": "Migdal Oz",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "An impenetrable place of safety; the name of the LORD as protection for the righteous",
+    "testament": "OT",
+    "verseRefs": [
+      "Proverbs 18:10",
+      "Psalm 61:3",
+      "2 Samuel 22:3",
+      "Psalm 144:2",
+      "Psalm 18:2"
+    ]
+  },
+  {
+    "id": "fortress",
+    "nameEn": "Fortress",
+    "nameOriginal": "מְצוּדָה",
+    "transliteration": "Metsudah",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "An impregnable stronghold; God as the one who cannot be breached by any enemy",
+    "testament": "OT",
+    "verseRefs": [
+      "2 Samuel 22:2",
+      "Psalm 18:2",
+      "Psalm 31:3",
+      "Psalm 71:3",
+      "Psalm 91:2"
+    ]
+  },
+  {
+    "id": "rock",
+    "nameEn": "The Rock",
+    "nameOriginal": "סֶלַע",
+    "transliteration": "Sela",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "Unchanging foundation; God as the immovable rock on whom faith can be safely built",
+    "testament": "Both",
+    "verseRefs": [
+      "Deuteronomy 32:4",
+      "1 Samuel 2:2",
+      "Psalm 18:2",
+      "Matthew 16:18",
+      "1 Corinthians 10:4"
+    ]
+  },
+  {
+    "id": "shield",
+    "nameEn": "Shield",
+    "nameOriginal": "מָגֵן",
+    "transliteration": "Magen",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "Divine protection; God who deflects attack and guards those who trust in Him",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 15:1",
+      "Psalm 3:3",
+      "Psalm 18:2",
+      "Proverbs 30:5",
+      "Ephesians 6:16"
+    ]
+  },
+  {
+    "id": "good-shepherd",
+    "nameEn": "Good Shepherd",
+    "nameOriginal": "ποιμὴν καλός",
+    "transliteration": "Poimen Kalos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The compassionate shepherd who knows each sheep by name, leads, feeds, and lays down His life",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 23:1",
+      "Ezekiel 34:15",
+      "John 10:11",
+      "John 10:14",
+      "1 Peter 5:4"
+    ]
+  },
+  {
+    "id": "bread-of-life",
+    "nameEn": "Bread of Life",
+    "nameOriginal": "ἄρτος τῆς ζωῆς",
+    "transliteration": "Artos tes Zoes",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The spiritual sustenance given by Christ; whoever comes to Him will never hunger",
+    "testament": "NT",
+    "verseRefs": [
+      "John 6:35",
+      "John 6:48",
+      "John 6:51",
+      "Exodus 16:15",
+      "Deuteronomy 8:3"
+    ]
+  },
+  {
+    "id": "living-water",
+    "nameEn": "Living Water",
+    "nameOriginal": "מַיִם חַיִּים",
+    "transliteration": "Mayim Chayyim",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The life-giving presence of God; whoever drinks will never thirst again",
+    "testament": "Both",
+    "verseRefs": [
+      "Jeremiah 2:13",
+      "John 4:10",
+      "John 7:38",
+      "Revelation 21:6",
+      "Revelation 22:1"
+    ]
+  },
+  {
+    "id": "true-vine",
+    "nameEn": "True Vine",
+    "nameOriginal": "ἡ ἄμπελος ἡ ἀληθινή",
+    "transliteration": "He Ampelos He Alethine",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The source of all spiritual fruitfulness; abiding in Him produces life and bearing of fruit",
+    "testament": "NT",
+    "verseRefs": [
+      "John 15:1",
+      "John 15:5",
+      "Isaiah 5:7",
+      "Psalm 80:8",
+      "Matthew 21:33"
+    ]
+  },
+  {
+    "id": "the-door",
+    "nameEn": "The Door",
+    "nameOriginal": "ἡ θύρα",
+    "transliteration": "He Thyra",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The Gate; the only way of access to salvation and to the Father",
+    "testament": "NT",
+    "verseRefs": [
+      "John 10:7",
+      "John 10:9",
+      "Matthew 7:13",
+      "Revelation 3:20",
+      "John 14:6"
+    ]
+  },
+  {
+    "id": "light-of-the-world",
+    "nameEn": "Light of the World",
+    "nameOriginal": "τὸ φῶς τοῦ κόσμου",
+    "transliteration": "To Phos tou Kosmou",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The divine light who illuminates all darkness; those who follow Him do not walk in darkness",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:2",
+      "John 8:12",
+      "John 9:5",
+      "John 12:46",
+      "Revelation 21:23"
+    ]
+  },
+  {
+    "id": "way-truth-life",
+    "nameEn": "The Way, the Truth, and the Life",
+    "nameOriginal": "ἡ ὁδὸς καὶ ἡ ἀλήθεια καὶ ἡ ζωή",
+    "transliteration": "He Hodos kai he Aletheia kai he Zoe",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Jesus as the path to God, the truth about God, and the source of eternal life",
+    "testament": "NT",
+    "verseRefs": [
+      "John 14:6",
+      "Psalm 16:11",
+      "John 17:3",
+      "Acts 9:2",
+      "John 11:25"
+    ]
+  },
+  {
+    "id": "king-of-kings",
+    "nameEn": "King of Kings",
+    "nameOriginal": "βασιλεὺς βασιλέων",
+    "transliteration": "Basileus Basileon",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "The supreme ruler over all earthly kings; no authority exists apart from His rule",
+    "testament": "Both",
+    "verseRefs": [
+      "1 Timothy 6:15",
+      "Revelation 17:14",
+      "Revelation 19:16",
+      "Ezra 7:12",
+      "Daniel 2:47"
+    ]
+  },
+  {
+    "id": "lord-of-lords",
+    "nameEn": "Lord of Lords",
+    "nameOriginal": "κύριος κυρίων",
+    "transliteration": "Kyrios Kyrion",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "Supreme authority over all masters; the one before whom every knee will bow",
+    "testament": "Both",
+    "verseRefs": [
+      "1 Timothy 6:15",
+      "Revelation 17:14",
+      "Revelation 19:16",
+      "Deuteronomy 10:17",
+      "Psalm 136:3"
+    ]
+  },
+  {
+    "id": "morning-star",
+    "nameEn": "Bright Morning Star",
+    "nameOriginal": "ὁ ἀστὴρ ὁ λαμπρὸς ὁ πρωϊνός",
+    "transliteration": "Ho Aster Ho Lampros Ho Proinos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The herald of a new eternal day; the radiant star who signals the coming dawn of God's kingdom",
+    "testament": "Both",
+    "verseRefs": [
+      "Numbers 24:17",
+      "Revelation 22:16",
+      "2 Peter 1:19",
+      "Isaiah 14:12",
+      "Luke 1:78"
+    ]
+  },
+  {
+    "id": "alpha-omega",
+    "nameEn": "Alpha and Omega",
+    "nameOriginal": "τὸ Ἄλφα καὶ τὸ Ὦ",
+    "transliteration": "To Alpha kai to O",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "The first and last letters of the Greek alphabet; God encompasses all of existence from beginning to end",
+    "testament": "NT",
+    "verseRefs": [
+      "Revelation 1:8",
+      "Revelation 21:6",
+      "Revelation 22:13",
+      "Isaiah 44:6",
+      "Isaiah 48:12"
+    ]
+  },
+  {
+    "id": "first-and-last",
+    "nameEn": "The First and the Last",
+    "nameOriginal": "הָרִאשׁוֹן וְהָאַחֲרוֹן",
+    "transliteration": "HaRishon veHaAcharon",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The eternal God who precedes and outlasts all of creation; there is none before or after Him",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 44:6",
+      "Isaiah 48:12",
+      "Revelation 1:17",
+      "Revelation 22:13",
+      "Isaiah 41:4"
+    ]
+  },
+  {
+    "id": "lion-of-judah",
+    "nameEn": "Lion of Judah",
+    "nameOriginal": "אֲרִי יְהוּדָה",
+    "transliteration": "Ari Yehudah",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The triumphant, conquering Messiah from the tribe of Judah; worthy to open the sealed scroll",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 49:9",
+      "Revelation 5:5",
+      "Hosea 11:10",
+      "2 Chronicles 20:21",
+      "Amos 3:8"
+    ]
+  },
+  {
+    "id": "lamb-of-god",
+    "nameEn": "Lamb of God",
+    "nameOriginal": "ὁ ἀμνὸς τοῦ θεοῦ",
+    "transliteration": "Ho Amnos tou Theou",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The perfect sacrificial lamb who takes away the sin of the world",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 53:7",
+      "John 1:29",
+      "John 1:36",
+      "Revelation 5:12",
+      "1 Peter 1:19"
+    ]
+  },
+  {
+    "id": "son-of-god-en",
+    "nameEn": "Son of God",
+    "nameOriginal": "υἱὸς τοῦ θεοῦ",
+    "transliteration": "Huios tou Theou",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "The unique eternal Son who shares the divine nature of the Father",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 3:17",
+      "John 1:34",
+      "John 3:16",
+      "Matthew 16:16",
+      "Romans 1:4"
+    ]
+  },
+  {
+    "id": "immanuel-en",
+    "nameEn": "Immanuel",
+    "nameOriginal": "עִמָּנוּ אֵל",
+    "transliteration": "Immanu El",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "God with Us; the Messianic promise of God's intimate presence with His people",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 7:14",
+      "Isaiah 8:8",
+      "Matthew 1:23",
+      "John 1:14",
+      "Matthew 28:20"
+    ]
+  },
+  {
+    "id": "prince-of-peace-en",
+    "nameEn": "Prince of Peace",
+    "nameOriginal": "שַׂר שָׁלוֹם",
+    "transliteration": "Sar Shalom",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The one who establishes and rules in perfect shalom — wholeness, harmony, and reconciliation",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "John 14:27",
+      "Romans 5:1",
+      "Ephesians 2:14",
+      "Colossians 3:15"
+    ]
+  },
+  {
+    "id": "wonderful-counselor-en",
+    "nameEn": "Wonderful Counselor",
+    "nameOriginal": "פֶּלֶא יוֹעֵץ",
+    "transliteration": "Pele Yoets",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The one whose counsel is miraculous and divine wisdom in all things",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "1 Corinthians 1:24",
+      "Colossians 2:3",
+      "Proverbs 8:14",
+      "Isaiah 28:29"
+    ]
+  },
+  {
+    "id": "everlasting-father-en",
+    "nameEn": "Everlasting Father",
+    "nameOriginal": "אֲבִי עַד",
+    "transliteration": "Avi Ad",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The eternal one who embodies fatherly love and care toward His people forever",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 9:6",
+      "John 10:30",
+      "John 14:9",
+      "Micah 5:2",
+      "Hebrews 7:3"
+    ]
+  },
+  {
+    "id": "i-am-en",
+    "nameEn": "I AM",
+    "nameOriginal": "אֶהְיֶה אֲשֶׁר אֶהְיֶה",
+    "transliteration": "Ehyeh Asher Ehyeh",
+    "language": "Hebrew",
+    "category": "covenant-name",
+    "meaning": "The self-existent, self-defining God; eternal being who owes His existence to none other",
+    "testament": "Both",
+    "verseRefs": [
+      "Exodus 3:14",
+      "John 8:58",
+      "John 6:35",
+      "John 10:9",
+      "John 11:25"
+    ]
+  },
+  {
+    "id": "comforter-en",
+    "nameEn": "Comforter",
+    "nameOriginal": "παράκλητος",
+    "transliteration": "Parakletos",
+    "language": "Greek",
+    "category": "divine-name",
+    "meaning": "The one called alongside to help; the Holy Spirit who comforts, guides, and advocates",
+    "testament": "NT",
+    "verseRefs": [
+      "John 14:16",
+      "John 14:26",
+      "John 15:26",
+      "John 16:7",
+      "2 Corinthians 1:3"
+    ]
+  },
+  {
+    "id": "god-of-all-comfort",
+    "nameEn": "God of All Comfort",
+    "nameOriginal": "ὁ θεὸς πάσης παρακλήσεως",
+    "transliteration": "Ho Theos Pases Parakleseos",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The Father who consoles in every affliction and equips believers to comfort others",
+    "testament": "NT",
+    "verseRefs": [
+      "2 Corinthians 1:3",
+      "2 Corinthians 1:4",
+      "Isaiah 51:12",
+      "Psalm 119:50",
+      "Romans 15:5"
+    ]
+  },
+  {
+    "id": "god-of-peace",
+    "nameEn": "God of Peace",
+    "nameOriginal": "ὁ θεὸς τῆς εἰρήνης",
+    "transliteration": "Ho Theos tes Eirenes",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The God whose very nature is peace and who bestows peace that surpasses understanding",
+    "testament": "NT",
+    "verseRefs": [
+      "Romans 15:33",
+      "Romans 16:20",
+      "Philippians 4:9",
+      "1 Thessalonians 5:23",
+      "Hebrews 13:20"
+    ]
+  },
+  {
+    "id": "god-of-hope",
+    "nameEn": "God of Hope",
+    "nameOriginal": "ὁ θεὸς τῆς ἐλπίδος",
+    "transliteration": "Ho Theos tes Elpidos",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The source of all hope; the God who fills believers with joy and peace through trusting in Him",
+    "testament": "NT",
+    "verseRefs": [
+      "Romans 15:13",
+      "Psalm 71:5",
+      "Lamentations 3:24",
+      "1 Timothy 1:1",
+      "Titus 2:13"
+    ]
+  },
+  {
+    "id": "god-of-love",
+    "nameEn": "God of Love",
+    "nameOriginal": "ὁ θεὸς τῆς ἀγάπης",
+    "transliteration": "Ho Theos tes Agapes",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The God whose essential nature is agape love, expressed supremely in giving His Son",
+    "testament": "Both",
+    "verseRefs": [
+      "1 John 4:8",
+      "1 John 4:16",
+      "2 Corinthians 13:11",
+      "John 3:16",
+      "Romans 8:39"
+    ]
+  },
+  {
+    "id": "god-of-grace",
+    "nameEn": "God of Grace",
+    "nameOriginal": "θεὸς πάσης χάριτος",
+    "transliteration": "Theos Pases Charitos",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The God of all grace who calls believers to eternal glory through Christ",
+    "testament": "NT",
+    "verseRefs": [
+      "1 Peter 5:10",
+      "Ephesians 2:8",
+      "Romans 5:15",
+      "John 1:16",
+      "2 Corinthians 9:14"
+    ]
+  },
+  {
+    "id": "god-of-glory",
+    "nameEn": "God of Glory",
+    "nameOriginal": "ὁ θεὸς τῆς δόξης",
+    "transliteration": "Ho Theos tes Doxes",
+    "language": "Greek",
+    "category": "descriptive-title",
+    "meaning": "The majestic God whose glory fills all creation and is the ultimate end of all things",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 29:3",
+      "Acts 7:2",
+      "Ephesians 1:17",
+      "Revelation 21:23",
+      "Isaiah 6:3"
+    ]
+  },
+  {
+    "id": "holy-one-israel-en",
+    "nameEn": "Holy One of Israel",
+    "nameOriginal": "קְדוֹשׁ יִשְׂרָאֵל",
+    "transliteration": "Kadosh Yisrael",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The perfectly holy God in covenant with Israel; His holiness both judges and saves",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 1:4",
+      "Isaiah 12:6",
+      "Isaiah 43:3",
+      "Isaiah 47:4",
+      "Mark 1:24"
+    ]
+  },
+  {
+    "id": "redeemer-en",
+    "nameEn": "Redeemer",
+    "nameOriginal": "גֹּאֵל",
+    "transliteration": "Go'el",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "The one who pays the redemption price to restore what was lost through sin",
+    "testament": "Both",
+    "verseRefs": [
+      "Job 19:25",
+      "Isaiah 41:14",
+      "Isaiah 43:14",
+      "Isaiah 44:6",
+      "Luke 1:68"
+    ]
+  },
+  {
+    "id": "heavenly-father",
+    "nameEn": "Heavenly Father",
+    "nameOriginal": "Πατὴρ ὁ ἐν τοῖς οὐρανοῖς",
+    "transliteration": "Pater Ho en tois Ouranois",
+    "language": "Greek",
+    "category": "relational-title",
+    "meaning": "The Father who is in heaven; the personal, relational God who provides and cares for His children",
+    "testament": "NT",
+    "verseRefs": [
+      "Matthew 6:9",
+      "Matthew 6:32",
+      "Matthew 7:11",
+      "John 17:11",
+      "Ephesians 3:14"
+    ]
+  },
+  {
+    "id": "savior-en",
+    "nameEn": "Savior",
+    "nameOriginal": "מוֹשִׁיעַ",
+    "transliteration": "Moshia",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The divine rescuer who saves from sin, judgment, and eternal death",
+    "testament": "Both",
+    "verseRefs": [
+      "Isaiah 43:3",
+      "Isaiah 45:21",
+      "Luke 2:11",
+      "Titus 2:13",
+      "1 John 4:14"
+    ]
+  },
+  {
+    "id": "advocate-en",
+    "nameEn": "Advocate",
+    "nameOriginal": "παράκλητος",
+    "transliteration": "Parakletos",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Jesus Christ as our legal advocate before the Father; the one who pleads our case",
+    "testament": "NT",
+    "verseRefs": [
+      "1 John 2:1",
+      "Romans 8:34",
+      "Hebrews 7:25",
+      "John 14:16",
+      "Isaiah 53:12"
+    ]
+  },
+  {
+    "id": "resurrection-life",
+    "nameEn": "The Resurrection and the Life",
+    "nameOriginal": "ἡ ἀνάστασις καὶ ἡ ζωή",
+    "transliteration": "He Anastasis kai he Zoe",
+    "language": "Greek",
+    "category": "messianic-title",
+    "meaning": "Jesus who holds authority over death; belief in Him guarantees eternal life",
+    "testament": "NT",
+    "verseRefs": [
+      "John 11:25",
+      "John 11:26",
+      "John 5:25",
+      "1 Corinthians 15:20",
+      "Romans 6:9"
+    ]
+  },
+  {
+    "id": "sovereign-lord-en",
+    "nameEn": "Sovereign Lord",
+    "nameOriginal": "אֲדֹנָי יְהוִה",
+    "transliteration": "Adonai Yahweh",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The supreme ruler who holds all authority; used especially in the prophets to emphasize divine power",
+    "testament": "Both",
+    "verseRefs": [
+      "Amos 3:7",
+      "Ezekiel 2:4",
+      "Genesis 15:2",
+      "Acts 4:24",
+      "Revelation 6:10"
+    ]
+  },
+  {
+    "id": "father-en",
+    "nameEn": "Father",
+    "nameOriginal": "אָב",
+    "transliteration": "Av",
+    "language": "Hebrew",
+    "category": "relational-title",
+    "meaning": "God as Father; the most intimate relational title revealing His parental love and care",
+    "testament": "Both",
+    "verseRefs": [
+      "Deuteronomy 32:6",
+      "Isaiah 63:16",
+      "Matthew 6:9",
+      "John 14:6",
+      "Romans 8:15"
+    ]
+  },
+  {
+    "id": "ruach-elohim",
+    "nameEn": "Ruach Elohim",
+    "nameOriginal": "רוּחַ אֱלֹהִים",
+    "transliteration": "Ruach Elohim",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "Spirit of God; the divine breath and presence of God moving over creation and inspiring His people",
+    "testament": "Both",
+    "verseRefs": [
+      "Genesis 1:2",
+      "Isaiah 63:10",
+      "Ezekiel 37:14",
+      "Romans 8:14",
+      "1 Corinthians 3:16"
+    ]
+  },
+  {
+    "id": "horn-of-salvation",
+    "nameEn": "Horn of Salvation",
+    "nameOriginal": "קֶרֶן יְשׁוּעָה",
+    "transliteration": "Keren Yeshuah",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "A mighty, powerful savior; the horn symbolizing strength in the animal world applied to God's saving power",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 18:2",
+      "Luke 1:69",
+      "2 Samuel 22:3",
+      "Psalm 148:14",
+      "Ezekiel 29:21"
+    ]
+  },
+  {
+    "id": "sun-of-righteousness",
+    "nameEn": "Sun of Righteousness",
+    "nameOriginal": "שֶׁמֶשׁ צְדָקָה",
+    "transliteration": "Shemesh Tsedaqah",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The Messianic figure who rises with healing in His wings for those who fear God",
+    "testament": "Both",
+    "verseRefs": [
+      "Malachi 4:2",
+      "Luke 1:78",
+      "John 8:12",
+      "2 Peter 1:19",
+      "Isaiah 60:1"
+    ]
+  },
+  {
+    "id": "word-of-god-en",
+    "nameEn": "Word of God",
+    "nameOriginal": "דְּבַר יְהוָה",
+    "transliteration": "Devar Yahweh",
+    "language": "Hebrew",
+    "category": "messianic-title",
+    "meaning": "The divine communication and revelation of God; in Christ, God's ultimate self-expression",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 33:6",
+      "John 1:1",
+      "John 1:14",
+      "Hebrews 4:12",
+      "Revelation 19:13"
+    ]
+  },
+  {
+    "id": "melek-haolam",
+    "nameEn": "Melech HaOlam",
+    "nameOriginal": "מֶלֶךְ הָעוֹלָם",
+    "transliteration": "Melech HaOlam",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "King of the Universe/Eternity; used in Jewish blessings to acknowledge God's cosmic sovereignty",
+    "testament": "Both",
+    "verseRefs": [
+      "Psalm 10:16",
+      "Psalm 29:10",
+      "Psalm 145:13",
+      "Revelation 15:3",
+      "1 Timothy 1:17"
+    ]
+  },
+  {
+    "id": "rishon-acharon",
+    "nameEn": "Rishon veAcharon",
+    "nameOriginal": "רִאשׁוֹן וְאַחֲרוֹן",
+    "transliteration": "Rishon veAcharon",
+    "language": "Hebrew",
+    "category": "divine-name",
+    "meaning": "The First and the Last; the eternal God who precedes and outlasts all of history",
+    "testament": "OT",
+    "verseRefs": [
+      "Isaiah 44:6",
+      "Isaiah 48:12",
+      "Isaiah 41:4",
+      "Revelation 1:17",
+      "Revelation 22:13"
+    ]
+  },
+  {
+    "id": "el-nasa",
+    "nameEn": "El Nose",
+    "nameOriginal": "אֵל נֹשֵׂא",
+    "transliteration": "El Nose",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "God Who Forgives; the God who lifts and carries away transgression, iniquity, and sin",
+    "testament": "OT",
+    "verseRefs": [
+      "Exodus 34:7",
+      "Micah 7:18",
+      "Psalm 103:12",
+      "Numbers 14:18",
+      "Isaiah 43:25"
+    ]
+  },
+  {
+    "id": "shepherd-israel",
+    "nameEn": "Shepherd of Israel",
+    "nameOriginal": "רֹעֵה יִשְׂרָאֵל",
+    "transliteration": "Roeh Yisrael",
+    "language": "Hebrew",
+    "category": "relational-title",
+    "meaning": "God who shepherds His people Israel; leads, protects, and gathers the flock",
+    "testament": "OT",
+    "verseRefs": [
+      "Psalm 80:1",
+      "Psalm 23:1",
+      "Isaiah 40:11",
+      "Ezekiel 34:15",
+      "Genesis 48:15"
+    ]
+  },
+  {
+    "id": "consuming-fire",
+    "nameEn": "Consuming Fire",
+    "nameOriginal": "אֵשׁ אֹכְלָה",
+    "transliteration": "Esh Okhelah",
+    "language": "Hebrew",
+    "category": "attribute",
+    "meaning": "God's holy presence as an all-consuming fire that devours evil and purifies His people",
+    "testament": "Both",
+    "verseRefs": [
+      "Deuteronomy 4:24",
+      "Deuteronomy 9:3",
+      "Hebrews 12:29",
+      "Exodus 24:17",
+      "Isaiah 33:14"
+    ]
+  }
+]

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "verse-mate-mobile",
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
+        "@gorhom/bottom-sheet": "^5.2.14",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-native-community/datetimepicker": "8.4.4",
         "@react-native-community/netinfo": "^11.4.1",
@@ -457,7 +458,7 @@
 
     "@expo/xcpretty": ["@expo/xcpretty@4.3.2", "", { "dependencies": { "@babel/code-frame": "7.10.4", "chalk": "^4.1.0", "find-up": "^5.0.0", "js-yaml": "^4.1.0" }, "bin": { "excpretty": "build/cli.js" } }, "sha512-ReZxZ8pdnoI3tP/dNnJdnmAk7uLT4FjsKDGW7YeDdvdOMz2XCQSmSCM9IWlrXuWtMF9zeSB6WJtEhCQ41gQOfw=="],
 
-    "@gorhom/bottom-sheet": ["@gorhom/bottom-sheet@5.2.6", "", { "dependencies": { "@gorhom/portal": "1.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-native": "*", "react": "*", "react-native": "*", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.16.0 || >=4.0.0-" }, "optionalPeers": ["@types/react", "@types/react-native"] }, "sha512-vmruJxdiUGDg+ZYcDmS30XDhq/h/+QkINOI5LY/uGjx8cPGwgJW0H6AB902gNTKtccbiKe/rr94EwdmIEz+LAQ=="],
+    "@gorhom/bottom-sheet": ["@gorhom/bottom-sheet@5.2.14", "", { "dependencies": { "@gorhom/portal": "1.0.14", "invariant": "^2.2.4" }, "peerDependencies": { "@types/react": "*", "@types/react-native": "*", "react": "*", "react-native": "*", "react-native-gesture-handler": ">=2.16.1", "react-native-reanimated": ">=3.16.0 || >=4.0.0-" }, "optionalPeers": ["@types/react", "@types/react-native"] }, "sha512-uLQFlDjp9z+jrOFcMSEldPqL5JdaXL3vXOh+juhwoNvXgTsEorJLjHTugXu+YccAG/0KJnShzKCrb71MHBsvJg=="],
 
     "@gorhom/portal": ["@gorhom/portal@1.0.14", "", { "dependencies": { "nanoid": "^3.3.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-MXyL4xvCjmgaORr/rtryDNFy3kU4qUbKlwtQqqsygd0xX3mhKjOLn6mQK8wfu0RkoE0pBE0nAasRoHua+/QZ7A=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
+        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#8b8546786f1729a3bfed228707fb8d8084e28c75",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
         "axios": "^1.12.2",
@@ -828,7 +828,7 @@
 
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
-    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#26012e6", {}, "verse-mate-verse-mate-lexicon-26012e6"],
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#8b85467", {}, "verse-mate-verse-mate-lexicon-8b85467"],
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#d9dadca", {}, "verse-mate-verse-mate-studies-d9dadca"],
 

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#8b8546786f1729a3bfed228707fb8d8084e28c75",
+        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
         "axios": "^1.12.2",
@@ -828,7 +828,7 @@
 
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
-    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#8b85467", {}, "verse-mate-verse-mate-lexicon-8b85467"],
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0"],
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#d9dadca", {}, "verse-mate-verse-mate-studies-d9dadca"],
 

--- a/components/bible/AutoHighlightTooltip.tsx
+++ b/components/bible/AutoHighlightTooltip.tsx
@@ -617,7 +617,7 @@ const createStyles = (
       backgroundColor: colors.backgroundElevated,
       borderTopLeftRadius: 16,
       borderTopRightRadius: tooltipWidth ? 0 : 16,
-      maxHeight: '95%',
+      maxHeight: '85%',
       width: tooltipWidth ?? '100%',
       paddingBottom: bottomInset > 0 ? bottomInset : spacing.md,
     },
@@ -813,6 +813,12 @@ const createStyles = (
       borderRadius: 8,
       borderWidth: 1,
       borderColor: colors.border,
+      // Static height cap so long Markdown content scrolls inside the
+      // ScrollView instead of stretching the modal toward the top of
+      // the screen. The Reanimated maxHeight on the outer wrapper
+      // (insightContentWrapper) wasn't reliably constraining a
+      // ScrollView child with intrinsic content height.
+      maxHeight: 360,
     },
     insightScrollContent: {
       padding: spacing.md,

--- a/components/bible/HamburgerMenu.tsx
+++ b/components/bible/HamburgerMenu.tsx
@@ -89,6 +89,7 @@ interface MenuItem {
     | 'bookmarks'
     | 'notes'
     | 'highlights'
+    | 'names-of-god'
     | 'settings'
     | 'share'
     | 'about'
@@ -100,6 +101,7 @@ const regularMenuItems: MenuItem[] = [
   { id: 'bookmarks', label: 'Bookmarks', icon: IconBookmarkFilled, action: 'bookmarks' },
   { id: 'notes', label: 'Notes', icon: IconDocument, action: 'notes' },
   { id: 'highlights', label: 'Highlights', icon: IconHighlight, action: 'highlights' },
+  { id: 'names-of-god', label: 'Names of God', icon: IconInfo, action: 'names-of-god' },
   { id: 'settings', label: 'Settings', icon: IconSettings, action: 'settings' },
   { id: 'share', label: 'Share VerseMate', icon: IconShare, action: 'share' },
   { id: 'about', label: 'About', icon: IconInfo, action: 'about' },
@@ -201,6 +203,9 @@ export function HamburgerMenu({ visible, onClose }: HamburgerMenuProps) {
       onClose();
       // biome-ignore lint/suspicious/noExplicitAny: Typed routes might be stale
       router.push('/highlights' as any);
+    } else if (item.action === 'names-of-god') {
+      onClose();
+      router.push('/names-of-god' as any);
     } else if (item.action === 'settings') {
       onClose();
       router.push('/settings' as never);

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -27,7 +27,6 @@ import {
   type GestureResponderEvent,
   type LayoutChangeEvent,
   type NativeSyntheticEvent,
-  Platform,
   StyleSheet,
   Text,
   type TextLayoutEventData,
@@ -1301,10 +1300,10 @@ const lexiconWordStyles = StyleSheet.create({
   },
   theme: {
     textDecorationLine: 'underline',
-    // Heavier weight + brighter color give the "thick tier" feel that the
-    // solid line alone can't communicate. iOS treats '600' as semi-bold;
-    // Android only renders the bold step at '700' for most font families.
-    fontWeight: Platform.OS === 'ios' ? '600' : '700',
+    // Theme tier differentiates from regular ONLY via the brighter
+    // underline color — no font-weight change. Andy 2026-05-22 explicitly
+    // didn't want emphasis bolding (the underline is supposed to carry
+    // the visual weight, not the glyphs themselves).
     textDecorationColor: LEX_UNDERLINE_THEME,
   },
 });

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -25,6 +25,7 @@ import {
   type BottomSheetBackdropProps,
   BottomSheetModal,
   BottomSheetScrollView,
+  useBottomSheetSpringConfigs,
 } from '@gorhom/bottom-sheet';
 import type { AlignedToken, LexEntry } from '@versemate/lexicon';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
@@ -74,6 +75,19 @@ export function LexiconPopover({
   // custom modal's `maxHeight: 85%`.
   const snapPoints = useMemo(() => ['85%'], []);
 
+  // Open + close spring physics that match AutoHighlightTooltip (the
+  // verse-insight modal). User explicitly asked for parity on both
+  // directions; AutoHighlightTooltip's snap-back/close uses
+  // damping=20, stiffness=90 — same numbers here, with overshoot
+  // clamping so the sheet doesn't bounce past its rest position on
+  // open.
+  const animationConfigs = useBottomSheetSpringConfigs({
+    damping: 20,
+    stiffness: 90,
+    mass: 1,
+    overshootClamping: true,
+  });
+
   useEffect(() => {
     if (visible) {
       sheetRef.current?.present();
@@ -112,6 +126,7 @@ export function LexiconPopover({
       onDismiss={handleDismiss}
       enablePanDownToClose
       enableDynamicSizing={false}
+      animationConfigs={animationConfigs}
       backdropComponent={renderBackdrop}
       backgroundStyle={styles.background}
       handleIndicatorStyle={styles.handleIndicator}

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -165,15 +165,19 @@ export function LexiconPopover({
     const close = () => closeRef.current();
     const scrollNative = Gesture.Native();
     const pan = Gesture.Pan()
-      .activeOffsetY([3, Infinity])
+      // 1px threshold makes the Pan trivially activate even on quick
+      // fingertip flicks — Andy reported (2026-05-22) that real-iPhone
+      // fast swipes intermittently failed to dismiss because the
+      // previous 3px threshold races the iOS ScrollView's own pan
+      // recognizer and sometimes loses (the touch lifts before the
+      // 3px threshold is crossed). 1px is small enough that any
+      // intentional downward gesture clears it.
+      .activeOffsetY([1, Infinity])
       .simultaneousWithExternalGesture(scrollNative)
       .onBegin(() => {
         'worklet';
-        // Freeze the "was at top?" check for this whole gesture. The
-        // pan's `activeOffsetY([3, Infinity])` threshold means there may
-        // be a few pixels of scroll between touch-down and the first
-        // onUpdate, but that's negligible; what matters is we don't let
-        // the gate flip when the user scrolls past zero mid-gesture.
+        // Freeze the "was at top?" check for this whole gesture so the
+        // gate doesn't flip when the user scrolls past zero mid-gesture.
         startedAtTop.value = scrollOffset.value <= 0;
       })
       .onUpdate((e) => {
@@ -184,7 +188,15 @@ export function LexiconPopover({
       })
       .onEnd((e) => {
         'worklet';
-        if (startedAtTop.value && (e.translationY > 50 || e.velocityY > 800)) {
+        // Dismiss if EITHER:
+        //   • the user dragged a meaningful distance (translationY > 50), OR
+        //   • the user flicked downward fast (velocityY > 500), even
+        //     with small translation. A quick 10px flick at 1500 px/s
+        //     reads as "clearly wanted to dismiss" — matching iOS
+        //     bottom-sheet conventions.
+        const draggedFar = e.translationY > 50;
+        const flicked = e.translationY > 0 && e.velocityY > 500;
+        if (startedAtTop.value && (draggedFar || flicked)) {
           runOnJS(close)();
         } else {
           translateY.value = withSpring(0, SPRING_CONFIG);

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -369,16 +369,21 @@ const createStyles = (
       paddingBottom: insets.bottom > 0 ? insets.bottom : spacing.md,
     },
 
-    // Drag area + handle
+    // Drag area + handle — the visual notch is the obvious affordance, so
+    // we keep the touch target generous (lg/md padding) and bump the notch
+    // to 48×5 so it reads as "grab here" from arm's length. The whole
+    // sheet is draggable too via the RNGH pan, but Andy 2026-05-22
+    // signalled most users still aim for the notch — so make THAT a
+    // forgiving target.
     dragArea: {
       alignItems: 'center',
-      paddingTop: spacing.sm,
-      paddingBottom: spacing.xs,
+      paddingTop: spacing.lg,
+      paddingBottom: spacing.md,
     },
     handle: {
-      width: 40,
-      height: 4,
-      borderRadius: 2,
+      width: 48,
+      height: 5,
+      borderRadius: 3,
       backgroundColor: colors.gray100,
     },
 

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -71,6 +71,15 @@ export function LexiconPopover({
   // scrolled to top", same pattern @gorhom/bottom-sheet uses internally.
   const scrollOffset = useSharedValue(0);
 
+  // Captured at gesture START (onBegin) — frozen for the duration of one
+  // touch so the gate doesn't flip mid-gesture. If the user starts a drag
+  // while scrolled away from the top, this stays false even when their
+  // scroll-back-up gesture reaches scrollOffset === 0 — so the modal
+  // doesn't suddenly snap down on the way past zero. They have to lift
+  // and start a NEW gesture at the top to dismiss. (User reported the
+  // snap-and-dismiss bug 2026-05-22.)
+  const startedAtTop = useSharedValue(true);
+
   // Internal visibility flag so we can play the close animation before the
   // Modal actually unmounts. Toggled by the visible-prop watcher below.
   const internalVisibleRef = useRef(false);
@@ -151,22 +160,31 @@ export function LexiconPopover({
     },
   });
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scrollOffset/translateY are stable Reanimated SharedValue refs (their identity never changes across renders); closeRef.current is read inside the worklet via the local `close` closure; the empty-dep array is intentional so the gesture instance stays stable across renders.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scrollOffset/translateY/startedAtTop are stable Reanimated SharedValue refs (their identity never changes across renders); closeRef.current is read inside the worklet via the local `close` closure; the empty-dep array is intentional so the gesture instance stays stable across renders.
   const { panGesture, scrollNativeGesture } = useMemo(() => {
     const close = () => closeRef.current();
     const scrollNative = Gesture.Native();
     const pan = Gesture.Pan()
       .activeOffsetY([3, Infinity])
       .simultaneousWithExternalGesture(scrollNative)
+      .onBegin(() => {
+        'worklet';
+        // Freeze the "was at top?" check for this whole gesture. The
+        // pan's `activeOffsetY([3, Infinity])` threshold means there may
+        // be a few pixels of scroll between touch-down and the first
+        // onUpdate, but that's negligible; what matters is we don't let
+        // the gate flip when the user scrolls past zero mid-gesture.
+        startedAtTop.value = scrollOffset.value <= 0;
+      })
       .onUpdate((e) => {
         'worklet';
-        if (scrollOffset.value <= 0 && e.translationY > 0) {
+        if (startedAtTop.value && e.translationY > 0) {
           translateY.value = e.translationY;
         }
       })
       .onEnd((e) => {
         'worklet';
-        if (scrollOffset.value <= 0 && (e.translationY > 50 || e.velocityY > 800)) {
+        if (startedAtTop.value && (e.translationY > 50 || e.velocityY > 800)) {
           runOnJS(close)();
         } else {
           translateY.value = withSpring(0, SPRING_CONFIG);
@@ -247,6 +265,13 @@ export function LexiconPopover({
                   showsVerticalScrollIndicator={false}
                   onScroll={scrollHandler}
                   scrollEventThrottle={16}
+                  // iOS-only: kill the overscroll rubber-band so dragging
+                  // the modal down from scrollOffset=0 isn't accompanied
+                  // by the ScrollView dropping its content down too.
+                  // The pan IS the bounce in our UX.
+                  bounces={false}
+                  // Android parity — no overscroll glow on pull-down.
+                  overScrollMode="never"
                 >
                   {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
                   {contextual ? (

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -190,12 +190,19 @@ export function LexiconPopover({
         'worklet';
         // Dismiss if EITHER:
         //   • the user dragged a meaningful distance (translationY > 50), OR
-        //   • the user flicked downward fast (velocityY > 500), even
-        //     with small translation. A quick 10px flick at 1500 px/s
-        //     reads as "clearly wanted to dismiss" — matching iOS
-        //     bottom-sheet conventions.
+        //   • the user clearly flicked downward — requires BOTH a real
+        //     translation (> 10px) AND high velocity (> 800 px/s).
+        // The earlier thresholds (translationY > 0, velocityY > 500)
+        // misfired on real-iPhone fingertip taps inside the modal:
+        // touch contact-patch jitter produces ~1-3px of downward
+        // translation, and natural lift-off velocity is often
+        // 300-700 px/s, which previously read as "flick to dismiss"
+        // and closed the modal under the user's finger. Andy reported
+        // this as "drag stopped working altogether" 2026-05-22; the
+        // iOS simulator doesn't reproduce because mouse-cursor input
+        // has zero contact jitter.
         const draggedFar = e.translationY > 50;
-        const flicked = e.translationY > 0 && e.velocityY > 500;
+        const flicked = e.translationY > 10 && e.velocityY > 800;
         if (startedAtTop.value && (draggedFar || flicked)) {
           runOnJS(close)();
         } else {

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -3,25 +3,32 @@
  *
  * Bottom-sheet modal showing the chapter-aligned Greek/Hebrew lexical
  * card for a verse word. Mirrors verse-mate-web/src/components/LexiconPopover.tsx
- * structure (six sections + loaded caveat strip) and matches the UX of
- * verse-mate-mobile/components/bible/VerseMateTooltip.tsx — same slide-up
- * spring, backdrop fade, drag-handle, swipe-down-to-dismiss.
+ * structure (six sections + loaded caveat strip).
  *
  * Triggered by tap on a dotted-underlined word in the Bible reader.
+ *
+ * Built on `@gorhom/bottom-sheet`. The earlier custom implementation
+ * (RN <Modal> + RNGH Gesture.Pan + Reanimated translateY) could not
+ * reliably co-exist with the inner ScrollView's native pan recognizer
+ * on real iOS — fast finger flicks would lose the race and never
+ * dismiss (Andy 2026-05-22/2026-05-23: "swipe down doesn't work, but
+ * hold-and-press-then-drag does"). gorhom's library patches its inner
+ * BottomSheetScrollView so the scroll handler reports up to the sheet
+ * and the pan/scroll handoff is done in worklets, not at the RN-bridge
+ * level. This is the same problem @gorhom/bottom-sheet was built to
+ * solve — adopting it removes ~100 lines of bespoke gesture code we
+ * were never going to make race-free in our own implementation.
  */
 
+import {
+  BottomSheetBackdrop,
+  type BottomSheetBackdropProps,
+  BottomSheetModal,
+  BottomSheetScrollView,
+} from '@gorhom/bottom-sheet';
 import type { AlignedToken, LexEntry } from '@versemate/lexicon';
-import { useEffect, useMemo, useRef } from 'react';
-import { Animated, Dimensions, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector, GestureHandlerRootView } from 'react-native-gesture-handler';
-import Reanimated, {
-  runOnJS,
-  useAnimatedScrollHandler,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated';
-import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
 
@@ -55,319 +62,163 @@ export function LexiconPopover({
   testID = 'lexicon-popover',
 }: LexiconPopoverProps) {
   const { colors } = useTheme();
-  const insets = useSafeAreaInsets();
-  const screenHeight = Dimensions.get('window').height;
-  const styles = useMemo(() => createStyles(colors, insets), [colors, insets]);
+  const styles = useMemo(() => createStyles(colors), [colors]);
 
-  // Backdrop fade stays on the old Animated API (no gesture coupling).
-  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  // gorhom uses an imperative ref API for show/dismiss. Bridge it to our
+  // declarative `visible` prop so the call sites in ChapterReader don't
+  // have to change.
+  const sheetRef = useRef<BottomSheetModal>(null);
 
-  // Sheet position lives in a Reanimated SharedValue so the pan gesture
-  // (which runs on the UI thread via react-native-gesture-handler) can
-  // drive it without round-tripping to JS every frame.
-  const translateY = useSharedValue(screenHeight);
+  // Single snap point at 85% of the available area. The sheet collapses
+  // to that height regardless of content size, matching the previous
+  // custom modal's `maxHeight: 85%`.
+  const snapPoints = useMemo(() => ['85%'], []);
 
-  // ScrollView offset — used to gate the dismiss-pan to "only when
-  // scrolled to top", same pattern @gorhom/bottom-sheet uses internally.
-  const scrollOffset = useSharedValue(0);
-
-  // Captured at gesture START (onBegin) — frozen for the duration of one
-  // touch so the gate doesn't flip mid-gesture. If the user starts a drag
-  // while scrolled away from the top, this stays false even when their
-  // scroll-back-up gesture reaches scrollOffset === 0 — so the modal
-  // doesn't suddenly snap down on the way past zero. They have to lift
-  // and start a NEW gesture at the top to dismiss. (User reported the
-  // snap-and-dismiss bug 2026-05-22.)
-  const startedAtTop = useSharedValue(true);
-
-  // Internal visibility flag so we can play the close animation before the
-  // Modal actually unmounts. Toggled by the visible-prop watcher below.
-  const internalVisibleRef = useRef(false);
-
-  const closeRef = useRef(onClose);
-  useEffect(() => {
-    closeRef.current = onClose;
-  });
-
-  // Spring config that matches AutoHighlightTooltip (the verse-insight
-  // modal) for a consistent feel across both bottom sheets.
-  const SPRING_CONFIG = {
-    damping: 20,
-    stiffness: 90,
-    overshootClamping: true,
-    restDisplacementThreshold: 0.5,
-    restSpeedThreshold: 0.5,
-  };
-
-  const animateOpen = () => {
-    internalVisibleRef.current = true;
-    Animated.timing(backdropOpacity, {
-      toValue: 1,
-      duration: 200,
-      useNativeDriver: true,
-    }).start();
-    translateY.value = withSpring(0, SPRING_CONFIG);
-  };
-
-  const animateClose = () => {
-    Animated.timing(backdropOpacity, {
-      toValue: 0,
-      duration: 200,
-      useNativeDriver: true,
-    }).start();
-    translateY.value = withSpring(screenHeight, SPRING_CONFIG);
-    setTimeout(() => {
-      internalVisibleRef.current = false;
-    }, 250);
-  };
-
-  // Drive animations off the `visible` prop. Open on mount, close on
-  // visible → false. The close path calls onClose synchronously so the
-  // parent (ChapterReader) can clear its activeLexicon state.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: animateOpen/animateClose/translateY/backdropOpacity/screenHeight are stable refs and closure-captured constants
   useEffect(() => {
     if (visible) {
-      translateY.value = screenHeight;
-      backdropOpacity.setValue(0);
-      animateOpen();
-    } else if (internalVisibleRef.current) {
-      animateClose();
+      sheetRef.current?.present();
+    } else {
+      sheetRef.current?.dismiss();
     }
   }, [visible]);
 
-  // ── Drag-to-dismiss ────────────────────────────────────────────────
-  // The standard "bottom sheet over a ScrollView" recipe from
-  // react-native-gesture-handler:
-  //
-  //   • `scrollNativeGesture` represents the ScrollView's own native
-  //     scroll handler — we acknowledge it explicitly so the pan can
-  //     coexist with vertical scrolling.
-  //   • `panGesture.activeOffsetY([3, Infinity])` activates the pan as
-  //     soon as the finger moves DOWN 3px. Below that the ScrollView
-  //     keeps its touches; above it the pan takes over with minimal
-  //     visible jump.
-  //   • Inside `onUpdate`, drag-translate is gated on `scrollOffset <= 0`
-  //     so dragging down while mid-scroll just scrolls (the modal
-  //     stays put). Once you're back at the top, drag-down dismisses
-  //     from anywhere on the sheet.
-  //
-  // Gestures + animated styles are memoized so they're stable across
-  // renders — recreating them every render causes RNGH to re-initialize
-  // each frame, which on a 120Hz Android display reads as choppy drag.
-  const scrollHandler = useAnimatedScrollHandler({
-    onScroll: (event) => {
-      scrollOffset.value = event.contentOffset.y;
-    },
-  });
+  // Fired when the modal is dismissed (backdrop tap or downward pan
+  // past close threshold). Forward to the consumer's `onClose` so the
+  // parent (ChapterReader) can clear its `activeLexicon` state.
+  const handleDismiss = useCallback(() => {
+    onClose();
+  }, [onClose]);
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: scrollOffset/translateY/startedAtTop are stable Reanimated SharedValue refs (their identity never changes across renders); closeRef.current is read inside the worklet via the local `close` closure; the empty-dep array is intentional so the gesture instance stays stable across renders.
-  const { panGesture, scrollNativeGesture } = useMemo(() => {
-    const close = () => closeRef.current();
-    const scrollNative = Gesture.Native();
-    const pan = Gesture.Pan()
-      // 1px threshold makes the Pan trivially activate even on quick
-      // fingertip flicks — Andy reported (2026-05-22) that real-iPhone
-      // fast swipes intermittently failed to dismiss because the
-      // previous 3px threshold races the iOS ScrollView's own pan
-      // recognizer and sometimes loses (the touch lifts before the
-      // 3px threshold is crossed). 1px is small enough that any
-      // intentional downward gesture clears it.
-      .activeOffsetY([1, Infinity])
-      .simultaneousWithExternalGesture(scrollNative)
-      .onBegin(() => {
-        'worklet';
-        // Freeze the "was at top?" check for this whole gesture so the
-        // gate doesn't flip when the user scrolls past zero mid-gesture.
-        startedAtTop.value = scrollOffset.value <= 0;
-      })
-      .onUpdate((e) => {
-        'worklet';
-        if (startedAtTop.value && e.translationY > 0) {
-          translateY.value = e.translationY;
-        }
-      })
-      .onEnd((e) => {
-        'worklet';
-        // Dismiss if EITHER:
-        //   • the user dragged a meaningful distance (translationY > 50), OR
-        //   • the user clearly flicked downward — requires BOTH a real
-        //     translation (> 10px) AND high velocity (> 800 px/s).
-        // The earlier thresholds (translationY > 0, velocityY > 500)
-        // misfired on real-iPhone fingertip taps inside the modal:
-        // touch contact-patch jitter produces ~1-3px of downward
-        // translation, and natural lift-off velocity is often
-        // 300-700 px/s, which previously read as "flick to dismiss"
-        // and closed the modal under the user's finger. Andy reported
-        // this as "drag stopped working altogether" 2026-05-22; the
-        // iOS simulator doesn't reproduce because mouse-cursor input
-        // has zero contact jitter.
-        const draggedFar = e.translationY > 50;
-        const flicked = e.translationY > 10 && e.velocityY > 800;
-        if (startedAtTop.value && (draggedFar || flicked)) {
-          runOnJS(close)();
-        } else {
-          translateY.value = withSpring(0, SPRING_CONFIG);
-        }
-      });
-    return { panGesture: pan, scrollNativeGesture: scrollNative };
-  }, []);
-
-  const sheetAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: translateY.value }],
-  }));
+  const renderBackdrop = useCallback(
+    (props: BottomSheetBackdropProps) => (
+      <BottomSheetBackdrop
+        {...props}
+        appearsOnIndex={0}
+        disappearsOnIndex={-1}
+        opacity={0.55}
+        pressBehavior="close"
+      />
+    ),
+    []
+  );
 
   const contextual = token.contextual;
   const lemmaIsHebrew = isHebrew(entry.lemma);
 
   return (
-    <Modal
-      visible={visible || internalVisibleRef.current}
-      transparent
-      animationType="none"
-      onRequestClose={onClose}
-      statusBarTranslucent
+    <BottomSheetModal
+      ref={sheetRef}
+      snapPoints={snapPoints}
+      onDismiss={handleDismiss}
+      enablePanDownToClose
+      enableDynamicSizing={false}
+      backdropComponent={renderBackdrop}
+      backgroundStyle={styles.background}
+      handleIndicatorStyle={styles.handleIndicator}
+      handleStyle={styles.handle}
+      // gorhom's native gesture handlers handle drag-to-dismiss from
+      // anywhere on the sheet — including over the ScrollView body —
+      // because it patches the inner scroll handler to coordinate with
+      // the pan worklet on the UI thread.
+      accessibilityLabel="Lexicon entry"
     >
-      {/* GestureHandlerRootView is REQUIRED inside RN's <Modal> for any
-          react-native-gesture-handler gestures to fire — Modal creates a
-          separate native window that the outer GestureHandlerRootView
-          (in _layout.tsx) doesn't reach into. Same pattern is used by
-          BibleNavigationModal. */}
-      <GestureHandlerRootView style={styles.overlay}>
-        <View style={styles.overlay} pointerEvents="box-none" testID={testID}>
-          {/* Backdrop with fade */}
-          <Animated.View
-            style={[styles.backdrop, { opacity: backdropOpacity }]}
-            pointerEvents="auto"
-          >
-            <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
-          </Animated.View>
-
-          {/* Sliding sheet — the outer GestureDetector applies the
-              drag-to-dismiss pan to the ENTIRE sheet (handle, header,
-              AND the ScrollView body). The pan only activates after
-              10px of downward motion (so taps and short scrolls pass
-              through to the ScrollView), and drag-translate is gated
-              on `scrollOffset <= 0` so it doesn't interfere mid-scroll. */}
-          <GestureDetector gesture={panGesture}>
-            <Reanimated.View style={[styles.sheet, sheetAnimatedStyle]} pointerEvents="auto">
-              <View style={styles.dragArea}>
-                <View style={styles.handle} />
-              </View>
-
-              {/* HEADER */}
-              <View style={styles.header} testID={`${testID}-header`}>
-                <View style={styles.headerRow}>
-                  <Text
-                    style={[styles.lemma, lemmaIsHebrew && styles.lemmaRtl]}
-                    accessibilityRole="header"
-                  >
-                    {entry.lemma}
-                  </Text>
-                  <Text style={styles.translit}>{entry.translit}</Text>
-                </View>
-                <Text style={styles.metaLine}>
-                  {entry.pos} • {entry.strongs}
-                  {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
-                  {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
-                    ? ` • ${entry.otFrequency}× in OT`
-                    : ''}
-                  {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
-                    ? ` • ${entry.ntFrequency}× in NT`
-                    : ''}
-                </Text>
-              </View>
-
-              <GestureDetector gesture={scrollNativeGesture}>
-                <Reanimated.ScrollView
-                  style={styles.scroll}
-                  contentContainerStyle={styles.scrollContent}
-                  showsVerticalScrollIndicator={false}
-                  onScroll={scrollHandler}
-                  scrollEventThrottle={16}
-                  // iOS-only: kill the overscroll rubber-band so dragging
-                  // the modal down from scrollOffset=0 isn't accompanied
-                  // by the ScrollView dropping its content down too.
-                  // The pan IS the bounce in our UX.
-                  bounces={false}
-                  // Android parity — no overscroll glow on pull-down.
-                  overScrollMode="never"
-                >
-                  {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
-                  {contextual ? (
-                    <Section
-                      label="In this verse"
-                      highlight
-                      styles={styles}
-                      testID={`${testID}-contextual`}
-                    >
-                      <Text style={styles.bodyText}>{contextual}</Text>
-                    </Section>
-                  ) : null}
-
-                  {/* BASIC SENSE */}
-                  <Section label="Basic sense" styles={styles} testID={`${testID}-basic`}>
-                    <Text style={styles.bodyText}>{entry.basicGloss}</Text>
-                  </Section>
-
-                  {/* SEMANTIC RANGE */}
-                  {entry.semanticRange && entry.semanticRange.length > 0 ? (
-                    <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
-                      <View style={styles.listWrap}>
-                        {entry.semanticRange.map((s) => (
-                          <View key={s} style={styles.listRow}>
-                            <Text style={styles.listBullet}>•</Text>
-                            <Text style={styles.listText}>{s}</Text>
-                          </View>
-                        ))}
-                      </View>
-                    </Section>
-                  ) : null}
-
-                  {/* RELATED WORDS */}
-                  {entry.related && entry.related.length > 0 ? (
-                    <Section label="Related" styles={styles} testID={`${testID}-related`}>
-                      <View style={styles.relatedWrap}>
-                        {entry.related.map((r, i) => {
-                          const rIsHebrew = isHebrew(r.lemma);
-                          return (
-                            <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
-                              <View style={styles.relatedHeadRow}>
-                                <Text style={[styles.relatedLemma, rIsHebrew && styles.lemmaRtl]}>
-                                  {r.lemma}
-                                </Text>
-                                <Text style={styles.relatedTranslit}>{r.translit}</Text>
-                              </View>
-                              <Text style={styles.relatedNote}>{r.note}</Text>
-                            </View>
-                          );
-                        })}
-                      </View>
-                    </Section>
-                  ) : null}
-
-                  {/* LEXICAL NOTE */}
-                  {entry.notes ? (
-                    <Section label="Lexical note" styles={styles} testID={`${testID}-notes`}>
-                      <Text style={styles.notesText}>{entry.notes}</Text>
-                    </Section>
-                  ) : null}
-
-                  {/* LOADED CAVEAT — no border, last row */}
-                  {entry.loaded ? (
-                    <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
-                      <Text style={styles.caveatText}>
-                        Context-sensitive: this word carries multiple senses across the NT. Meaning
-                        is governed by usage, not a single gloss.
-                      </Text>
-                    </View>
-                  ) : null}
-                </Reanimated.ScrollView>
-              </GestureDetector>
-            </Reanimated.View>
-          </GestureDetector>
+      {/* Header lives INSIDE the BottomSheetScrollView as its first
+          child, with stickyHeaderIndices={[0]} to keep it pinned while
+          the body scrolls. Earlier attempt with a flex wrapper around
+          BottomSheetView + BottomSheetScrollView broke gorhom's
+          internal scroll/pan worklet coordination — the ScrollView
+          stopped scrolling. Direct-child placement is what the library
+          expects. */}
+      <BottomSheetScrollView contentContainerStyle={styles.scrollContent} stickyHeaderIndices={[0]}>
+        {/* HEADER — pinned via stickyHeaderIndices */}
+        <View style={styles.header} testID={`${testID}-header`}>
+          <View style={styles.headerRow}>
+            <Text
+              style={[styles.lemma, lemmaIsHebrew && styles.lemmaRtl]}
+              accessibilityRole="header"
+            >
+              {entry.lemma}
+            </Text>
+            <Text style={styles.translit}>{entry.translit}</Text>
+          </View>
+          <Text style={styles.metaLine}>
+            {entry.pos} • {entry.strongs}
+            {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
+            {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
+              ? ` • ${entry.otFrequency}× in OT`
+              : ''}
+            {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
+              ? ` • ${entry.ntFrequency}× in NT`
+              : ''}
+          </Text>
         </View>
-      </GestureHandlerRootView>
-    </Modal>
+
+        {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
+        {contextual ? (
+          <Section label="In this verse" highlight styles={styles} testID={`${testID}-contextual`}>
+            <Text style={styles.bodyText}>{contextual}</Text>
+          </Section>
+        ) : null}
+
+        {/* BASIC SENSE */}
+        <Section label="Basic sense" styles={styles} testID={`${testID}-basic`}>
+          <Text style={styles.bodyText}>{entry.basicGloss}</Text>
+        </Section>
+
+        {/* SEMANTIC RANGE */}
+        {entry.semanticRange && entry.semanticRange.length > 0 ? (
+          <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
+            <View style={styles.listWrap}>
+              {entry.semanticRange.map((s) => (
+                <View key={s} style={styles.listRow}>
+                  <Text style={styles.listBullet}>•</Text>
+                  <Text style={styles.listText}>{s}</Text>
+                </View>
+              ))}
+            </View>
+          </Section>
+        ) : null}
+
+        {/* RELATED WORDS */}
+        {entry.related && entry.related.length > 0 ? (
+          <Section label="Related" styles={styles} testID={`${testID}-related`}>
+            <View style={styles.relatedWrap}>
+              {entry.related.map((r, i) => {
+                const rIsHebrew = isHebrew(r.lemma);
+                return (
+                  <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
+                    <View style={styles.relatedHeadRow}>
+                      <Text style={[styles.relatedLemma, rIsHebrew && styles.lemmaRtl]}>
+                        {r.lemma}
+                      </Text>
+                      <Text style={styles.relatedTranslit}>{r.translit}</Text>
+                    </View>
+                    <Text style={styles.relatedNote}>{r.note}</Text>
+                  </View>
+                );
+              })}
+            </View>
+          </Section>
+        ) : null}
+
+        {/* LEXICAL NOTE */}
+        {entry.notes ? (
+          <Section label="Lexical note" styles={styles} testID={`${testID}-notes`}>
+            <Text style={styles.notesText}>{entry.notes}</Text>
+          </Section>
+        ) : null}
+
+        {/* LOADED CAVEAT — no border, last row */}
+        {entry.loaded ? (
+          <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
+            <Text style={styles.caveatText}>
+              Context-sensitive: this word carries multiple senses across the NT. Meaning is
+              governed by usage, not a single gloss.
+            </Text>
+          </View>
+        ) : null}
+      </BottomSheetScrollView>
+    </BottomSheetModal>
   );
 }
 
@@ -392,54 +243,40 @@ function Section({ label, highlight, styles, testID, children }: SectionProps) {
 
 // ─── Styles ─────────────────────────────────────────────────────────────
 
-const createStyles = (
-  colors: ReturnType<typeof getColors>,
-  insets: { bottom: number; top: number; left: number; right: number }
-) =>
+const createStyles = (colors: ReturnType<typeof getColors>) =>
   StyleSheet.create({
-    overlay: {
-      flex: 1,
-      justifyContent: 'flex-end',
-    },
-    backdrop: {
-      ...StyleSheet.absoluteFillObject,
-      backgroundColor: 'rgba(0,0,0,0.55)',
-    },
-    sheet: {
+    // BottomSheet background — replaces our old `sheet` style. Color +
+    // top corner radius mirror the previous custom modal.
+    background: {
       backgroundColor: colors.backgroundElevated,
       borderTopLeftRadius: 16,
       borderTopRightRadius: 16,
-      maxHeight: '85%',
-      paddingBottom: insets.bottom > 0 ? insets.bottom : spacing.md,
     },
-
-    // Drag area + handle — the visual notch is the obvious affordance, so
-    // we keep the touch target generous (lg/md padding) and bump the notch
-    // to 48×5 so it reads as "grab here" from arm's length. The whole
-    // sheet is draggable too via the RNGH pan, but Andy 2026-05-22
-    // signalled most users still aim for the notch — so make THAT a
-    // forgiving target.
-    dragArea: {
-      alignItems: 'center',
-      paddingTop: spacing.lg,
-      paddingBottom: spacing.md,
-    },
-    handle: {
+    // Drag indicator (the notch). 48×5 matches Andy's "make the top
+    // bigger to grab" feedback — same as the previous custom handle.
+    handleIndicator: {
       width: 48,
       height: 5,
       borderRadius: 3,
       backgroundColor: colors.gray100,
     },
-
-    scroll: {
-      flexGrow: 0,
+    // The handle container that gorhom renders above the body. Extra
+    // padding here makes the touch target larger (the whole top strip
+    // is draggable).
+    handle: {
+      paddingTop: spacing.md,
+      paddingBottom: spacing.sm,
     },
+
     scrollContent: {
-      paddingBottom: spacing.md,
+      paddingBottom: spacing.lg,
     },
 
-    // Header
+    // Header — `stickyHeaderIndices={[0]}` on the ScrollView pins this
+    // at the top while body content scrolls beneath. backgroundColor is
+    // required so the scrolling sections don't show through.
     header: {
+      backgroundColor: colors.backgroundElevated,
       paddingHorizontal: spacing.lg,
       paddingTop: spacing.md,
       paddingBottom: spacing.sm,

--- a/components/bible/SimpleChapterPager.tsx
+++ b/components/bible/SimpleChapterPager.tsx
@@ -145,6 +145,14 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
 
     useEffect(() => clearPendingTimer, []);
 
+    // While a programmatic setPageWithoutAnimation is settling, the native
+    // ViewPager fires `onPageSelected` for intermediate positions. Without
+    // this guard, the very first reposition lands on position=0 (the prev
+    // slot) and gets mistaken for a swipe — kicks navigateToChapter back
+    // to the previous chapter (e.g. dropdown → James 1 silently rewinds
+    // to Hebrews 13). See bug repro 2026-05-24.
+    const programmaticTargetRef = useRef<number | null>(null);
+
     // Reset pager position to center after props change (parent navigated). Runs in
     // useLayoutEffect so the setPageWithoutAnimation lands in the same paint frame as
     // the children-array swap. With useDeferredValue on the parent, the heavy commit
@@ -156,6 +164,9 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
       if (prevChapterKey.current === currentKey) return;
       prevChapterKey.current = currentKey;
       const targetIndex = canGoPrevious ? PAGE_CURRENT_MIDDLE : 0;
+      // Suppress pageSelected handling until the pager actually lands on
+      // the target index — see programmaticTargetRef.
+      programmaticTargetRef.current = targetIndex;
       pagerRef.current?.setPageWithoutAnimation(targetIndex);
     }, [bookId, chapterNumber, canGoPrevious]);
 
@@ -187,6 +198,18 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
      */
     const handlePageSelected = (event: { nativeEvent: { position: number } }) => {
       const newPosition = event.nativeEvent.position;
+
+      // If a programmatic reposition is in flight, swallow page-selected
+      // events until we land on the target index. Without this, the
+      // intermediate position emitted during setPageWithoutAnimation
+      // (often position=0) gets treated as a user swipe and triggers
+      // a phantom navigateToChapter to the prev/next chapter.
+      if (programmaticTargetRef.current !== null) {
+        if (newPosition === programmaticTargetRef.current) {
+          programmaticTargetRef.current = null;
+        }
+        return;
+      }
 
       if (canGoPrevious && canGoNext) {
         // 3 pages: [prev, current, next]

--- a/components/bible/VisualsPanel.tsx
+++ b/components/bible/VisualsPanel.tsx
@@ -516,6 +516,13 @@ export function VisualsPanel({
         animationType="fade"
         onRequestClose={closeLightbox}
         statusBarTranslucent
+        // iOS-only: without this, the Modal defaults its
+        // UISupportedInterfaceOrientations to portrait, which overrides the
+        // app-level Info.plist declaration and snaps the device back to
+        // portrait when the lightbox opens — even when the Visuals tab
+        // was already rotated to landscape. Allowing both lets the user
+        // keep landscape on tap-to-open (Andy iOS-only repro 2026-05-22).
+        supportedOrientations={['portrait', 'landscape']}
       >
         {/* GestureHandlerRootView is REQUIRED inside RN's <Modal> for any
             react-native-gesture-handler gestures to fire — Modal creates

--- a/contexts/BibleInteractionContext.tsx
+++ b/contexts/BibleInteractionContext.tsx
@@ -135,9 +135,9 @@ export function BibleInteractionProvider({
     if (verseTooltipState.verseNumber) {
       // Close tooltip and open color picker
       setVerseTooltipState(prev => ({ ...prev, visible: false }));
-      
-      setColorPickerState({ 
-          visible: true, 
+
+      setColorPickerState({
+          visible: true,
           verseNumber: verseTooltipState.verseNumber,
           text: verseTooltipState.verseText
       });
@@ -165,7 +165,7 @@ export function BibleInteractionProvider({
 
   const handleColorPickerSave = async (color: HighlightColor) => {
     if (!colorPickerState.verseNumber) return;
-    
+
     const verseNum = colorPickerState.verseNumber;
     setColorPickerState(prev => ({ ...prev, visible: false }));
 
@@ -176,7 +176,7 @@ export function BibleInteractionProvider({
         startVerse: verseNum,
         endVerse: verseNum,
         color,
-        selectedText: colorPickerState.text || `Verse ${verseNum}`, 
+        selectedText: colorPickerState.text || `Verse ${verseNum}`,
       });
       showToast('Highlight saved!');
     } catch (error) {

--- a/hooks/bible/use-highlights.ts
+++ b/hooks/bible/use-highlights.ts
@@ -406,7 +406,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
       // Re-throw error for component to handle (especially overlap errors)
       throw error;
     },
-    onSuccess: (data, variables) => {
+    onSuccess: async (data, variables) => {
       try {
         // Track analytics: HIGHLIGHT_CREATED event
         if (variables.body) {
@@ -454,13 +454,36 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
           }
         }
       } finally {
-        // Only invalidate offline fallback caches — chapter/all caches are already up to date
-        if (!isOnline) {
-          queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
-          queryClient.invalidateQueries({
-            queryKey: ['local-chapter-highlights-offline-fallback'],
-          });
+        // When online + isUserDataSynced=true (the default once initial
+        // sync is done), the UI reads from localChapterHighlights, not
+        // from the remote query cache the optimistic update wrote to.
+        // We MUST persist the server-confirmed highlight into local
+        // SQLite and invalidate the local-fallback query so the reader
+        // sees the new row. Without this the modal closes, the API
+        // call succeeds, and the user observes nothing — regression
+        // introduced by PR #268 (read local data when synced).
+        const serverHighlightForLocal = (data as { highlight?: Highlight })?.highlight;
+        if (isOnline && serverHighlightForLocal) {
+          try {
+            await addLocalHighlight({
+              highlight_id: serverHighlightForLocal.highlight_id,
+              book_id: serverHighlightForLocal.book_id,
+              chapter_number: serverHighlightForLocal.chapter_number,
+              start_verse: serverHighlightForLocal.start_verse,
+              end_verse: serverHighlightForLocal.end_verse,
+              color: serverHighlightForLocal.color,
+              start_char: (serverHighlightForLocal.start_char as number | null) ?? null,
+              end_char: (serverHighlightForLocal.end_char as number | null) ?? null,
+              updated_at: serverHighlightForLocal.created_at ?? new Date().toISOString(),
+            });
+          } catch (e) {
+            console.warn('[highlights] local mirror after add failed:', e);
+          }
         }
+        queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
+        queryClient.invalidateQueries({
+          queryKey: ['local-chapter-highlights-offline-fallback'],
+        });
       }
     },
   });
@@ -562,7 +585,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
       console.error('Failed to update highlight color:', error);
       showToast('Failed to update highlight. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       try {
         // Track analytics: HIGHLIGHT_EDITED event
         if (variables.body && variables.path) {
@@ -572,13 +595,23 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
           });
         }
       } finally {
-        // Invalidate in finally to ensure cache consistency even if analytics throws
-        if (!isOnline) {
-          queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
-          queryClient.invalidateQueries({
-            queryKey: ['local-chapter-highlights-offline-fallback'],
-          });
+        // See addMutation's onSuccess — online + locally-synced UI
+        // reads from local SQLite, so mirror the color change there
+        // and invalidate the local-fallback query.
+        if (isOnline && variables.path && variables.body) {
+          try {
+            await updateLocalHighlightColor(
+              variables.path.highlight_id,
+              variables.body.color || 'yellow'
+            );
+          } catch (e) {
+            console.warn('[highlights] local mirror after color update failed:', e);
+          }
         }
+        queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
+        queryClient.invalidateQueries({
+          queryKey: ['local-chapter-highlights-offline-fallback'],
+        });
       }
     },
   });
@@ -655,7 +688,7 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
       console.error('Failed to delete highlight:', error);
       showToast('Failed to remove highlight. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       try {
         // Track analytics: HIGHLIGHT_DELETED event
         if (variables.path) {
@@ -664,13 +697,20 @@ export function useHighlights(options?: UseHighlightsOptions): UseHighlightsResu
           });
         }
       } finally {
-        // Invalidate in finally to ensure cache consistency even if analytics throws
-        if (!isOnline) {
-          queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
-          queryClient.invalidateQueries({
-            queryKey: ['local-chapter-highlights-offline-fallback'],
-          });
+        // See addMutation's onSuccess for the rationale — the online
+        // path must also remove from local SQLite + invalidate the
+        // local-fallback query when isUserDataSynced reads from local.
+        if (isOnline && variables.path) {
+          try {
+            await deleteLocalHighlight(variables.path.highlight_id);
+          } catch (e) {
+            console.warn('[highlights] local mirror after delete failed:', e);
+          }
         }
+        queryClient.invalidateQueries({ queryKey: ['local-all-highlights-offline-fallback'] });
+        queryClient.invalidateQueries({
+          queryKey: ['local-chapter-highlights-offline-fallback'],
+        });
       }
     },
   });

--- a/hooks/names-of-god/use-verse-texts.ts
+++ b/hooks/names-of-god/use-verse-texts.ts
@@ -1,0 +1,64 @@
+import { useQueries } from '@tanstack/react-query';
+import { getBibleBookByBookIdByChapterNumberOptions } from '@/src/api/generated/@tanstack/react-query.gen';
+import type { ParsedVerseRef } from '@/utils/names-of-god/parse-verse-ref';
+
+export interface VerseTextResult {
+  ref: ParsedVerseRef;
+  text: string | null;
+  isLoading: boolean;
+  hasError: boolean;
+}
+
+/**
+ * Fetches verse text for a page of parsed verse refs in the user's selected
+ * Bible version. Deduplicates chapter fetches so one chapter is only fetched
+ * once even if multiple verses from it appear on the page.
+ */
+export function useVerseTexts(refs: ParsedVerseRef[], bibleVersion: string): VerseTextResult[] {
+  // Unique (bookId, chapter) pairs for this page
+  const uniqueChapters = Array.from(
+    new Map(refs.map((r) => [`${r.bookId}-${r.chapter}`, r])).values()
+  ).map((r) => ({ bookId: r.bookId, chapter: r.chapter }));
+
+  const results = useQueries({
+    queries: uniqueChapters.map(({ bookId, chapter }) =>
+      getBibleBookByBookIdByChapterNumberOptions({
+        path: { bookId, chapterNumber: chapter },
+        query: { versionKey: bibleVersion },
+      })
+    ),
+  });
+
+  // Build lookup: "bookId-chapter" → verse array
+  const chapterVersesMap = new Map<string, { verseNumber: number; text: string }[]>();
+  uniqueChapters.forEach(({ bookId, chapter }, i) => {
+    const result = results[i];
+    if (!result?.data) return;
+    const book = (
+      result.data as {
+        book?: {
+          chapters?: { chapterNumber: number; verses: { verseNumber: number; text: string }[] }[];
+        };
+      }
+    ).book;
+    const ch = book?.chapters?.find((c) => c.chapterNumber === chapter);
+    if (ch) {
+      chapterVersesMap.set(`${bookId}-${chapter}`, ch.verses);
+    }
+  });
+
+  return refs.map((ref) => {
+    const key = `${ref.bookId}-${ref.chapter}`;
+    const idx = uniqueChapters.findIndex((c) => `${c.bookId}-${c.chapter}` === key);
+    const queryResult = idx >= 0 ? results[idx] : undefined;
+    const verses = chapterVersesMap.get(key);
+    const verseData = verses?.find((v) => v.verseNumber === ref.verse);
+
+    return {
+      ref,
+      text: verseData?.text ?? null,
+      isLoading: queryResult?.isLoading ?? false,
+      hasError: !!(queryResult?.isError && !verseData),
+    };
+  });
+}

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -8,15 +8,18 @@
  *   3. Device locale via `expo-localization`
  *   4. Fallback: 'en'
  *
- * Currently English-only. Other locale catalogs ship as `locales/<code>.json`
- * via the translation pipeline (out of scope for the initial setup).
+ * Supported locales: en, es, fr, de, pt. All catalogs bundled statically.
  */
 
 import * as Localization from 'expo-localization';
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import de from '../../locales/de.json';
 import en from '../../locales/en.json';
+import es from '../../locales/es.json';
+import fr from '../../locales/fr.json';
+import pt from '../../locales/pt.json';
 
 export const FALLBACK_LANGUAGE = 'en';
 
@@ -39,7 +42,10 @@ export async function initI18n(initialLanguage?: string): Promise<typeof i18next
   await i18next.use(initReactI18next).init({
     resources: {
       en: { translation: en },
-      // Other locales loaded lazily as they ship.
+      es: { translation: es },
+      fr: { translation: fr },
+      de: { translation: de },
+      pt: { translation: pt },
     },
     lng: initialLanguage ?? detectInitialLanguage(),
     fallbackLng: FALLBACK_LANGUAGE,

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "German",
+    "code": "de",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Anmelden",
+      "welcome_back": "Willkommen zurück",
+      "subtitle": "Melde dich in deinem Konto an",
+      "email_label": "E-Mail-Adresse",
+      "email_placeholder": "du@beispiel.com",
+      "password_label": "Passwort",
+      "submit": "Anmelden",
+      "forgot_password": "Passwort vergessen?",
+      "no_account": "Kein Konto?",
+      "create_account": "Neues Konto erstellen",
+      "continue_without": "Ohne Konto fortfahren",
+      "or_continue_with": "oder fortfahren mit"
+    },
+    "signup": {
+      "title": "Konto erstellen",
+      "subtitle": "Bitte gib die folgenden Informationen an, um dein Konto einzurichten.",
+      "first_name_label": "Vorname",
+      "last_name_label": "Nachname",
+      "email_label": "E-Mail-Adresse",
+      "password_label": "Passwort",
+      "submit": "Konto erstellen",
+      "have_account": "Hast du bereits ein Konto?",
+      "sign_in": "Anmelden"
+    },
+    "errors": {
+      "invalid_credentials": "Ungültige E-Mail-Adresse oder ungültiges Passwort",
+      "rate_limited": "Zu viele Versuche. Versuche es in einer Minute erneut.",
+      "network_error": "Netzwerkfehler. Überprüfe deine Verbindung."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Überspringen",
+    "next": "Weiter",
+    "get_started": "Loslegen",
+    "login": "Anmelden"
+  },
+
+  "settings": {
+    "title": "Einstellungen",
+    "account": "Konto",
+    "preferences": "Einstellungen",
+    "storage": "Speicher",
+    "help": "Hilfe",
+    "logout": "Abmelden",
+    "logout_confirm_title": "Abmelden",
+    "logout_confirm_message": "Bist du sicher, dass du dich abmelden möchtest?",
+    "delete_account": "Konto löschen",
+    "delete_account_a11y": "Konto dauerhaft löschen",
+    "delete_account_hint": "Diese Aktion kann nicht rückgängig gemacht werden",
+    "language": "Sprache",
+    "language_preferences": "Spracheinstellungen",
+    "select_language": "Sprache auswählen",
+    "theme": "Design",
+    "theme_auto": "Automatisch",
+    "theme_light": "Hell",
+    "theme_dark": "Dunkel",
+    "font_size": "Schriftgröße",
+    "bible_version": "Bibelversion",
+    "select_version": "Version auswählen",
+    "auto_highlights": "Automatische Markierungen",
+    "manage_downloads": "Downloads verwalten",
+    "manage_downloads_a11y": "Offline-Downloads verwalten",
+    "manage_downloads_subtitle": "Inhalte für die Offline-Nutzung herunterladen",
+    "downloads_offline": "Downloads und Offline",
+    "profile_information": "Profilinformationen",
+    "profile_details": "Profildetails",
+    "profile_subtext": "Persönliche Informationen aktualisieren",
+    "first_name": "Vorname",
+    "last_name": "Nachname",
+    "email": "E-Mail-Adresse",
+    "first_name_placeholder": "Vorname eingeben",
+    "last_name_placeholder": "Nachname eingeben",
+    "email_placeholder": "E-Mail-Adresse eingeben",
+    "go_back": "Zurück",
+    "sign_in_message": "Melde dich an, um automatische Markierungen und Profileinstellungen zu nutzen.",
+    "errors": {
+      "save_bible_version": "Bibelversion konnte nicht gespeichert werden",
+      "save_language": "Spracheinstellung konnte nicht gespeichert werden"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Kapitel wird geladen…",
+    "error": "Dieses Kapitel konnte nicht geladen werden. Tippe zum Wiederholen.",
+    "view_bible": "Bibel",
+    "view_insight": "Einblick",
+    "tab_summary": "Zusammenfassung",
+    "tab_byline": "Versweise",
+    "tab_detailed": "Detailliert",
+    "no_translation_available": "Englisch wird angezeigt (keine Übersetzung verfügbar)",
+    "offline_indicator": "Offline — zwischengespeicherte Inhalte werden angezeigt"
+  },
+
+  "bookmarks": {
+    "title": "Lesezeichen",
+    "empty": "Noch keine Lesezeichen. Tippe beim Lesen auf das Lesezeichen-Symbol.",
+    "empty_title": "Noch keine mit Lesezeichen versehenen Kapitel",
+    "empty_subtitle": "Tippe beim Lesen auf das Lesezeichen-Symbol, um Kapitel für später zu speichern.",
+    "login_required": "Bitte melde dich an, um deine Lesezeichen anzuzeigen",
+    "login_subtitle": "Melde dich an, um deine Lieblings-Bibelkapitel zu speichern und abzurufen",
+    "remove_confirm": "Dieses Lesezeichen entfernen?"
+  },
+
+  "highlights": {
+    "title": "Markierungen",
+    "empty": "Noch keine Markierungen. Halte einen Vers gedrückt und wähle eine Farbe.",
+    "empty_title": "Noch keine Markierungen",
+    "empty_subtitle": "Beginne damit, Verse zu markieren, um sie hier anzuzeigen.",
+    "auto_highlights": "Automatische Markierungen",
+    "my_highlights": "Meine Markierungen",
+    "remove_confirm": "Diese Markierung entfernen?"
+  },
+
+  "notes": {
+    "title": "Notizen",
+    "empty": "Noch keine Notizen. Tippe auf einen Vers, um eine hinzuzufügen.",
+    "empty_title": "Noch keine Notizen",
+    "empty_subtitle": "Beginne damit, Notizen beim Lesen zu machen, um sie hier anzuzeigen.",
+    "login_required": "Bitte melde dich an, um deine Notizen anzuzeigen",
+    "login_subtitle": "Melde dich an, um Bibelstudium-Notizen zu erstellen und abzurufen",
+    "edit": "Notiz bearbeiten",
+    "delete": "Notiz löschen",
+    "delete_confirm": "Diese Notiz löschen?",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "placeholder": "Notiz schreiben…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Ich lese {{book}} {{chapter}} — vielleicht gefällt es dir auch. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Ich habe das über {{topic}} gefunden und musste an dich denken. {{url}}"
+    },
+    "note": {
+      "title": "Notiz zu {{book}} {{chapter}}",
+      "body": "Eine Notiz, die ich zu {{book}} {{chapter}} gemacht habe:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "delete": "Löschen",
+    "confirm": "Bestätigen",
+    "retry": "Erneut versuchen",
+    "back": "Zurück",
+    "go_back": "Zurück",
+    "close": "Schließen",
+    "loading": "Wird geladen…",
+    "error": "Etwas ist schiefgelaufen",
+    "error_title": "Fehler",
+    "unknown_error": "Unbekannter Fehler"
+  },
+
+  "names_of_god": {
+    "title": "Namen Gottes",
+    "testament_ot": "Altes Testament",
+    "testament_nt": "Neues Testament",
+    "testament_both": "Beide Testamente",
+    "verses_count": "{{count}} Verse",
+    "page_label": "Seite {{current}} von {{total}}",
+    "previous_page": "Vorherige Seite",
+    "next_page": "Nächste Seite",
+    "loading_verses": "Verse werden geladen…",
+    "verse_error": "Verstext konnte nicht geladen werden",
+    "error_name_not_found": "Name nicht gefunden",
+    "error_name_not_found_detail": "Dieser Name konnte im Datensatz nicht gefunden werden.",
+    "go_back": "Zurück",
+    "language_hebrew": "Hebräisch",
+    "language_greek": "Griechisch",
+    "language_aramaic": "Aramäisch",
+    "language_english": "Englisch",
+    "search_placeholder": "Namen suchen…",
+    "filter_all": "Alle",
+    "names_count": "{{count}} Namen",
+    "no_results": "Kein Name entspricht deiner Suche."
+  }
+}

--- a/locales/en.json
+++ b/locales/en.json
@@ -185,6 +185,10 @@
     "language_hebrew": "Hebrew",
     "language_greek": "Greek",
     "language_aramaic": "Aramaic",
-    "language_english": "English"
+    "language_english": "English",
+    "search_placeholder": "Search names…",
+    "filter_all": "All",
+    "names_count": "{{count}} names",
+    "no_results": "No names match your search."
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -166,5 +166,25 @@
     "error": "Something went wrong",
     "error_title": "Error",
     "unknown_error": "Unknown error"
+  },
+
+  "names_of_god": {
+    "title": "Names of God",
+    "testament_ot": "Old Testament",
+    "testament_nt": "New Testament",
+    "testament_both": "Both Testaments",
+    "verses_count": "{{count}} verses",
+    "page_label": "Page {{current}} of {{total}}",
+    "previous_page": "Previous page",
+    "next_page": "Next page",
+    "loading_verses": "Loading verses…",
+    "verse_error": "Couldn't load verse text",
+    "error_name_not_found": "Name not found",
+    "error_name_not_found_detail": "This name could not be found in the dataset.",
+    "go_back": "Go back",
+    "language_hebrew": "Hebrew",
+    "language_greek": "Greek",
+    "language_aramaic": "Aramaic",
+    "language_english": "English"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "Spanish",
+    "code": "es",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Iniciar sesión",
+      "welcome_back": "Bienvenido de nuevo",
+      "subtitle": "Inicia sesión en tu cuenta",
+      "email_label": "Correo electrónico",
+      "email_placeholder": "tu@ejemplo.com",
+      "password_label": "Contraseña",
+      "submit": "Iniciar sesión",
+      "forgot_password": "¿Olvidaste tu contraseña?",
+      "no_account": "¿No tienes cuenta?",
+      "create_account": "Crear nueva cuenta",
+      "continue_without": "Continuar sin cuenta",
+      "or_continue_with": "o continuar con"
+    },
+    "signup": {
+      "title": "Crear cuenta",
+      "subtitle": "Por favor, proporciona la siguiente información para configurar tu cuenta.",
+      "first_name_label": "Nombre",
+      "last_name_label": "Apellido",
+      "email_label": "Correo electrónico",
+      "password_label": "Contraseña",
+      "submit": "Crear cuenta",
+      "have_account": "¿Ya tienes una cuenta?",
+      "sign_in": "Iniciar sesión"
+    },
+    "errors": {
+      "invalid_credentials": "Correo o contraseña incorrectos",
+      "rate_limited": "Demasiados intentos. Vuelve a intentarlo en un minuto.",
+      "network_error": "Error de red. Comprueba tu conexión."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Omitir",
+    "next": "Siguiente",
+    "get_started": "Comenzar",
+    "login": "Iniciar sesión"
+  },
+
+  "settings": {
+    "title": "Ajustes",
+    "account": "Cuenta",
+    "preferences": "Preferencias",
+    "storage": "Almacenamiento",
+    "help": "Ayuda",
+    "logout": "Cerrar sesión",
+    "logout_confirm_title": "Cerrar sesión",
+    "logout_confirm_message": "¿Estás seguro de que quieres cerrar sesión?",
+    "delete_account": "Eliminar cuenta",
+    "delete_account_a11y": "Eliminar cuenta permanentemente",
+    "delete_account_hint": "Esta acción no se puede deshacer",
+    "language": "Idioma",
+    "language_preferences": "Preferencias de idioma",
+    "select_language": "Seleccionar idioma",
+    "theme": "Tema",
+    "theme_auto": "Automático",
+    "theme_light": "Claro",
+    "theme_dark": "Oscuro",
+    "font_size": "Tamaño de fuente",
+    "bible_version": "Versión de la Biblia",
+    "select_version": "Seleccionar versión",
+    "auto_highlights": "Resaltados automáticos",
+    "manage_downloads": "Gestionar descargas",
+    "manage_downloads_a11y": "Gestionar descargas sin conexión",
+    "manage_downloads_subtitle": "Descarga contenido para uso sin conexión",
+    "downloads_offline": "Descargas y sin conexión",
+    "profile_information": "Información del perfil",
+    "profile_details": "Detalles del perfil",
+    "profile_subtext": "Actualiza tu información personal",
+    "first_name": "Nombre",
+    "last_name": "Apellido",
+    "email": "Correo electrónico",
+    "first_name_placeholder": "Ingresa tu nombre",
+    "last_name_placeholder": "Ingresa tu apellido",
+    "email_placeholder": "Ingresa tu correo electrónico",
+    "go_back": "Volver",
+    "sign_in_message": "Inicia sesión para acceder a los resaltados automáticos y la configuración del perfil.",
+    "errors": {
+      "save_bible_version": "Error al guardar la versión de la Biblia",
+      "save_language": "Error al guardar la preferencia de idioma"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Cargando capítulo…",
+    "error": "No se pudo cargar este capítulo. Toca para reintentar.",
+    "view_bible": "Biblia",
+    "view_insight": "Reflexión",
+    "tab_summary": "Resumen",
+    "tab_byline": "Por versículo",
+    "tab_detailed": "Detallado",
+    "no_translation_available": "Mostrando en inglés (traducción no disponible)",
+    "offline_indicator": "Sin conexión — mostrando contenido en caché"
+  },
+
+  "bookmarks": {
+    "title": "Marcadores",
+    "empty": "Aún no hay marcadores. Toca el ícono de marcador mientras lees.",
+    "empty_title": "Aún no hay capítulos marcados",
+    "empty_subtitle": "Toca el ícono de marcador mientras lees para guardar capítulos para más tarde.",
+    "login_required": "Por favor, inicia sesión para ver tus marcadores",
+    "login_subtitle": "Inicia sesión para guardar y acceder a tus capítulos favoritos de la Biblia",
+    "remove_confirm": "¿Eliminar este marcador?"
+  },
+
+  "highlights": {
+    "title": "Resaltados",
+    "empty": "Aún no hay resaltados. Mantén presionado un versículo y elige un color.",
+    "empty_title": "Aún no hay resaltados",
+    "empty_subtitle": "Comienza a resaltar versículos para verlos aquí.",
+    "auto_highlights": "Resaltados automáticos",
+    "my_highlights": "Mis resaltados",
+    "remove_confirm": "¿Eliminar este resaltado?"
+  },
+
+  "notes": {
+    "title": "Notas",
+    "empty": "Aún no hay notas. Toca un versículo para añadir una.",
+    "empty_title": "Aún no hay notas",
+    "empty_subtitle": "Comienza a tomar notas mientras lees capítulos para verlas aquí.",
+    "login_required": "Por favor, inicia sesión para ver tus notas",
+    "login_subtitle": "Inicia sesión para crear y acceder a tus notas de estudio bíblico",
+    "edit": "Editar nota",
+    "delete": "Eliminar nota",
+    "delete_confirm": "¿Eliminar esta nota?",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "placeholder": "Escribe tu nota…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Leyendo {{book}} {{chapter}} — creo que también te puede gustar. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Encontré esto sobre {{topic}} y pensé en ti. {{url}}"
+    },
+    "note": {
+      "title": "Nota sobre {{book}} {{chapter}}",
+      "body": "Una nota que hice sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "Aceptar",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "confirm": "Confirmar",
+    "retry": "Reintentar",
+    "back": "Atrás",
+    "go_back": "Volver",
+    "close": "Cerrar",
+    "loading": "Cargando…",
+    "error": "Algo salió mal",
+    "error_title": "Error",
+    "unknown_error": "Error desconocido"
+  },
+
+  "names_of_god": {
+    "title": "Nombres de Dios",
+    "testament_ot": "Antiguo Testamento",
+    "testament_nt": "Nuevo Testamento",
+    "testament_both": "Ambos Testamentos",
+    "verses_count": "{{count}} versículos",
+    "page_label": "Página {{current}} de {{total}}",
+    "previous_page": "Página anterior",
+    "next_page": "Página siguiente",
+    "loading_verses": "Cargando versículos…",
+    "verse_error": "No se pudo cargar el texto del versículo",
+    "error_name_not_found": "Nombre no encontrado",
+    "error_name_not_found_detail": "Este nombre no pudo encontrarse en el conjunto de datos.",
+    "go_back": "Volver",
+    "language_hebrew": "Hebreo",
+    "language_greek": "Griego",
+    "language_aramaic": "Arameo",
+    "language_english": "Inglés",
+    "search_placeholder": "Buscar nombres…",
+    "filter_all": "Todos",
+    "names_count": "{{count}} nombres",
+    "no_results": "Ningún nombre coincide con tu búsqueda."
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "French",
+    "code": "fr",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Connexion",
+      "welcome_back": "Bon retour",
+      "subtitle": "Connectez-vous à votre compte",
+      "email_label": "Adresse e-mail",
+      "email_placeholder": "vous@exemple.com",
+      "password_label": "Mot de passe",
+      "submit": "Se connecter",
+      "forgot_password": "Mot de passe oublié ?",
+      "no_account": "Pas de compte ?",
+      "create_account": "Créer un nouveau compte",
+      "continue_without": "Continuer sans compte",
+      "or_continue_with": "ou continuer avec"
+    },
+    "signup": {
+      "title": "Créer un compte",
+      "subtitle": "Veuillez fournir les informations suivantes pour configurer votre compte.",
+      "first_name_label": "Prénom",
+      "last_name_label": "Nom de famille",
+      "email_label": "Adresse e-mail",
+      "password_label": "Mot de passe",
+      "submit": "Créer un compte",
+      "have_account": "Vous avez déjà un compte ?",
+      "sign_in": "Se connecter"
+    },
+    "errors": {
+      "invalid_credentials": "Adresse e-mail ou mot de passe incorrect",
+      "rate_limited": "Trop de tentatives. Réessayez dans une minute.",
+      "network_error": "Erreur réseau. Vérifiez votre connexion."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Passer",
+    "next": "Suivant",
+    "get_started": "Commencer",
+    "login": "Se connecter"
+  },
+
+  "settings": {
+    "title": "Paramètres",
+    "account": "Compte",
+    "preferences": "Préférences",
+    "storage": "Stockage",
+    "help": "Aide",
+    "logout": "Se déconnecter",
+    "logout_confirm_title": "Déconnexion",
+    "logout_confirm_message": "Êtes-vous sûr de vouloir vous déconnecter ?",
+    "delete_account": "Supprimer le compte",
+    "delete_account_a11y": "Supprimer définitivement le compte",
+    "delete_account_hint": "Cette action est irréversible",
+    "language": "Langue",
+    "language_preferences": "Préférences de langue",
+    "select_language": "Sélectionner une langue",
+    "theme": "Thème",
+    "theme_auto": "Automatique",
+    "theme_light": "Clair",
+    "theme_dark": "Sombre",
+    "font_size": "Taille de police",
+    "bible_version": "Version de la Bible",
+    "select_version": "Sélectionner une version",
+    "auto_highlights": "Surlignage automatique",
+    "manage_downloads": "Gérer les téléchargements",
+    "manage_downloads_a11y": "Gérer les téléchargements hors ligne",
+    "manage_downloads_subtitle": "Téléchargez du contenu pour une utilisation hors ligne",
+    "downloads_offline": "Téléchargements et hors ligne",
+    "profile_information": "Informations du profil",
+    "profile_details": "Détails du profil",
+    "profile_subtext": "Mettez à jour vos informations personnelles",
+    "first_name": "Prénom",
+    "last_name": "Nom de famille",
+    "email": "Adresse e-mail",
+    "first_name_placeholder": "Entrez votre prénom",
+    "last_name_placeholder": "Entrez votre nom de famille",
+    "email_placeholder": "Entrez votre adresse e-mail",
+    "go_back": "Retour",
+    "sign_in_message": "Connectez-vous pour accéder au surlignage automatique et aux paramètres du profil.",
+    "errors": {
+      "save_bible_version": "Échec de l'enregistrement de la version de la Bible",
+      "save_language": "Échec de l'enregistrement de la préférence de langue"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Chargement du chapitre…",
+    "error": "Impossible de charger ce chapitre. Appuyez pour réessayer.",
+    "view_bible": "Bible",
+    "view_insight": "Réflexion",
+    "tab_summary": "Résumé",
+    "tab_byline": "Par verset",
+    "tab_detailed": "Détaillé",
+    "no_translation_available": "Affichage en anglais (aucune traduction disponible)",
+    "offline_indicator": "Hors ligne — affichage du contenu mis en cache"
+  },
+
+  "bookmarks": {
+    "title": "Signets",
+    "empty": "Aucun signet pour l'instant. Appuyez sur l'icône de signet pendant la lecture.",
+    "empty_title": "Aucun chapitre mis en signet",
+    "empty_subtitle": "Appuyez sur l'icône de signet pendant la lecture pour sauvegarder des chapitres.",
+    "login_required": "Veuillez vous connecter pour voir vos signets",
+    "login_subtitle": "Connectez-vous pour sauvegarder et accéder à vos chapitres bibliques favoris",
+    "remove_confirm": "Supprimer ce signet ?"
+  },
+
+  "highlights": {
+    "title": "Surlignages",
+    "empty": "Aucun surlignage pour l'instant. Appuyez longuement sur un verset et choisissez une couleur.",
+    "empty_title": "Aucun surlignage pour l'instant",
+    "empty_subtitle": "Commencez à surligner des versets pour les voir ici.",
+    "auto_highlights": "Surlignages automatiques",
+    "my_highlights": "Mes surlignages",
+    "remove_confirm": "Supprimer ce surlignage ?"
+  },
+
+  "notes": {
+    "title": "Notes",
+    "empty": "Aucune note pour l'instant. Appuyez sur un verset pour en ajouter une.",
+    "empty_title": "Aucune note pour l'instant",
+    "empty_subtitle": "Commencez à prendre des notes pendant la lecture pour les voir ici.",
+    "login_required": "Veuillez vous connecter pour voir vos notes",
+    "login_subtitle": "Connectez-vous pour créer et accéder à vos notes d'étude biblique",
+    "edit": "Modifier la note",
+    "delete": "Supprimer la note",
+    "delete_confirm": "Supprimer cette note ?",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "placeholder": "Rédigez votre note…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Je lis {{book}} {{chapter}} — je pense que ça pourrait vous plaire aussi. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "J'ai trouvé ceci sur {{topic}} et j'ai pensé à vous. {{url}}"
+    },
+    "note": {
+      "title": "Note sur {{book}} {{chapter}}",
+      "body": "Une note que j'ai faite sur {{book}} {{chapter}} :\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "confirm": "Confirmer",
+    "retry": "Réessayer",
+    "back": "Retour",
+    "go_back": "Retour",
+    "close": "Fermer",
+    "loading": "Chargement…",
+    "error": "Une erreur s'est produite",
+    "error_title": "Erreur",
+    "unknown_error": "Erreur inconnue"
+  },
+
+  "names_of_god": {
+    "title": "Noms de Dieu",
+    "testament_ot": "Ancien Testament",
+    "testament_nt": "Nouveau Testament",
+    "testament_both": "Les deux Testaments",
+    "verses_count": "{{count}} versets",
+    "page_label": "Page {{current}} sur {{total}}",
+    "previous_page": "Page précédente",
+    "next_page": "Page suivante",
+    "loading_verses": "Chargement des versets…",
+    "verse_error": "Impossible de charger le texte du verset",
+    "error_name_not_found": "Nom introuvable",
+    "error_name_not_found_detail": "Ce nom n'a pas pu être trouvé dans l'ensemble de données.",
+    "go_back": "Retour",
+    "language_hebrew": "Hébreu",
+    "language_greek": "Grec",
+    "language_aramaic": "Araméen",
+    "language_english": "Anglais",
+    "search_placeholder": "Rechercher des noms…",
+    "filter_all": "Tous",
+    "names_count": "{{count}} noms",
+    "no_results": "Aucun nom ne correspond à votre recherche."
+  }
+}

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "Portuguese",
+    "code": "pt",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Entrar",
+      "welcome_back": "Bem-vindo de volta",
+      "subtitle": "Entre na sua conta",
+      "email_label": "E-mail",
+      "email_placeholder": "voce@exemplo.com",
+      "password_label": "Senha",
+      "submit": "Entrar",
+      "forgot_password": "Esqueceu a senha?",
+      "no_account": "Não tem conta?",
+      "create_account": "Criar nova conta",
+      "continue_without": "Continuar sem conta",
+      "or_continue_with": "ou continuar com"
+    },
+    "signup": {
+      "title": "Criar conta",
+      "subtitle": "Por favor, forneça as seguintes informações para configurar sua conta.",
+      "first_name_label": "Nome",
+      "last_name_label": "Sobrenome",
+      "email_label": "E-mail",
+      "password_label": "Senha",
+      "submit": "Criar conta",
+      "have_account": "Já tem uma conta?",
+      "sign_in": "Entrar"
+    },
+    "errors": {
+      "invalid_credentials": "E-mail ou senha inválidos",
+      "rate_limited": "Muitas tentativas. Tente novamente em um minuto.",
+      "network_error": "Erro de rede. Verifique sua conexão."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Pular",
+    "next": "Próximo",
+    "get_started": "Começar",
+    "login": "Entrar"
+  },
+
+  "settings": {
+    "title": "Configurações",
+    "account": "Conta",
+    "preferences": "Preferências",
+    "storage": "Armazenamento",
+    "help": "Ajuda",
+    "logout": "Sair",
+    "logout_confirm_title": "Sair",
+    "logout_confirm_message": "Tem certeza de que deseja sair?",
+    "delete_account": "Excluir conta",
+    "delete_account_a11y": "Excluir conta permanentemente",
+    "delete_account_hint": "Esta ação não pode ser desfeita",
+    "language": "Idioma",
+    "language_preferences": "Preferências de idioma",
+    "select_language": "Selecionar idioma",
+    "theme": "Tema",
+    "theme_auto": "Automático",
+    "theme_light": "Claro",
+    "theme_dark": "Escuro",
+    "font_size": "Tamanho da fonte",
+    "bible_version": "Versão da Bíblia",
+    "select_version": "Selecionar versão",
+    "auto_highlights": "Destaques automáticos",
+    "manage_downloads": "Gerenciar downloads",
+    "manage_downloads_a11y": "Gerenciar downloads offline",
+    "manage_downloads_subtitle": "Baixe conteúdo para uso offline",
+    "downloads_offline": "Downloads e offline",
+    "profile_information": "Informações do perfil",
+    "profile_details": "Detalhes do perfil",
+    "profile_subtext": "Atualize suas informações pessoais",
+    "first_name": "Nome",
+    "last_name": "Sobrenome",
+    "email": "E-mail",
+    "first_name_placeholder": "Digite seu nome",
+    "last_name_placeholder": "Digite seu sobrenome",
+    "email_placeholder": "Digite seu e-mail",
+    "go_back": "Voltar",
+    "sign_in_message": "Entre para acessar os destaques automáticos e as configurações de perfil.",
+    "errors": {
+      "save_bible_version": "Falha ao salvar a versão da Bíblia",
+      "save_language": "Falha ao salvar a preferência de idioma"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Carregando capítulo…",
+    "error": "Não foi possível carregar este capítulo. Toque para tentar novamente.",
+    "view_bible": "Bíblia",
+    "view_insight": "Reflexão",
+    "tab_summary": "Resumo",
+    "tab_byline": "Por versículo",
+    "tab_detailed": "Detalhado",
+    "no_translation_available": "Exibindo em inglês (tradução não disponível)",
+    "offline_indicator": "Offline — exibindo conteúdo em cache"
+  },
+
+  "bookmarks": {
+    "title": "Favoritos",
+    "empty": "Ainda sem favoritos. Toque no ícone de favorito durante a leitura.",
+    "empty_title": "Ainda sem capítulos favoritados",
+    "empty_subtitle": "Toque no ícone de favorito durante a leitura para salvar capítulos para mais tarde.",
+    "login_required": "Por favor, entre para ver seus favoritos",
+    "login_subtitle": "Entre para salvar e acessar seus capítulos bíblicos favoritos",
+    "remove_confirm": "Remover este favorito?"
+  },
+
+  "highlights": {
+    "title": "Destaques",
+    "empty": "Ainda sem destaques. Pressione um versículo e escolha uma cor.",
+    "empty_title": "Ainda sem destaques",
+    "empty_subtitle": "Comece a destacar versículos para vê-los aqui.",
+    "auto_highlights": "Destaques automáticos",
+    "my_highlights": "Meus destaques",
+    "remove_confirm": "Remover este destaque?"
+  },
+
+  "notes": {
+    "title": "Notas",
+    "empty": "Ainda sem notas. Toque em um versículo para adicionar uma.",
+    "empty_title": "Ainda sem notas",
+    "empty_subtitle": "Comece a fazer anotações durante a leitura para vê-las aqui.",
+    "login_required": "Por favor, entre para ver suas notas",
+    "login_subtitle": "Entre para criar e acessar suas notas de estudo bíblico",
+    "edit": "Editar nota",
+    "delete": "Excluir nota",
+    "delete_confirm": "Excluir esta nota?",
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "placeholder": "Escreva sua nota…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Estou lendo {{book}} {{chapter}} — acho que você também vai gostar. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Encontrei isso sobre {{topic}} e pensei em você. {{url}}"
+    },
+    "note": {
+      "title": "Nota sobre {{book}} {{chapter}}",
+      "body": "Uma nota que fiz sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "confirm": "Confirmar",
+    "retry": "Tentar novamente",
+    "back": "Voltar",
+    "go_back": "Voltar",
+    "close": "Fechar",
+    "loading": "Carregando…",
+    "error": "Algo deu errado",
+    "error_title": "Erro",
+    "unknown_error": "Erro desconhecido"
+  },
+
+  "names_of_god": {
+    "title": "Nomes de Deus",
+    "testament_ot": "Antigo Testamento",
+    "testament_nt": "Novo Testamento",
+    "testament_both": "Ambos os Testamentos",
+    "verses_count": "{{count}} versículos",
+    "page_label": "Página {{current}} de {{total}}",
+    "previous_page": "Página anterior",
+    "next_page": "Próxima página",
+    "loading_verses": "Carregando versículos…",
+    "verse_error": "Não foi possível carregar o texto do versículo",
+    "error_name_not_found": "Nome não encontrado",
+    "error_name_not_found_detail": "Este nome não pôde ser encontrado no conjunto de dados.",
+    "go_back": "Voltar",
+    "language_hebrew": "Hebraico",
+    "language_greek": "Grego",
+    "language_aramaic": "Aramaico",
+    "language_english": "Inglês",
+    "search_placeholder": "Pesquisar nomes…",
+    "filter_all": "Todos",
+    "names_count": "{{count}} nomes",
+    "no_results": "Nenhum nome corresponde à sua pesquisa."
+  }
+}

--- a/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
@@ -202,11 +202,15 @@ public final class DottedUnderlineTextView: ExpoView {
   }
 
   private func updateAttributedText() {
-    let font = resolvedFont()
+    // NOTE: avoid naming this `font` — that would shadow the
+    // `font(forWeight:)` method in this scope and Swift 6 / Xcode 26
+    // refuses to resolve the method call further down (cannot call
+    // value of non-function type 'UIFont').
+    let baseFont = resolvedFont()
 
     // Base attributes — applied to the entire string.
     var baseAttrs: [NSAttributedString.Key: Any] = [
-      .font: font,
+      .font: baseFont,
       .foregroundColor: textColor,
     ]
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
+    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
     "axios": "^1.12.2",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
+    "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
     "@react-native-community/netinfo": "^11.4.1",
@@ -144,7 +145,7 @@
   "bun": {
     "test": {
       "preload": "./test-setup.ts",
-      "timeout": 10000
+      "timeout": 1e4
     }
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verse-mate-mobile",
   "main": "expo-router/entry",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -144,7 +144,7 @@
   "bun": {
     "test": {
       "preload": "./test-setup.ts",
-      "timeout": 1e4
+      "timeout": 10000
     }
   },
   "private": true

--- a/services/names-of-god-repository.ts
+++ b/services/names-of-god-repository.ts
@@ -1,0 +1,19 @@
+import type { NameOfGod } from '@/types/names-of-god';
+
+let cache: NameOfGod[] | null = null;
+
+function load(): NameOfGod[] {
+  if (cache) return cache;
+  // require() for Metro bundler and Jest compatibility
+  const data = require('@/assets/names-of-god.json');
+  cache = (data.default ?? data) as NameOfGod[];
+  return cache;
+}
+
+export function getAll(): NameOfGod[] {
+  return load();
+}
+
+export function clearCache(): void {
+  cache = null;
+}

--- a/services/names-of-god-use-case.ts
+++ b/services/names-of-god-use-case.ts
@@ -1,0 +1,32 @@
+import { getAll } from '@/services/names-of-god-repository';
+import type { LanguageFilter, NameOfGod } from '@/types/names-of-god';
+
+export function getAllNames(): NameOfGod[] {
+  return getAll();
+}
+
+/**
+ * Case-insensitive substring search across English name, transliteration, and meaning.
+ * All query tokens must match somewhere in those three fields.
+ */
+export function searchNames(query: string): NameOfGod[] {
+  const trimmed = query.trim();
+  if (!trimmed) return getAll();
+
+  const tokens = trimmed.toLowerCase().split(/\s+/);
+
+  return getAll().filter((entry) => {
+    const haystack = `${entry.nameEn} ${entry.transliteration} ${entry.meaning}`.toLowerCase();
+    return tokens.every((token) => haystack.includes(token));
+  });
+}
+
+/** Filter by language. 'All' returns the full list. */
+export function filterByCategory(category: LanguageFilter): NameOfGod[] {
+  if (category === 'All') return getAll();
+  return getAll().filter((entry) => entry.language === category);
+}
+
+export function getNameById(id: string): NameOfGod | null {
+  return getAll().find((entry) => entry.id === id) ?? null;
+}

--- a/types/names-of-god.ts
+++ b/types/names-of-god.ts
@@ -11,4 +11,4 @@ export interface NameOfGod {
 }
 
 /** Language filter for the list screen — 'All' returns every entry */
-export type LanguageFilter = 'Hebrew' | 'Greek' | 'English' | 'All';
+export type LanguageFilter = 'Hebrew' | 'Greek' | 'Aramaic' | 'English' | 'All';

--- a/types/names-of-god.ts
+++ b/types/names-of-god.ts
@@ -1,0 +1,14 @@
+export interface NameOfGod {
+  id: string;
+  nameEn: string;
+  nameOriginal: string;
+  transliteration: string;
+  language: string;
+  category: string;
+  meaning: string;
+  testament: string;
+  verseRefs: string[];
+}
+
+/** Language filter for the list screen — 'All' returns every entry */
+export type LanguageFilter = 'Hebrew' | 'Greek' | 'English' | 'All';

--- a/utils/names-of-god/parse-verse-ref.ts
+++ b/utils/names-of-god/parse-verse-ref.ts
@@ -1,0 +1,55 @@
+import { BIBLE_BOOKS } from '@/constants/bible-books';
+
+export interface ParsedVerseRef {
+  raw: string;
+  bookId: number;
+  bookName: string;
+  chapter: number;
+  verse: number;
+}
+
+/**
+ * Parses a verse reference string ("Genesis 2:4", "1 Samuel 16:7") into
+ * structured data. Returns null if the string can't be matched to a known book.
+ *
+ * Matching is case-insensitive and normalises "Psalms" <-> "Psalm" variants.
+ */
+export function parseVerseRef(raw: string): ParsedVerseRef | null {
+  const match = raw.trim().match(/^(.*)\s(\d+):(\d+)$/);
+  if (!match) return null;
+
+  const [, bookName, chapterStr, verseStr] = match;
+  const chapter = Number(chapterStr);
+  const verse = Number(verseStr);
+
+  const normalised = bookName
+    .trim()
+    .toLowerCase()
+    .replace(/^psalms$/, 'psalms');
+  const book = BIBLE_BOOKS.find(
+    (b) =>
+      b.name.toLowerCase() === normalised ||
+      b.name.toLowerCase().replace(/^psalms$/, 'psalms') === normalised
+  );
+  if (!book) return null;
+
+  return { raw, bookId: book.id, bookName: book.name, chapter, verse };
+}
+
+/** Canonical sort comparator: Gen → Rev, then chapter ASC, then verse ASC. */
+export function compareVerseRefs(a: ParsedVerseRef, b: ParsedVerseRef): number {
+  if (a.bookId !== b.bookId) return a.bookId - b.bookId;
+  if (a.chapter !== b.chapter) return a.chapter - b.chapter;
+  return a.verse - b.verse;
+}
+
+/**
+ * Parses and sorts an array of raw verse reference strings in canonical order.
+ * Refs that cannot be parsed are silently dropped.
+ */
+export function parseSortVerseRefs(rawRefs: string[]): ParsedVerseRef[] {
+  return rawRefs
+    .map(parseVerseRef)
+    .filter((r): r is ParsedVerseRef => r !== null)
+    .sort(compareVerseRefs);
+}


### PR DESCRIPTION
## Summary

- Adds `types/names-of-god.ts` — `NameOfGod` interface and `LanguageFilter` union type
- Adds `services/names-of-god-repository.ts` — lazy-loads `assets/names-of-god.json` with module-level in-memory cache (same pattern as `easton-service`)
- Adds `services/names-of-god-use-case.ts` — exposes `getAllNames()`, `searchNames(query)`, `filterByCategory(category)`, `getNameById(id)`
- Adds 30 unit tests (2 files) covering load, cache, search, filter, and getById

## Spec

Implements [VER-132#document-plan](/VER/issues/VER-132#document-plan) §T2.

Closes [VER-144](/VER/issues/VER-144). Unblocks [VER-145](/VER/issues/VER-145), [VER-146](/VER/issues/VER-146), [VER-147](/VER/issues/VER-147).

## Notes

- `searchNames` does case-insensitive multi-token substring match across `nameEn + transliteration + meaning` — no deps, fast for 130 entries
- `filterByCategory` maps to `entry.language`; 'All' returns full list
- 30/30 unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)