### PR TITLE
fix(bible): Andy round 4 — pill align, lex drag, single-tap video, iOS rotation + ship native dotted-underline module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ modules/dictionary/android/build/*
 crash_logs
 
 .agent-os/**/*
+modules/*/android/build/

--- a/app.config.js
+++ b/app.config.js
@@ -21,6 +21,20 @@ const config = {
       // backgrounded so explanations don't cut off when the screen
       // locks or the user switches apps.
       UIBackgroundModes: ['audio'],
+      // Andy round 4 — iOS visuals rotation: by default Expo's
+      // `orientation: 'default'` ships UISupportedInterfaceOrientations as
+      // portrait-only on iPhone. expo-screen-orientation's
+      // `unlockAsync()` can't override the Info.plist superset at runtime,
+      // so the Visuals tab couldn't rotate to landscape even though
+      // VisualsPanel called unlockAsync on mount. Declaring all four
+      // orientations here lets the runtime calls take effect; non-Visuals
+      // screens stay portrait because nothing else calls unlockAsync.
+      UISupportedInterfaceOrientations: [
+        'UIInterfaceOrientationPortrait',
+        'UIInterfaceOrientationPortraitUpsideDown',
+        'UIInterfaceOrientationLandscapeLeft',
+        'UIInterfaceOrientationLandscapeRight',
+      ],
       CFBundleURLTypes: [
         {
           CFBundleURLSchemes: [

--- a/biome.json
+++ b/biome.json
@@ -15,6 +15,7 @@
       "__tests__/**/*.{js,jsx,ts,tsx}",
       "e2e/**/*.{js,jsx,ts,tsx}",
       "agent-os/references/**/*.{js,jsx,ts,tsx}",
+      "modules/**/*.{js,jsx,ts,tsx}",
       "*.{js,jsx,ts,tsx}"
     ],
     "ignoreUnknown": false

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "verse-mate-mobile",
@@ -15,6 +14,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
+        "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
@@ -824,6 +824,8 @@
     "@urql/core": ["@urql/core@5.2.0", "", { "dependencies": { "@0no-co/graphql.web": "^1.0.13", "wonka": "^6.3.2" } }, "sha512-/n0ieD0mvvDnVAXEQgX/7qJiVcvYvNkOHeBvkwtylfjydar123caCXcl58PXFY11oU1oquJocVXHxLAbtv4x1A=="],
 
     "@urql/exchange-retry": ["@urql/exchange-retry@1.3.2", "", { "dependencies": { "@urql/core": "^5.1.2", "wonka": "^6.3.2" } }, "sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg=="],
+
+    "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
     "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#26012e6", {}, "verse-mate-verse-mate-lexicon-26012e6"],
 

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -20,6 +20,7 @@
  * @see Visual: after-selected-text-popup.png (highlighted text appearance)
  */
 
+import { DottedUnderlineText, type UnderlineRange } from '@versemate/dotted-underline-text';
 import type { AlignedToken, ChapterAlignment, LexEntry } from '@versemate/lexicon';
 import * as Haptics from 'expo-haptics';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
@@ -1098,6 +1099,223 @@ export function HighlightedText({
       </Text>
     );
   };
+
+  // ─── NATIVE RENDER PATH (option 3) ───────────────────────────────────
+  // When alignment is provided AND a lexicon tap handler is wired, render the
+  // whole verse via the @versemate/dotted-underline-text native module:
+  // one UILabel (iOS) / TextView (Android) holds the entire verse, with per-
+  // character ranges carrying lex underlines + highlight backgrounds. Gives
+  // us:
+  //   - Real CSS-style dotted underlines on BOTH iOS and Android (the RN
+  //     `textDecorationStyle: 'dotted'` was iOS-only / Android-solid).
+  //   - Native text selection (UILabel + UIMenu / TextView.setTextIsSelectable).
+  //   - Highlight backgrounds via per-range `backgroundColor`.
+  //   - Theme-tier brightening via per-range `fontWeight` + `textColor`.
+  //
+  // The legacy tokenized path below is kept verbatim as the fallback when
+  // `alignment` is null (e.g. BibleExplanationsPanel inline lex via markdown).
+  if (lexiconMode && lexiconLookups) {
+    // Build ranges + side-table for tap dispatch. Each native range entry has
+    // a parallel `rangeDispatch[]` entry that tells onRangeTap which handler
+    // to fire when that range is tapped.
+    type RangeAction =
+      | { kind: 'lex'; token: AlignedToken; entry: LexEntry; isTheme: boolean; surface: string }
+      | { kind: 'highlight'; id: number }
+      | { kind: 'autoHighlight'; data: AutoHighlight };
+    const nativeRanges: UnderlineRange[] = [];
+    const rangeDispatch: RangeAction[] = [];
+
+    // ---- 1. Lex word ranges (single + multi-word matches) --------------
+    const LEX_COLOR = '#B09A6D';
+    const LEX_THEME_COLOR = '#C7B074';
+    const THEME_WEIGHT = Platform.OS === 'ios' ? '600' : '700';
+    const verseTokens = tokenizeText(text);
+    const verseLexHits = verseTokens.map((t) => lexiconMatch(t.word));
+
+    // Try a multi-word match starting at tokens[startIdx]; greedy longest.
+    // Mirrors the logic in renderSegmentTokenized but operates on the full
+    // verse text instead of per-segment.
+    const findMultiAt = (startIdx: number) => {
+      const head = stripPunct(verseTokens[startIdx]?.word ?? '');
+      if (!head) return null;
+      const candidates = lexiconLookups.multi.get(head);
+      if (!candidates) return null;
+      // Greedy longest among candidates whose parts match starting here.
+      let bestEndIdx = -1;
+      let best: (typeof candidates)[number] | null = null;
+      for (const cand of candidates) {
+        let ok = true;
+        for (let k = 0; k < cand.parts.length; k++) {
+          const tok = verseTokens[startIdx + k];
+          if (!tok) {
+            ok = false;
+            break;
+          }
+          const tokKey = stripPunct(tok.word);
+          if (tokKey !== cand.parts[k]) {
+            ok = false;
+            break;
+          }
+          // Disallow blocking punctuation mid-phrase: trailing comma/period
+          // on a non-last token would break the visual underline.
+          if (k < cand.parts.length - 1 && /[.,;:!?]$/.test(tok.word)) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok && startIdx + cand.parts.length - 1 > bestEndIdx) {
+          bestEndIdx = startIdx + cand.parts.length - 1;
+          best = cand;
+        }
+      }
+      return best;
+    };
+
+    let i = 0;
+    while (i < verseTokens.length) {
+      const multi = findMultiAt(i);
+      if (multi) {
+        const endIdx = i + multi.parts.length - 1;
+        const startChar = verseTokens[i].startChar;
+        const endChar = verseTokens[endIdx].endChar;
+        nativeRanges.push({
+          start: startChar,
+          end: endChar,
+          style: 'dotted',
+          color: multi.isTheme ? LEX_THEME_COLOR : LEX_COLOR,
+          fontWeight: multi.isTheme ? THEME_WEIGHT : undefined,
+          textColor: multi.isTheme ? LEX_THEME_COLOR : undefined,
+        });
+        rangeDispatch.push({
+          kind: 'lex',
+          token: multi.token,
+          entry: multi.entry,
+          isTheme: multi.isTheme,
+          surface: text.slice(startChar, endChar),
+        });
+        i = endIdx + 1;
+        continue;
+      }
+      const hit = verseLexHits[i];
+      if (hit) {
+        const startChar = verseTokens[i].startChar;
+        // Strip trailing punctuation from the underline's end-char so the
+        // dotted line doesn't extend under a comma/period.
+        const tokenText = verseTokens[i].word;
+        const trailingMatch = tokenText.match(/[.,;:!?]+$/);
+        const trailingLen = trailingMatch ? trailingMatch[0].length : 0;
+        const endChar = verseTokens[i].endChar - trailingLen;
+        if (endChar > startChar) {
+          nativeRanges.push({
+            start: startChar,
+            end: endChar,
+            style: 'dotted',
+            color: hit.isTheme ? LEX_THEME_COLOR : LEX_COLOR,
+            fontWeight: hit.isTheme ? THEME_WEIGHT : undefined,
+            textColor: hit.isTheme ? LEX_THEME_COLOR : undefined,
+          });
+          rangeDispatch.push({
+            kind: 'lex',
+            token: hit.token,
+            entry: hit.entry,
+            isTheme: hit.isTheme,
+            surface: text.slice(startChar, endChar),
+          });
+        }
+      }
+      i++;
+    }
+
+    // ---- 2. Highlight ranges (user highlights + auto highlights) -------
+    // Per-verse: clamp the multi-verse highlight start/end to this verse's
+    // text bounds.
+    const verseHighlights = highlights.filter(
+      (h) => h.start_verse <= verseNumber && h.end_verse >= verseNumber
+    );
+    for (const h of verseHighlights) {
+      // Highlight type carries char-level offsets only when start_verse ===
+      // verseNumber (resp. end_verse for the end). When the highlight spans
+      // a different verse boundary on either side, use the full verse text.
+      // start_char / end_char are typed as `number | unknown` because the
+      // server returns `null` for older highlights — guard with `typeof`.
+      const rawStart =
+        h.start_verse === verseNumber && typeof h.start_char === 'number' ? h.start_char : 0;
+      const rawEnd =
+        h.end_verse === verseNumber && typeof h.end_char === 'number' ? h.end_char : text.length;
+      const clampedStart = Math.max(0, Math.min(rawStart, text.length));
+      const clampedEnd = Math.max(clampedStart, Math.min(rawEnd, text.length));
+      if (clampedEnd <= clampedStart) continue;
+      const hex = getHighlightColor(h.color, mode);
+      // Append the 35%-opacity alpha so the highlight is semi-transparent.
+      const alphaHex = Math.round(HIGHLIGHT_OPACITY * 255)
+        .toString(16)
+        .padStart(2, '0');
+      nativeRanges.push({
+        start: clampedStart,
+        end: clampedEnd,
+        backgroundColor: hex + alphaHex,
+      });
+      rangeDispatch.push({ kind: 'highlight', id: h.highlight_id });
+    }
+
+    // Auto-highlights are whole-verse only (no char-level offsets in the
+    // type), so each one spans the entire verse text.
+    const verseAutoHighlights = autoHighlights.filter(
+      (h) => h.start_verse <= verseNumber && h.end_verse >= verseNumber
+    );
+    for (const ah of verseAutoHighlights) {
+      if (text.length === 0) continue;
+      const hex = getHighlightColor(ah.theme_color, mode);
+      const alphaHex = Math.round(AUTO_HIGHLIGHT_OPACITY * 255)
+        .toString(16)
+        .padStart(2, '0');
+      nativeRanges.push({
+        start: 0,
+        end: text.length,
+        backgroundColor: hex + alphaHex,
+      });
+      rangeDispatch.push({ kind: 'autoHighlight', data: ah });
+    }
+
+    const handleNativeRangeTap = (index: number) => {
+      const action = rangeDispatch[index];
+      if (!action) return;
+      if (action.kind === 'lex') {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+        onLexiconWordPress?.({
+          surface: action.surface,
+          token: action.token,
+          entry: action.entry,
+          isTheme: action.isTheme,
+        });
+      } else if (action.kind === 'highlight') {
+        onHighlightTap?.(action.id);
+      } else if (action.kind === 'autoHighlight') {
+        onAutoHighlightPress?.(action.data);
+      }
+    };
+
+    const handleNativePress = () => {
+      // Taps OUTSIDE any range → verse insight (matches the existing
+      // verse-tap behaviour for plain words). Native side fires this only
+      // when the tap landed off all ranges.
+      onVerseTap?.(verseNumber);
+    };
+
+    return (
+      <DottedUnderlineText
+        text={text}
+        style={style}
+        ranges={nativeRanges}
+        selectable={true}
+        onRangeTap={handleNativeRangeTap}
+        onPress={handleNativePress}
+        accessibilityLabel={text}
+        testID={`verse-text-${verseNumber}`}
+      />
+    );
+  }
+  // ─── END NATIVE RENDER PATH ──────────────────────────────────────────
 
   return (
     <Text

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -20,7 +20,6 @@
  * @see Visual: after-selected-text-popup.png (highlighted text appearance)
  */
 
-import { DottedUnderlineText, type UnderlineRange } from '@versemate/dotted-underline-text';
 import type { AlignedToken, ChapterAlignment, LexEntry } from '@versemate/lexicon';
 import * as Haptics from 'expo-haptics';
 import { type ReactNode, useEffect, useMemo, useRef, useState } from 'react';
@@ -1100,223 +1099,6 @@ export function HighlightedText({
     );
   };
 
-  // ─── NATIVE RENDER PATH (option 3) ───────────────────────────────────
-  // When alignment is provided AND a lexicon tap handler is wired, render the
-  // whole verse via the @versemate/dotted-underline-text native module:
-  // one UILabel (iOS) / TextView (Android) holds the entire verse, with per-
-  // character ranges carrying lex underlines + highlight backgrounds. Gives
-  // us:
-  //   - Real CSS-style dotted underlines on BOTH iOS and Android (the RN
-  //     `textDecorationStyle: 'dotted'` was iOS-only / Android-solid).
-  //   - Native text selection (UILabel + UIMenu / TextView.setTextIsSelectable).
-  //   - Highlight backgrounds via per-range `backgroundColor`.
-  //   - Theme-tier brightening via per-range `fontWeight` + `textColor`.
-  //
-  // The legacy tokenized path below is kept verbatim as the fallback when
-  // `alignment` is null (e.g. BibleExplanationsPanel inline lex via markdown).
-  if (lexiconMode && lexiconLookups) {
-    // Build ranges + side-table for tap dispatch. Each native range entry has
-    // a parallel `rangeDispatch[]` entry that tells onRangeTap which handler
-    // to fire when that range is tapped.
-    type RangeAction =
-      | { kind: 'lex'; token: AlignedToken; entry: LexEntry; isTheme: boolean; surface: string }
-      | { kind: 'highlight'; id: number }
-      | { kind: 'autoHighlight'; data: AutoHighlight };
-    const nativeRanges: UnderlineRange[] = [];
-    const rangeDispatch: RangeAction[] = [];
-
-    // ---- 1. Lex word ranges (single + multi-word matches) --------------
-    const LEX_COLOR = '#B09A6D';
-    const LEX_THEME_COLOR = '#C7B074';
-    const THEME_WEIGHT = Platform.OS === 'ios' ? '600' : '700';
-    const verseTokens = tokenizeText(text);
-    const verseLexHits = verseTokens.map((t) => lexiconMatch(t.word));
-
-    // Try a multi-word match starting at tokens[startIdx]; greedy longest.
-    // Mirrors the logic in renderSegmentTokenized but operates on the full
-    // verse text instead of per-segment.
-    const findMultiAt = (startIdx: number) => {
-      const head = stripPunct(verseTokens[startIdx]?.word ?? '');
-      if (!head) return null;
-      const candidates = lexiconLookups.multi.get(head);
-      if (!candidates) return null;
-      // Greedy longest among candidates whose parts match starting here.
-      let bestEndIdx = -1;
-      let best: (typeof candidates)[number] | null = null;
-      for (const cand of candidates) {
-        let ok = true;
-        for (let k = 0; k < cand.parts.length; k++) {
-          const tok = verseTokens[startIdx + k];
-          if (!tok) {
-            ok = false;
-            break;
-          }
-          const tokKey = stripPunct(tok.word);
-          if (tokKey !== cand.parts[k]) {
-            ok = false;
-            break;
-          }
-          // Disallow blocking punctuation mid-phrase: trailing comma/period
-          // on a non-last token would break the visual underline.
-          if (k < cand.parts.length - 1 && /[.,;:!?]$/.test(tok.word)) {
-            ok = false;
-            break;
-          }
-        }
-        if (ok && startIdx + cand.parts.length - 1 > bestEndIdx) {
-          bestEndIdx = startIdx + cand.parts.length - 1;
-          best = cand;
-        }
-      }
-      return best;
-    };
-
-    let i = 0;
-    while (i < verseTokens.length) {
-      const multi = findMultiAt(i);
-      if (multi) {
-        const endIdx = i + multi.parts.length - 1;
-        const startChar = verseTokens[i].startChar;
-        const endChar = verseTokens[endIdx].endChar;
-        nativeRanges.push({
-          start: startChar,
-          end: endChar,
-          style: 'dotted',
-          color: multi.isTheme ? LEX_THEME_COLOR : LEX_COLOR,
-          fontWeight: multi.isTheme ? THEME_WEIGHT : undefined,
-          textColor: multi.isTheme ? LEX_THEME_COLOR : undefined,
-        });
-        rangeDispatch.push({
-          kind: 'lex',
-          token: multi.token,
-          entry: multi.entry,
-          isTheme: multi.isTheme,
-          surface: text.slice(startChar, endChar),
-        });
-        i = endIdx + 1;
-        continue;
-      }
-      const hit = verseLexHits[i];
-      if (hit) {
-        const startChar = verseTokens[i].startChar;
-        // Strip trailing punctuation from the underline's end-char so the
-        // dotted line doesn't extend under a comma/period.
-        const tokenText = verseTokens[i].word;
-        const trailingMatch = tokenText.match(/[.,;:!?]+$/);
-        const trailingLen = trailingMatch ? trailingMatch[0].length : 0;
-        const endChar = verseTokens[i].endChar - trailingLen;
-        if (endChar > startChar) {
-          nativeRanges.push({
-            start: startChar,
-            end: endChar,
-            style: 'dotted',
-            color: hit.isTheme ? LEX_THEME_COLOR : LEX_COLOR,
-            fontWeight: hit.isTheme ? THEME_WEIGHT : undefined,
-            textColor: hit.isTheme ? LEX_THEME_COLOR : undefined,
-          });
-          rangeDispatch.push({
-            kind: 'lex',
-            token: hit.token,
-            entry: hit.entry,
-            isTheme: hit.isTheme,
-            surface: text.slice(startChar, endChar),
-          });
-        }
-      }
-      i++;
-    }
-
-    // ---- 2. Highlight ranges (user highlights + auto highlights) -------
-    // Per-verse: clamp the multi-verse highlight start/end to this verse's
-    // text bounds.
-    const verseHighlights = highlights.filter(
-      (h) => h.start_verse <= verseNumber && h.end_verse >= verseNumber
-    );
-    for (const h of verseHighlights) {
-      // Highlight type carries char-level offsets only when start_verse ===
-      // verseNumber (resp. end_verse for the end). When the highlight spans
-      // a different verse boundary on either side, use the full verse text.
-      // start_char / end_char are typed as `number | unknown` because the
-      // server returns `null` for older highlights — guard with `typeof`.
-      const rawStart =
-        h.start_verse === verseNumber && typeof h.start_char === 'number' ? h.start_char : 0;
-      const rawEnd =
-        h.end_verse === verseNumber && typeof h.end_char === 'number' ? h.end_char : text.length;
-      const clampedStart = Math.max(0, Math.min(rawStart, text.length));
-      const clampedEnd = Math.max(clampedStart, Math.min(rawEnd, text.length));
-      if (clampedEnd <= clampedStart) continue;
-      const hex = getHighlightColor(h.color, mode);
-      // Append the 35%-opacity alpha so the highlight is semi-transparent.
-      const alphaHex = Math.round(HIGHLIGHT_OPACITY * 255)
-        .toString(16)
-        .padStart(2, '0');
-      nativeRanges.push({
-        start: clampedStart,
-        end: clampedEnd,
-        backgroundColor: hex + alphaHex,
-      });
-      rangeDispatch.push({ kind: 'highlight', id: h.highlight_id });
-    }
-
-    // Auto-highlights are whole-verse only (no char-level offsets in the
-    // type), so each one spans the entire verse text.
-    const verseAutoHighlights = autoHighlights.filter(
-      (h) => h.start_verse <= verseNumber && h.end_verse >= verseNumber
-    );
-    for (const ah of verseAutoHighlights) {
-      if (text.length === 0) continue;
-      const hex = getHighlightColor(ah.theme_color, mode);
-      const alphaHex = Math.round(AUTO_HIGHLIGHT_OPACITY * 255)
-        .toString(16)
-        .padStart(2, '0');
-      nativeRanges.push({
-        start: 0,
-        end: text.length,
-        backgroundColor: hex + alphaHex,
-      });
-      rangeDispatch.push({ kind: 'autoHighlight', data: ah });
-    }
-
-    const handleNativeRangeTap = (index: number) => {
-      const action = rangeDispatch[index];
-      if (!action) return;
-      if (action.kind === 'lex') {
-        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-        onLexiconWordPress?.({
-          surface: action.surface,
-          token: action.token,
-          entry: action.entry,
-          isTheme: action.isTheme,
-        });
-      } else if (action.kind === 'highlight') {
-        onHighlightTap?.(action.id);
-      } else if (action.kind === 'autoHighlight') {
-        onAutoHighlightPress?.(action.data);
-      }
-    };
-
-    const handleNativePress = () => {
-      // Taps OUTSIDE any range → verse insight (matches the existing
-      // verse-tap behaviour for plain words). Native side fires this only
-      // when the tap landed off all ranges.
-      onVerseTap?.(verseNumber);
-    };
-
-    return (
-      <DottedUnderlineText
-        text={text}
-        style={style}
-        ranges={nativeRanges}
-        selectable={true}
-        onRangeTap={handleNativeRangeTap}
-        onPress={handleNativePress}
-        accessibilityLabel={text}
-        testID={`verse-text-${verseNumber}`}
-      />
-    );
-  }
-  // ─── END NATIVE RENDER PATH ──────────────────────────────────────────
-
   return (
     <Text
       style={style}
@@ -1508,30 +1290,28 @@ const selectionStyles = StyleSheet.create({
  */
 const LEX_UNDERLINE = '#B09A6D';
 const LEX_UNDERLINE_THEME = '#C7B074';
+// Andy round 4 #2 + native-module retreat: dropped the dotted style on
+// iOS. RN's `textDecorationStyle: 'dotted'` is iOS-only AND draws per-word
+// with visibly large gaps that Andy flagged as looking like accidental
+// whitespace. Android has never rendered dotted (RN ignores the style).
+// The `@versemate/dotted-underline-text` native module IS shipped on this
+// branch — it draws real dots — but it's a native View and can't nest
+// inside paragraph-mode <Text> verses (RN gives Views inside Text 0×0).
+// Result: thin solid underline on both platforms now. Cross-platform
+// consistent, no gaps, cleanest read. Native module is dormant until a
+// future custom-shadow-node experiment can render real dots inline.
 const lexiconWordStyles = StyleSheet.create({
   regular: {
     textDecorationLine: 'underline',
-    // iOS-only props — Android no-ops these, so they don't hurt cross-platform.
-    ...Platform.select({
-      ios: {
-        textDecorationStyle: 'dotted' as const,
-        textDecorationColor: LEX_UNDERLINE,
-      },
-      default: {},
-    }),
+    textDecorationColor: LEX_UNDERLINE,
   },
   theme: {
     textDecorationLine: 'underline',
+    // Heavier weight + brighter color give the "thick tier" feel that the
+    // solid line alone can't communicate. iOS treats '600' as semi-bold;
+    // Android only renders the bold step at '700' for most font families.
     fontWeight: Platform.OS === 'ios' ? '600' : '700',
-    ...Platform.select({
-      ios: {
-        // Web uses dotted for BOTH tiers — match that on iOS where we can.
-        // Brighter color + heavier weight carry the "thick tier" feel.
-        textDecorationStyle: 'dotted' as const,
-        textDecorationColor: LEX_UNDERLINE_THEME,
-      },
-      default: {},
-    }),
+    textDecorationColor: LEX_UNDERLINE_THEME,
   },
 });
 // TODO(VER-mobile-lex-dotted-android): real dotted underlines on Android

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -12,15 +12,17 @@
 
 import type { AlignedToken, LexEntry } from '@versemate/lexicon';
 import { useEffect, useMemo, useRef } from 'react';
-import { Dimensions, Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withSpring,
-  withTiming,
-} from 'react-native-reanimated';
+import {
+  Animated,
+  Dimensions,
+  Modal,
+  PanResponder,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -59,147 +61,147 @@ export function LexiconPopover({
   const screenHeight = Dimensions.get('window').height;
   const styles = useMemo(() => createStyles(colors, insets), [colors, insets]);
 
-  // Reanimated SharedValues — single sheet-position SV so the open/close
-  // animations AND the pan gesture all drive the same translateY. The pan
-  // gesture sets translateY directly during drag; on release it either
-  // springs back to 0 or animates out to screenHeight and fires onClose.
-  const sheetTranslateY = useSharedValue(screenHeight);
-  const backdropOpacity = useSharedValue(0);
-
-  // scrollY mirrored as a SharedValue so the worklet-based pan gesture can
-  // read the latest scroll offset without crossing the JS<->UI boundary.
-  // Updated from the ScrollView's onScroll via the UI thread (cheap).
-  const scrollY = useSharedValue(0);
+  // Animated values — same shape as VerseMateTooltip.
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(screenHeight)).current;
 
   // Internal visibility flag so we can play the close animation before the
   // Modal actually unmounts. Toggled by the visible-prop watcher below.
   const internalVisibleRef = useRef(false);
 
-  // closeRef so gesture callbacks always see the latest onClose prop without
-  // re-binding the gesture (Gesture.Pan is rebuilt each render, but a ref is
-  // still safer for the runOnJS call site).
-  const closeRef = useRef(onClose);
-  useEffect(() => {
-    closeRef.current = onClose;
-  });
-
-  const triggerClose = () => {
-    closeRef.current();
-  };
-
   const animateOpen = () => {
     internalVisibleRef.current = true;
-    backdropOpacity.value = withTiming(1, { duration: 200 });
-    sheetTranslateY.value = withSpring(0, { damping: 20, stiffness: 90 });
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 1,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+      // Plain timing on open — Andy reported the previous spring made the
+      // modal feel jittery / bounce-on-open. Straight slide-up matches the
+      // verse-insight modal.
+      Animated.timing(slideAnim, {
+        toValue: 0,
+        duration: 220,
+        useNativeDriver: true,
+      }),
+    ]).start();
   };
 
-  const animateClose = () => {
-    backdropOpacity.value = withTiming(0, { duration: 250 });
-    sheetTranslateY.value = withSpring(screenHeight, {
-      damping: 20,
-      stiffness: 90,
-      overshootClamping: true,
-    });
+  const animateClose = (cb?: () => void) => {
+    Animated.parallel([
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 250,
+        useNativeDriver: true,
+      }),
+      Animated.spring(slideAnim, {
+        toValue: screenHeight,
+        useNativeDriver: true,
+        damping: 20,
+        stiffness: 90,
+        overshootClamping: true,
+        restDisplacementThreshold: 40,
+        restSpeedThreshold: 40,
+      }),
+    ]).start();
     setTimeout(() => {
       internalVisibleRef.current = false;
+      cb?.();
     }, 150);
   };
 
   // Drive animations off the `visible` prop. Open on mount, close on
   // visible → false. The close path calls onClose synchronously so the
   // parent (ChapterReader) can clear its activeLexicon state.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: animateOpen/animateClose/sheetTranslateY/backdropOpacity/screenHeight are stable refs and closure-captured constants
+  // biome-ignore lint/correctness/useExhaustiveDependencies: animateOpen/animateClose/slideAnim/backdropOpacity/screenHeight are stable refs and closure-captured constants
   useEffect(() => {
     if (visible) {
-      sheetTranslateY.value = screenHeight;
-      backdropOpacity.value = 0;
+      slideAnim.setValue(screenHeight);
+      backdropOpacity.setValue(0);
       animateOpen();
     } else if (internalVisibleRef.current) {
       animateClose();
     }
   }, [visible]);
 
-  // ─── Gesture composition ─────────────────────────────────────────────
+  // PanResponder for swipe-to-dismiss from anywhere on the sheet.
   //
-  // Problem we're solving: when the user swipes down inside the ScrollView
-  // body, the ScrollView's native gesture grabs the touch first and the
-  // outer PanResponder never fires. RNGH v2 fixes this with
-  // `Gesture.Native()` (the ScrollView's native pan, represented as an RNGH
-  // gesture) composed with our Pan via `simultaneousWithExternalGesture`.
-  // Both gestures activate together; our Pan only translates the sheet
-  // when scroll is at the top + drag direction is downward, so normal
-  // scrolling still works.
+  // Two gesture cooperations:
+  //   - Drag from the always-on region (handle + header) → captures
+  //     immediately, no scroll-position check (no scrollable content to
+  //     fight in that strip anyway).
+  //   - Drag from the ScrollView body → only captures when the scroll is
+  //     at the top AND the user is dragging DOWN, so normal scrolling
+  //     works for the rest of the time.
   //
-  // Activation thresholds (worklet-side):
-  //   dy > 5 AND |dy| > |dx| * 1.2 AND scrollY <= 0 → drag the sheet
-  // Release thresholds:
-  //   dy > 100 OR velocityY > 600 → dismiss
-  //   otherwise → spring back to 0
-  //
-  // The handle (4×40 grey pill at the very top) gets its OWN Pan gesture
-  // without the scrollY check so the user can always grab it to dismiss.
-
-  const scrollNativeGesture = Gesture.Native();
-
-  const bodyPanGesture = Gesture.Pan()
-    .activeOffsetY(5)
-    .failOffsetX([-15, 15])
-    .onUpdate((e) => {
-      'worklet';
-      if (e.translationY > 0 && scrollY.value <= 0) {
-        sheetTranslateY.value = e.translationY;
-      }
+  // Thresholds: we capture at `dy > 3` (instead of 5) and dismiss at
+  // `dy > 50` (instead of 70). Andy reported the previous values made
+  // the sheet feel like you had to "grip the top to swipe it away" —
+  // smaller-feeling thresholds restore the expected iOS-sheet feel.
+  const closeRef = useRef(onClose);
+  useEffect(() => {
+    closeRef.current = onClose;
+  });
+  const scrollYRef = useRef(0);
+  const panResponder = useRef(
+    PanResponder.create({
+      // Capture phase — fires BEFORE children (the ScrollView) receive
+      // touch events. We only return true (and steal the gesture from
+      // the ScrollView) when the user is at the top of scrollable
+      // content AND drags downward, so normal scrolling is unaffected.
+      onStartShouldSetPanResponderCapture: () => false,
+      onMoveShouldSetPanResponderCapture: (_, g) => {
+        const isVerticalDown = g.dy > 3 && Math.abs(g.dy) > Math.abs(g.dx);
+        const atTop = scrollYRef.current <= 0;
+        return isVerticalDown && atTop;
+      },
+      onPanResponderMove: (_, g) => {
+        if (g.dy > 0) slideAnim.setValue(g.dy);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > 50) {
+          closeRef.current();
+        } else if (g.dy > 0) {
+          // Snap-back uses plain timing (not spring) to match the
+          // bounce-less open animation Andy asked for.
+          Animated.timing(slideAnim, {
+            toValue: 0,
+            duration: 150,
+            useNativeDriver: true,
+          }).start();
+        }
+      },
+      onPanResponderTerminationRequest: () => false,
     })
-    .onEnd((e) => {
-      'worklet';
-      if (e.translationY > 100 || e.velocityY > 600) {
-        sheetTranslateY.value = withSpring(screenHeight, {
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-        });
-        backdropOpacity.value = withTiming(0, { duration: 200 });
-        runOnJS(triggerClose)();
-      } else {
-        sheetTranslateY.value = withSpring(0, { damping: 20, stiffness: 90 });
-      }
+  ).current;
+
+  // Dedicated pan responder for the always-on drag region (handle + header)
+  // — bypasses the scroll-at-top check so the user can always drag the
+  // modal down by grabbing the handle OR anywhere in the lemma/meta header.
+  const handlePanResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: (_, g) => Math.abs(g.dy) > 3,
+      onPanResponderMove: (_, g) => {
+        if (g.dy > 0) slideAnim.setValue(g.dy);
+      },
+      onPanResponderRelease: (_, g) => {
+        if (g.dy > 50) {
+          closeRef.current();
+        } else if (g.dy > 0) {
+          // Snap-back uses plain timing (not spring) to match the
+          // bounce-less open animation Andy asked for.
+          Animated.timing(slideAnim, {
+            toValue: 0,
+            duration: 150,
+            useNativeDriver: true,
+          }).start();
+        }
+      },
+      onPanResponderTerminationRequest: () => false,
     })
-    .simultaneousWithExternalGesture(scrollNativeGesture);
-
-  // Handle + header drag region: always-on, no scrollY check. Same
-  // dismiss/snap behavior as bodyPanGesture but it never has to fight a
-  // ScrollView, so no simultaneous composition needed.
-  const headerPanGesture = Gesture.Pan()
-    .activeOffsetY(5)
-    .failOffsetX([-15, 15])
-    .onUpdate((e) => {
-      'worklet';
-      if (e.translationY > 0) {
-        sheetTranslateY.value = e.translationY;
-      }
-    })
-    .onEnd((e) => {
-      'worklet';
-      if (e.translationY > 100 || e.velocityY > 600) {
-        sheetTranslateY.value = withSpring(screenHeight, {
-          damping: 20,
-          stiffness: 90,
-          overshootClamping: true,
-        });
-        backdropOpacity.value = withTiming(0, { duration: 200 });
-        runOnJS(triggerClose)();
-      } else {
-        sheetTranslateY.value = withSpring(0, { damping: 20, stiffness: 90 });
-      }
-    });
-
-  const sheetAnimatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateY: sheetTranslateY.value }],
-  }));
-
-  const backdropAnimatedStyle = useAnimatedStyle(() => ({
-    opacity: backdropOpacity.value,
-  }));
+  ).current;
 
   const contextual = token.contextual;
   const lemmaIsHebrew = isHebrew(entry.lemma);
@@ -214,131 +216,130 @@ export function LexiconPopover({
     >
       <View style={styles.overlay} pointerEvents="box-none" testID={testID}>
         {/* Backdrop with fade */}
-        <Animated.View style={[styles.backdrop, backdropAnimatedStyle]} pointerEvents="auto">
+        <Animated.View style={[styles.backdrop, { opacity: backdropOpacity }]} pointerEvents="auto">
           <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         </Animated.View>
 
-        {/* Sliding sheet — the inner ScrollView is wrapped in a composed
-            Gesture.Simultaneous(bodyPan, scrollNative) so swipe-down at the
-            top of scroll dismisses the sheet, but normal scrolling works
-            everywhere else. The handle + header use their own headerPan
-            gesture (no scroll-at-top check). */}
-        <Animated.View style={[styles.sheet, sheetAnimatedStyle]} pointerEvents="auto">
+        {/* Sliding sheet — pan responder wraps the whole sheet so swipe-down
+            from any point dismisses (subject to scroll-at-top check). */}
+        <Animated.View
+          style={[styles.sheet, { transform: [{ translateY: slideAnim }] }]}
+          pointerEvents="auto"
+          {...panResponder.panHandlers}
+        >
           {/* Always-on drag region: handle + header. Anywhere in this strip
               the user can pull down to dismiss without needing the
-              scroll-position check the body uses. */}
-          <GestureDetector gesture={headerPanGesture}>
-            <View>
-              <View style={styles.dragArea}>
-                <View style={styles.handle} />
-              </View>
+              scroll-position check the body uses. Andy's TF feedback was
+              that you "had to grip the top" — expanding this region to
+              include the lemma + meta lines fixes that. */}
+          <View {...handlePanResponder.panHandlers}>
+            <View style={styles.dragArea}>
+              <View style={styles.handle} />
+            </View>
 
-              {/* HEADER */}
-              <View style={styles.header} testID={`${testID}-header`}>
-                <View style={styles.headerRow}>
-                  <Text
-                    style={[styles.lemma, lemmaIsHebrew && styles.lemmaRtl]}
-                    accessibilityRole="header"
-                  >
-                    {entry.lemma}
-                  </Text>
-                  <Text style={styles.translit}>{entry.translit}</Text>
+            {/* HEADER */}
+            <View style={styles.header} testID={`${testID}-header`}>
+              <View style={styles.headerRow}>
+                <Text
+                  style={[styles.lemma, lemmaIsHebrew && styles.lemmaRtl]}
+                  accessibilityRole="header"
+                >
+                  {entry.lemma}
+                </Text>
+                <Text style={styles.translit}>{entry.translit}</Text>
+              </View>
+              <Text style={styles.metaLine}>
+                {entry.pos} • {entry.strongs}
+                {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
+                {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
+                  ? ` • ${entry.otFrequency}× in OT`
+                  : ''}
+                {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
+                  ? ` • ${entry.ntFrequency}× in NT`
+                  : ''}
+              </Text>
+            </View>
+          </View>
+
+          <ScrollView
+            style={styles.scroll}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            onScroll={(e) => {
+              scrollYRef.current = e.nativeEvent.contentOffset.y;
+            }}
+            scrollEventThrottle={16}
+          >
+            {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
+            {contextual ? (
+              <Section
+                label="In this verse"
+                highlight
+                styles={styles}
+                testID={`${testID}-contextual`}
+              >
+                <Text style={styles.bodyText}>{contextual}</Text>
+              </Section>
+            ) : null}
+
+            {/* BASIC SENSE */}
+            <Section label="Basic sense" styles={styles} testID={`${testID}-basic`}>
+              <Text style={styles.bodyText}>{entry.basicGloss}</Text>
+            </Section>
+
+            {/* SEMANTIC RANGE */}
+            {entry.semanticRange && entry.semanticRange.length > 0 ? (
+              <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
+                <View style={styles.listWrap}>
+                  {entry.semanticRange.map((s) => (
+                    <View key={s} style={styles.listRow}>
+                      <Text style={styles.listBullet}>•</Text>
+                      <Text style={styles.listText}>{s}</Text>
+                    </View>
+                  ))}
                 </View>
-                <Text style={styles.metaLine}>
-                  {entry.pos} • {entry.strongs}
-                  {entry.pronunciation ? ` • ${entry.pronunciation}` : ''}
-                  {typeof entry.otFrequency === 'number' && entry.otFrequency > 0
-                    ? ` • ${entry.otFrequency}× in OT`
-                    : ''}
-                  {typeof entry.ntFrequency === 'number' && entry.ntFrequency > 0
-                    ? ` • ${entry.ntFrequency}× in NT`
-                    : ''}
+              </Section>
+            ) : null}
+
+            {/* RELATED WORDS */}
+            {entry.related && entry.related.length > 0 ? (
+              <Section label="Related" styles={styles} testID={`${testID}-related`}>
+                <View style={styles.relatedWrap}>
+                  {entry.related.map((r, i) => {
+                    const rIsHebrew = isHebrew(r.lemma);
+                    return (
+                      <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
+                        <View style={styles.relatedHeadRow}>
+                          <Text style={[styles.relatedLemma, rIsHebrew && styles.lemmaRtl]}>
+                            {r.lemma}
+                          </Text>
+                          <Text style={styles.relatedTranslit}>{r.translit}</Text>
+                        </View>
+                        <Text style={styles.relatedNote}>{r.note}</Text>
+                      </View>
+                    );
+                  })}
+                </View>
+              </Section>
+            ) : null}
+
+            {/* LEXICAL NOTE */}
+            {entry.notes ? (
+              <Section label="Lexical note" styles={styles} testID={`${testID}-notes`}>
+                <Text style={styles.notesText}>{entry.notes}</Text>
+              </Section>
+            ) : null}
+
+            {/* LOADED CAVEAT — no border, last row */}
+            {entry.loaded ? (
+              <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
+                <Text style={styles.caveatText}>
+                  Context-sensitive: this word carries multiple senses across the NT. Meaning is
+                  governed by usage, not a single gloss.
                 </Text>
               </View>
-            </View>
-          </GestureDetector>
-
-          <GestureDetector gesture={Gesture.Simultaneous(bodyPanGesture, scrollNativeGesture)}>
-            <ScrollView
-              style={styles.scroll}
-              contentContainerStyle={styles.scrollContent}
-              showsVerticalScrollIndicator={false}
-              onScroll={(e) => {
-                scrollY.value = e.nativeEvent.contentOffset.y;
-              }}
-              scrollEventThrottle={16}
-            >
-              {/* IN THIS VERSE (Layer 2 — contextual gloss) */}
-              {contextual ? (
-                <Section
-                  label="In this verse"
-                  highlight
-                  styles={styles}
-                  testID={`${testID}-contextual`}
-                >
-                  <Text style={styles.bodyText}>{contextual}</Text>
-                </Section>
-              ) : null}
-
-              {/* BASIC SENSE */}
-              <Section label="Basic sense" styles={styles} testID={`${testID}-basic`}>
-                <Text style={styles.bodyText}>{entry.basicGloss}</Text>
-              </Section>
-
-              {/* SEMANTIC RANGE */}
-              {entry.semanticRange && entry.semanticRange.length > 0 ? (
-                <Section label="Semantic range" styles={styles} testID={`${testID}-range`}>
-                  <View style={styles.listWrap}>
-                    {entry.semanticRange.map((s) => (
-                      <View key={s} style={styles.listRow}>
-                        <Text style={styles.listBullet}>•</Text>
-                        <Text style={styles.listText}>{s}</Text>
-                      </View>
-                    ))}
-                  </View>
-                </Section>
-              ) : null}
-
-              {/* RELATED WORDS */}
-              {entry.related && entry.related.length > 0 ? (
-                <Section label="Related" styles={styles} testID={`${testID}-related`}>
-                  <View style={styles.relatedWrap}>
-                    {entry.related.map((r, i) => {
-                      const rIsHebrew = isHebrew(r.lemma);
-                      return (
-                        <View key={`${r.lemma}-${i}`} style={styles.relatedItem}>
-                          <View style={styles.relatedHeadRow}>
-                            <Text style={[styles.relatedLemma, rIsHebrew && styles.lemmaRtl]}>
-                              {r.lemma}
-                            </Text>
-                            <Text style={styles.relatedTranslit}>{r.translit}</Text>
-                          </View>
-                          <Text style={styles.relatedNote}>{r.note}</Text>
-                        </View>
-                      );
-                    })}
-                  </View>
-                </Section>
-              ) : null}
-
-              {/* LEXICAL NOTE */}
-              {entry.notes ? (
-                <Section label="Lexical note" styles={styles} testID={`${testID}-notes`}>
-                  <Text style={styles.notesText}>{entry.notes}</Text>
-                </Section>
-              ) : null}
-
-              {/* LOADED CAVEAT — no border, last row */}
-              {entry.loaded ? (
-                <View style={styles.caveatBlock} testID={`${testID}-loaded`}>
-                  <Text style={styles.caveatText}>
-                    Context-sensitive: this word carries multiple senses across the NT. Meaning is
-                    governed by usage, not a single gloss.
-                  </Text>
-                </View>
-              ) : null}
-            </ScrollView>
-          </GestureDetector>
+            ) : null}
+          </ScrollView>
         </Animated.View>
       </View>
     </Modal>

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -1339,6 +1339,14 @@ const createStyles = (colors: Colors) =>
       paddingVertical: 2,
       borderRadius: 999,
       backgroundColor: colors.gold,
+      // Nudges the pill down so its visual top aligns with the body
+      // text's first-line cap-height. With bodySmall (14) + lineHeights.body
+      // (~1.5) the line-box has ~3.5px above the cap; matching that here
+      // keeps the pill from "floating" above the text. This was originally
+      // added in round 2 (a925ee4), accidentally dropped when round 3
+      // restored the side-by-side layout (a05a4c8). Andy round 4 #1 surfaced
+      // the regression.
+      marginTop: 4,
     },
     bulletTagText: {
       fontSize: fontSizes.caption,

--- a/components/bible/VisualsPanel.tsx
+++ b/components/bible/VisualsPanel.tsx
@@ -184,17 +184,13 @@ export function VisualsPanel({
   // IFrame Player API. When YouTube hard-refuses the embed (channel-level
   // block, age gate, etc.) `onError` flips `videoError = true` so we can
   // surface a "open in YouTube" fallback.
-  const [videoPlaying, setVideoPlaying] = useState(false);
+  // Round 4: drop the in-app thumbnail + play overlay (Andy: "we have to click
+  // twice on video to watch"). YoutubePlayer now mounts directly, with its own
+  // play button as the first interaction — single tap to start.
   const [videoError, setVideoError] = useState(false);
-  const handleVideoPress = useCallback(() => {
-    if (!video) return;
-    setVideoError(false);
-    setVideoPlaying(true);
-  }, [video]);
   // Reset playback state on chapter change — a new chapter may have a
   // different (or no) video.
   useEffect(() => {
-    setVideoPlaying(false);
     setVideoError(false);
   }, [bookId, chapter]);
 
@@ -433,114 +429,47 @@ export function VisualsPanel({
           to the thumbnail in either case. */}
       {video ? (
         <View style={styles.videoCard} testID={`${testID}-video-card`}>
-          {videoPlaying && videoError ? (
-            <>
-              <View style={styles.videoErrorOverlay}>
-                <Ionicons name="alert-circle-outline" size={32} color="#FAF6EA" />
-                <Text style={styles.videoErrorTitle}>Video can&apos;t play in-app</Text>
-                <Pressable
-                  onPress={handleVideoFallback}
-                  style={styles.videoErrorButton}
-                  accessibilityRole="button"
-                  accessibilityLabel="Open video in YouTube"
-                  testID={`${testID}-video-open-external`}
-                >
-                  <Text style={styles.videoErrorButtonText}>Open in YouTube</Text>
-                </Pressable>
-              </View>
+          {videoError ? (
+            <View style={styles.videoErrorOverlay}>
+              <Ionicons name="alert-circle-outline" size={32} color="#FAF6EA" />
+              <Text style={styles.videoErrorTitle}>Video can&apos;t play in-app</Text>
               <Pressable
-                onPress={() => {
-                  setVideoPlaying(false);
-                  setVideoError(false);
-                }}
-                style={styles.videoCloseButton}
+                onPress={handleVideoFallback}
+                style={styles.videoErrorButton}
                 accessibilityRole="button"
-                accessibilityLabel="Close video and return to thumbnail"
-                testID={`${testID}-video-close`}
-                hitSlop={12}
+                accessibilityLabel="Open video in YouTube"
+                testID={`${testID}-video-open-external`}
               >
-                <Ionicons name="close" size={20} color="#FAF6EA" />
+                <Text style={styles.videoErrorButtonText}>Open in YouTube</Text>
               </Pressable>
-            </>
-          ) : videoPlaying ? (
-            <>
-              <YoutubePlayer
-                videoId={video.youtubeId}
-                height={videoPlayerHeight}
-                play={videoPlaying}
-                webViewStyle={styles.videoWebView}
-                // The parent `videoCard` is `aspectRatio: 16/9`, so the
-                // fixed `height={220}` would otherwise letterbox on
-                // tablets / landscape. Stretch the inner container to
-                // the card so playback fills the available 16:9 box.
-                viewContainerStyle={StyleSheet.absoluteFillObject}
-                onChangeState={(state: string) => {
-                  // States: 'unstarted' | 'ended' | 'playing' | 'paused'
-                  // | 'buffering' | 'video cued'. No-op for now —
-                  // logged for future analytics hooks.
-                  if (__DEV__) {
-                    console.debug('[VisualsPanel] yt state:', state);
-                  }
-                }}
-                onError={(err: string) => {
-                  // Error codes (per IFrame Player API): 2, 5, 100,
-                  // 101, 150 — the latter three are channel/embed
-                  // restrictions like the BibleProject "153" Andy
-                  // hit. Flip to the fallback UI in all cases.
-                  console.warn('[VisualsPanel] yt embed error:', err);
-                  setVideoError(true);
-                }}
-                webViewProps={{
-                  allowsInlineMediaPlayback: true,
-                  mediaPlaybackRequiresUserAction: false,
-                  androidLayerType: 'hardware',
-                }}
-              />
-              <Pressable
-                onPress={() => setVideoPlaying(false)}
-                style={styles.videoCloseButton}
-                accessibilityRole="button"
-                accessibilityLabel="Close video and return to thumbnail"
-                testID={`${testID}-video-close`}
-                hitSlop={12}
-              >
-                <Ionicons name="close" size={20} color="#FAF6EA" />
-              </Pressable>
-            </>
+            </View>
           ) : (
-            <Pressable
-              onPress={handleVideoPress}
-              style={StyleSheet.absoluteFill}
-              accessibilityRole="button"
-              accessibilityLabel={`Play the BibleProject ${bookName} overview video`}
-            >
-              {/* Thumbnail backdrop — use the first card's thumb (typically
-                  the BibleProject poster) as a tinted backdrop. */}
-              {cards[0] ? (
-                <Image
-                  source={{ uri: absolutizeVisualUrl(cards[0].thumb) }}
-                  style={styles.videoBackdrop}
-                  contentFit="cover"
-                  transition={150}
-                />
-              ) : null}
-              <View style={styles.videoOverlay} />
-              <View style={styles.videoOverlayContent}>
-                <View style={styles.playButton}>
-                  <Ionicons name="play" size={28} color="#1B1B1B" />
-                </View>
-                <Text style={styles.videoTitle} numberOfLines={2}>
-                  {video.title}
-                </Text>
-                <Text style={styles.videoSubtitle}>BibleProject overview · animated explainer</Text>
-                <Text style={styles.videoRange}>
-                  Covers chapters {video.chapterStart}–{video.chapterEnd}
-                </Text>
-              </View>
-              <View style={styles.attributionBadge}>
-                <Text style={styles.attributionBadgeText}>BibleProject · CC BY-SA 4.0</Text>
-              </View>
-            </Pressable>
+            // Single-tap start: YoutubePlayer mounts directly with its own
+            // YouTube-branded play button. Removed our thumbnail-with-play
+            // overlay (Andy: "we have to click twice on video to watch").
+            // `play={false}` initially — first tap on YouTube's own play
+            // button starts playback.
+            <YoutubePlayer
+              videoId={video.youtubeId}
+              height={videoPlayerHeight}
+              play={false}
+              webViewStyle={styles.videoWebView}
+              viewContainerStyle={StyleSheet.absoluteFillObject}
+              onChangeState={(state: string) => {
+                if (__DEV__) {
+                  console.debug('[VisualsPanel] yt state:', state);
+                }
+              }}
+              onError={(err: string) => {
+                console.warn('[VisualsPanel] yt embed error:', err);
+                setVideoError(true);
+              }}
+              webViewProps={{
+                allowsInlineMediaPlayback: true,
+                mediaPlaybackRequiresUserAction: false,
+                androidLayerType: 'hardware',
+              }}
+            />
           )}
         </View>
       ) : null}

--- a/modules/dotted-underline-text/android/build.gradle
+++ b/modules/dotted-underline-text/android/build.gradle
@@ -1,0 +1,71 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'maven-publish'
+
+group = 'expo.modules.dottedunderlinetext'
+version = '1.0.0'
+
+buildscript {
+  def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+  if (expoModulesCorePlugin.exists()) {
+    apply from: expoModulesCorePlugin
+    applyKotlinExpoModulesCorePlugin()
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+      }
+    }
+    repositories {
+      maven {
+        url = mavenLocal().url
+      }
+    }
+  }
+}
+
+android {
+  namespace "expo.modules.dottedunderlinetext"
+  compileSdkVersion safeExtGet("compileSdkVersion", 34)
+
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 23)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+  }
+
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
+
+  lintOptions {
+    abortOnError false
+  }
+
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
+
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
+  }
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "androidx.appcompat:appcompat:1.6.1"
+}
+
+def safeExtGet(prop, fallback) {
+  rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}

--- a/modules/dotted-underline-text/android/src/main/AndroidManifest.xml
+++ b/modules/dotted-underline-text/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+</manifest>

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
@@ -49,8 +49,11 @@ class DottedUnderlineTextModule : Module() {
       Prop("fontSize") { view: DottedUnderlineTextView, value: Double? ->
         if (value != null) view.setFontSize(value.toFloat())
       }
-      Prop("color") { view: DottedUnderlineTextView, value: Int? ->
-        if (value != null) view.setTextColor(value)
+      Prop("color") { view: DottedUnderlineTextView, value: String? ->
+        // JS forwards `style.color` as a hex/rgba string. Expo's Android
+        // bridge doesn't auto-coerce strings to Int for color props
+        // (unlike iOS UIColor decoding), so we parse manually here.
+        view.setTextColor(parseColorOr(value, Color.BLACK))
       }
       Prop("fontFamily") { view: DottedUnderlineTextView, value: String? ->
         view.setFontFamily(value)
@@ -67,8 +70,8 @@ class DottedUnderlineTextModule : Module() {
       Prop("textAlign") { view: DottedUnderlineTextView, value: String? ->
         view.setTextAlign(value)
       }
-      Prop("underlineColor") { view: DottedUnderlineTextView, value: Int? ->
-        if (value != null) view.setUnderlineColor(value)
+      Prop("underlineColor") { view: DottedUnderlineTextView, value: String? ->
+        view.setUnderlineColor(parseColorOr(value, Color.BLACK))
       }
       Prop("underlineStyle") { view: DottedUnderlineTextView, value: String? ->
         view.setUnderlineStyle(value ?: "dotted")

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
@@ -1,0 +1,91 @@
+package expo.modules.dottedunderlinetext
+
+import android.graphics.Color
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+
+/**
+ * Range record forwarded from JS via the `ranges` prop. The Expo Records
+ * machinery deserializes plain JS objects into this type automatically when
+ * referenced as a Prop value type.
+ */
+class RangeRecord : Record {
+  @Field var start: Int = 0
+  @Field var end: Int = 0
+  @Field var style: String? = null
+  @Field var color: String? = null
+  @Field var thickness: Double? = null
+}
+
+class DottedUnderlineTextModule : Module() {
+  override fun definition() = ModuleDefinition {
+    Name("DottedUnderlineText")
+
+    View(DottedUnderlineTextView::class) {
+      Events("onPress", "onRangeTap")
+
+      Prop("text") { view: DottedUnderlineTextView, value: String? ->
+        view.setText(value ?: "")
+      }
+      Prop("fontSize") { view: DottedUnderlineTextView, value: Double? ->
+        if (value != null) view.setFontSize(value.toFloat())
+      }
+      Prop("color") { view: DottedUnderlineTextView, value: Int? ->
+        if (value != null) view.setTextColor(value)
+      }
+      Prop("fontFamily") { view: DottedUnderlineTextView, value: String? ->
+        view.setFontFamily(value)
+      }
+      Prop("fontWeight") { view: DottedUnderlineTextView, value: String? ->
+        view.setFontWeight(value)
+      }
+      Prop("letterSpacing") { view: DottedUnderlineTextView, value: Double? ->
+        if (value != null) view.setLetterSpacing(value.toFloat())
+      }
+      Prop("lineHeight") { view: DottedUnderlineTextView, value: Double? ->
+        if (value != null) view.setLineHeightPx(value.toFloat())
+      }
+      Prop("textAlign") { view: DottedUnderlineTextView, value: String? ->
+        view.setTextAlign(value)
+      }
+      Prop("underlineColor") { view: DottedUnderlineTextView, value: Int? ->
+        if (value != null) view.setUnderlineColor(value)
+      }
+      Prop("underlineStyle") { view: DottedUnderlineTextView, value: String? ->
+        view.setUnderlineStyle(value ?: "dotted")
+      }
+      Prop("underlineThickness") { view: DottedUnderlineTextView, value: Double? ->
+        view.setUnderlineThickness((value ?: 1.0).toFloat())
+      }
+      Prop("ranges") { view: DottedUnderlineTextView, value: List<RangeRecord>? ->
+        if (value == null) {
+          view.setRanges(null)
+        } else {
+          val descriptors = value.map { r ->
+            val parsedColor = try {
+              if (!r.color.isNullOrEmpty()) Color.parseColor(r.color) else Color.BLACK
+            } catch (_: IllegalArgumentException) {
+              Color.BLACK
+            }
+            UnderlineDescriptor(
+              start = r.start,
+              end = r.end,
+              color = parsedColor,
+              thicknessDp = (r.thickness ?: 1.0).toFloat(),
+              isDotted = (r.style ?: "dotted") == "dotted"
+            )
+          }
+          view.setRanges(descriptors)
+        }
+      }
+      Prop("selectable") { view: DottedUnderlineTextView, value: Boolean? ->
+        view.setSelectableText(value ?: true)
+      }
+      Prop("accessibilityLabel") { view: DottedUnderlineTextView, value: String? ->
+        view.setAccessibilityLabelText(value)
+      }
+    }
+  }
+}

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextModule.kt
@@ -11,12 +11,29 @@ import expo.modules.kotlin.records.Record
  * machinery deserializes plain JS objects into this type automatically when
  * referenced as a Prop value type.
  */
+/** Parse a color string the JS side might send. Returns `fallback` on
+ *  failure (logs no error — we don't want a typo'd hex to crash render). */
+private fun parseColorOr(value: String?, fallback: Int): Int {
+  if (value.isNullOrEmpty()) return fallback
+  return try { Color.parseColor(value) } catch (_: IllegalArgumentException) { fallback }
+}
+
+/** Returns null instead of a fallback color so callers can branch on
+ *  "this range has no per-range background/textColor at all". */
+private fun parseColorOrNull(value: String?): Int? {
+  if (value.isNullOrEmpty()) return null
+  return try { Color.parseColor(value) } catch (_: IllegalArgumentException) { null }
+}
+
 class RangeRecord : Record {
   @Field var start: Int = 0
   @Field var end: Int = 0
   @Field var style: String? = null
   @Field var color: String? = null
   @Field var thickness: Double? = null
+  @Field var backgroundColor: String? = null
+  @Field var fontWeight: String? = null
+  @Field var textColor: String? = null
 }
 
 class DottedUnderlineTextModule : Module() {
@@ -64,17 +81,17 @@ class DottedUnderlineTextModule : Module() {
           view.setRanges(null)
         } else {
           val descriptors = value.map { r ->
-            val parsedColor = try {
-              if (!r.color.isNullOrEmpty()) Color.parseColor(r.color) else Color.BLACK
-            } catch (_: IllegalArgumentException) {
-              Color.BLACK
-            }
+            val parsedUnderlineColor = parseColorOr(r.color, Color.BLACK)
             UnderlineDescriptor(
               start = r.start,
               end = r.end,
-              color = parsedColor,
+              color = parsedUnderlineColor,
               thicknessDp = (r.thickness ?: 1.0).toFloat(),
-              isDotted = (r.style ?: "dotted") == "dotted"
+              hasUnderline = !r.style.isNullOrEmpty(),
+              isDotted = (r.style ?: "dotted") == "dotted",
+              backgroundColor = parseColorOrNull(r.backgroundColor),
+              fontWeight = r.fontWeight,
+              textColor = parseColorOrNull(r.textColor)
             )
           }
           view.setRanges(descriptors)

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
@@ -1,0 +1,351 @@
+package expo.modules.dottedunderlinetext
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.DashPathEffect
+import android.graphics.Paint
+import android.graphics.Typeface
+import android.text.method.LinkMovementMethod
+import android.util.TypedValue
+import android.view.MotionEvent
+import android.view.ViewGroup
+import android.widget.LinearLayout
+import androidx.appcompat.widget.AppCompatTextView
+import expo.modules.kotlin.AppContext
+import expo.modules.kotlin.viewevent.EventDispatcher
+import expo.modules.kotlin.views.ExpoView
+
+/**
+ * One range of decoration to draw on top of the text.
+ *
+ * `start`/`end` are character indices into the view's text (end exclusive,
+ * matching JS String.slice).
+ */
+data class UnderlineDescriptor(
+  val start: Int,
+  val end: Int,
+  val color: Int,
+  val thicknessDp: Float,
+  val isDotted: Boolean
+)
+
+/**
+ * Custom TextView that draws CSS-style dotted (or solid) underlines beneath
+ * the text. Two modes:
+ *  - Whole-text mode (default): one underline for the entire text, using the
+ *    `underlineColor`/`underlineStyle`/`underlineThickness` props.
+ *  - Per-range mode: when the `ranges` prop is set, only the specified
+ *    character ranges are underlined (each with their own color/style/
+ *    thickness). This lets HighlightedText render a single verse as one
+ *    Spannable while still showing per-word lexicon underlines.
+ *
+ * We do the drawing in `onDraw` rather than via UnderlineSpan because
+ * Android's UnderlineSpan is always solid and gives no control over color
+ * or thickness. Drawing manually means we can produce true dots with
+ * `DashPathEffect` and color/thickness per range.
+ */
+@SuppressLint("AppCompatCustomView", "ViewConstructor")
+class DottedUnderlineTextView(context: Context, appContext: AppContext) :
+  ExpoView(context, appContext) {
+
+  // RN doesn't always re-measure ExpoView children when the underlying text
+  // changes; opting into Android layout makes the inner TextView re-wrap.
+  override val shouldUseAndroidLayout: Boolean = true
+
+  internal val onPress by EventDispatcher<Map<String, Any?>>()
+  internal val onRangeTap by EventDispatcher<Map<String, Any?>>()
+
+  private val textView: InnerTextView = InnerTextView(context).apply {
+    // Match RN <Text> defaults as closely as possible.
+    setTextColor(Color.BLACK)
+    includeFontPadding = false
+    isClickable = true
+    isLongClickable = true
+    movementMethod = LinkMovementMethod.getInstance()
+  }
+
+  init {
+    // Fill the ExpoView (which is sized by Yoga) horizontally so the inner
+    // TextView wraps at the same width RN gave us.
+    addView(
+      textView,
+      LinearLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT
+      )
+    )
+  }
+
+  // ---- Props (called by the Module's Prop bindings) ---------------------
+
+  fun setText(value: String) {
+    textView.text = value
+    textView.requestLayout()
+    textView.invalidate()
+  }
+
+  fun setFontSize(sizeSp: Float) {
+    textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, sizeSp)
+  }
+
+  fun setTextColor(colorInt: Int) {
+    textView.setTextColor(colorInt)
+  }
+
+  fun setFontFamily(family: String?) {
+    val tf = if (family.isNullOrEmpty()) Typeface.DEFAULT else Typeface.create(family, Typeface.NORMAL)
+    textView.typeface = tf
+  }
+
+  fun setFontWeight(weight: String?) {
+    val isBold = weight == "bold" || (weight?.toIntOrNull() ?: 400) >= 600
+    val base = textView.typeface ?: Typeface.DEFAULT
+    textView.typeface = if (isBold) Typeface.create(base, Typeface.BOLD) else Typeface.create(base, Typeface.NORMAL)
+  }
+
+  fun setLetterSpacing(value: Float) {
+    // RN passes letterSpacing in px-equivalent; TextView uses em units.
+    val fontPx = textView.textSize.takeIf { it > 0 } ?: 1f
+    textView.letterSpacing = value / fontPx
+  }
+
+  fun setLineHeightPx(value: Float) {
+    textView.setLineSpacing(0f, 1f) // reset multiplier
+    val density = resources.displayMetrics.density
+    textView.lineHeight = (value * density).toInt().coerceAtLeast(1)
+  }
+
+  fun setTextAlign(value: String?) {
+    textView.textAlignment = when (value) {
+      "center" -> android.view.View.TEXT_ALIGNMENT_CENTER
+      "right" -> android.view.View.TEXT_ALIGNMENT_VIEW_END
+      "left" -> android.view.View.TEXT_ALIGNMENT_VIEW_START
+      "justify" -> android.view.View.TEXT_ALIGNMENT_INHERIT
+      else -> android.view.View.TEXT_ALIGNMENT_INHERIT
+    }
+  }
+
+  fun setUnderlineColor(colorInt: Int) {
+    textView.underlineColor = colorInt
+    textView.invalidate()
+  }
+
+  fun setUnderlineStyle(style: String) {
+    textView.underlineStyle = style
+    textView.invalidate()
+  }
+
+  fun setUnderlineThickness(thicknessDp: Float) {
+    textView.underlineThicknessDp = thicknessDp
+    textView.invalidate()
+  }
+
+  fun setRanges(ranges: List<UnderlineDescriptor>?) {
+    textView.ranges = ranges
+    textView.invalidate()
+  }
+
+  fun setSelectableText(selectable: Boolean) {
+    textView.setTextIsSelectable(selectable)
+  }
+
+  fun setAccessibilityLabelText(label: String?) {
+    textView.contentDescription = label
+  }
+
+  // -----------------------------------------------------------------------
+
+  /**
+   * Inner AppCompatTextView that does the actual drawing. We separate this
+   * from the ExpoView wrapper so the wrapper can host RN layout / event
+   * plumbing while the TextView focuses on text + custom underline rendering.
+   */
+  @SuppressLint("AppCompatCustomView", "ViewConstructor")
+  private inner class InnerTextView(ctx: Context) : AppCompatTextView(ctx) {
+    var underlineColor: Int = Color.BLACK
+    var underlineStyle: String = "dotted"
+    var underlineThicknessDp: Float = 1f
+    var ranges: List<UnderlineDescriptor>? = null
+
+    private val underlinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+      style = Paint.Style.STROKE
+    }
+
+    // Touch tracking for per-range tap detection. ACTION_DOWN coords vs.
+    // ACTION_UP coords let us distinguish a tap (no movement, no long-press)
+    // from a drag/long-press for selection. Using touchSlop as the threshold.
+    private var downX: Float = 0f
+    private var downY: Float = 0f
+    private var downTimeMs: Long = 0L
+
+    override fun onDraw(canvas: Canvas) {
+      super.onDraw(canvas)
+
+      val layout = layout ?: return
+      val density = resources.displayMetrics.density
+
+      val rs = ranges
+      if (rs != null) {
+        // Per-range mode: each range drawn independently.
+        for (r in rs) {
+          drawRange(canvas, layout, density, r)
+        }
+      } else {
+        // Whole-text mode: single underline across each line.
+        drawWholeText(canvas, layout, density)
+      }
+    }
+
+    private fun drawWholeText(canvas: Canvas, layout: android.text.Layout, density: Float) {
+      val strokePx = underlineThicknessDp * density
+      underlinePaint.color = underlineColor
+      underlinePaint.strokeWidth = strokePx
+      underlinePaint.pathEffect = if (underlineStyle == "dotted") {
+        val seg = 2f * density
+        DashPathEffect(floatArrayOf(seg, seg), 0f)
+      } else {
+        null
+      }
+
+      // Clear descender area below the baseline before drawing the line.
+      val offsetPx = 3f * density
+
+      for (i in 0 until layout.lineCount) {
+        val baseline = layout.getLineBaseline(i).toFloat()
+        val left = layout.getLineLeft(i)
+        val right = layout.getLineRight(i)
+        val y = baseline + offsetPx
+
+        // NB: dotted dashes look best when drawn left-to-right; for RTL lines
+        // (Arabic / Hebrew) the visual order is still left-to-right at the
+        // pixel level, so this works without extra logic.
+        canvas.drawLine(left + paddingLeft, y, right + paddingLeft, y, underlinePaint)
+      }
+    }
+
+    private fun drawRange(
+      canvas: Canvas,
+      layout: android.text.Layout,
+      density: Float,
+      r: UnderlineDescriptor
+    ) {
+      val textLen = (text?.length ?: 0)
+      if (textLen == 0) return
+      val safeStart = r.start.coerceIn(0, textLen)
+      val safeEnd = r.end.coerceIn(safeStart, textLen)
+      if (safeEnd <= safeStart) return
+
+      val strokePx = r.thicknessDp * density
+      underlinePaint.color = r.color
+      underlinePaint.strokeWidth = strokePx
+      underlinePaint.pathEffect = if (r.isDotted) {
+        val seg = 2f * density
+        DashPathEffect(floatArrayOf(seg, seg), 0f)
+      } else {
+        null
+      }
+
+      val offsetPx = 3f * density
+      // Walk the lines the range spans. For each line, the visible portion
+      // of the range is [max(rangeStart, lineStart) .. min(rangeEnd, lineEnd)].
+      val startLine = layout.getLineForOffset(safeStart)
+      val endLine = layout.getLineForOffset(safeEnd)
+      for (line in startLine..endLine) {
+        val lineStart = layout.getLineStart(line)
+        val lineEnd = layout.getLineEnd(line)
+        val from = maxOf(safeStart, lineStart)
+        // getLineEnd includes trailing whitespace + the newline; cap at
+        // safeEnd so we don't underline characters past the range.
+        val to = minOf(safeEnd, lineEnd)
+        if (to <= from) continue
+
+        val xFrom = layout.getPrimaryHorizontal(from)
+        // For the last position on a line, getPrimaryHorizontal returns the
+        // x at the END of the character only when `to` is < lineEnd; if
+        // `to == lineEnd` we want the right edge of the last char, which
+        // is also the x for position `to`.
+        val xTo = layout.getPrimaryHorizontal(to)
+        val baseline = layout.getLineBaseline(line).toFloat()
+        val y = baseline + offsetPx
+        canvas.drawLine(
+          xFrom + paddingLeft,
+          y,
+          xTo + paddingLeft,
+          y,
+          underlinePaint
+        )
+      }
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+      // Capture down position so ACTION_UP can decide tap-vs-drag and which
+      // range was hit. We still call super so selection / link movement
+      // gestures keep working.
+      when (event.action) {
+        MotionEvent.ACTION_DOWN -> {
+          downX = event.x
+          downY = event.y
+          downTimeMs = event.eventTime
+        }
+        MotionEvent.ACTION_UP -> {
+          val dx = event.x - downX
+          val dy = event.y - downY
+          val touchSlop = android.view.ViewConfiguration.get(context).scaledTouchSlop
+          val pressTimeout = android.view.ViewConfiguration.getLongPressTimeout()
+          val isTap = dx * dx + dy * dy <= touchSlop * touchSlop &&
+            (event.eventTime - downTimeMs) < pressTimeout
+          if (isTap) {
+            val hitIndex = hitTestRangeIndex(event.x, event.y)
+            if (hitIndex >= 0) {
+              this@DottedUnderlineTextView.onRangeTap(mapOf("index" to hitIndex))
+              // Consume the tap when it lands on a range so the outer
+              // onPress / underlying selection toggle doesn't also fire.
+              super.onTouchEvent(event)
+              return true
+            }
+            // Fall through to default behaviour, then forward outer onPress.
+            val handled = super.onTouchEvent(event)
+            this@DottedUnderlineTextView.onPress(emptyMap())
+            return handled
+          }
+        }
+      }
+      return super.onTouchEvent(event)
+    }
+
+    /**
+     * Convert a touch (x, y) into the index of the matching range, or -1
+     * if the touch did not land inside any range.
+     */
+    private fun hitTestRangeIndex(x: Float, y: Float): Int {
+      val rs = ranges ?: return -1
+      val layout = layout ?: return -1
+      val line = layout.getLineForVertical(y.toInt())
+      if (line < 0) return -1
+      val xInLayout = x - paddingLeft
+      // getOffsetForHorizontal can return positions outside the actual
+      // visible characters on lines with trailing space; getLineEnd-1 gives
+      // a safer upper bound for ASCII text. For Bible content this is fine.
+      val offset = layout.getOffsetForHorizontal(line, xInLayout)
+      for (i in rs.indices) {
+        val r = rs[i]
+        if (offset in r.start until r.end) {
+          return i
+        }
+      }
+      return -1
+    }
+
+    override fun performClick(): Boolean {
+      super.performClick()
+      return true
+    }
+  }
+
+  // Forward parent click through to onPress dispatcher (set in init).
+  override fun performClick(): Boolean {
+    return super.performClick()
+  }
+}

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
@@ -89,6 +89,28 @@ class DottedUnderlineTextView(context: Context, appContext: AppContext) :
     )
   }
 
+  /**
+   * Yoga sometimes gives the ExpoView a width of 0/1 (UNSPECIFIED first pass)
+   * which causes the TextView to wrap each character into its own line. We
+   * still need to call super (LinearLayout) first so its internal mMaxAscent
+   * / mMaxDescent arrays are populated for onLayout — skipping it causes an
+   * NPE in `LinearLayout.layoutHorizontal`. If super's measure gave us a
+   * collapsed size but the incoming width spec is actually known, re-measure
+   * the inner TextView at that real width and override the dimension.
+   */
+  override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+    super.onMeasure(widthMeasureSpec, heightMeasureSpec)
+    val incomingWidth = MeasureSpec.getSize(widthMeasureSpec)
+    val incomingMode = MeasureSpec.getMode(widthMeasureSpec)
+    val tooSmall = measuredWidth < 8
+    if (tooSmall && incomingMode != MeasureSpec.UNSPECIFIED && incomingWidth >= 8) {
+      val childWidthSpec = MeasureSpec.makeMeasureSpec(incomingWidth, MeasureSpec.EXACTLY)
+      val childHeightSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED)
+      textView.measure(childWidthSpec, childHeightSpec)
+      setMeasuredDimension(incomingWidth, textView.measuredHeight)
+    }
+  }
+
   // ---- Props (called by the Module's Prop bindings) ---------------------
 
   fun setText(value: String) {

--- a/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
+++ b/modules/dotted-underline-text/android/src/main/java/expo/modules/dottedunderlinetext/DottedUnderlineTextView.kt
@@ -7,7 +7,12 @@ import android.graphics.Color
 import android.graphics.DashPathEffect
 import android.graphics.Paint
 import android.graphics.Typeface
+import android.text.SpannableString
+import android.text.Spanned
 import android.text.method.LinkMovementMethod
+import android.text.style.BackgroundColorSpan
+import android.text.style.ForegroundColorSpan
+import android.text.style.StyleSpan
 import android.util.TypedValue
 import android.view.MotionEvent
 import android.view.ViewGroup
@@ -28,7 +33,13 @@ data class UnderlineDescriptor(
   val end: Int,
   val color: Int,
   val thicknessDp: Float,
-  val isDotted: Boolean
+  /** When false the range gets no underline drawn — useful for ranges that
+   *  only carry a background or per-range font/color (e.g. highlights). */
+  val hasUnderline: Boolean,
+  val isDotted: Boolean,
+  val backgroundColor: Int? = null,
+  val fontWeight: String? = null,
+  val textColor: Int? = null,
 )
 
 /**
@@ -81,7 +92,7 @@ class DottedUnderlineTextView(context: Context, appContext: AppContext) :
   // ---- Props (called by the Module's Prop bindings) ---------------------
 
   fun setText(value: String) {
-    textView.text = value
+    textView.setRawText(value)
     textView.requestLayout()
     textView.invalidate()
   }
@@ -143,7 +154,7 @@ class DottedUnderlineTextView(context: Context, appContext: AppContext) :
   }
 
   fun setRanges(ranges: List<UnderlineDescriptor>?) {
-    textView.ranges = ranges
+    textView.setRangesInternal(ranges)
     textView.invalidate()
   }
 
@@ -168,6 +179,69 @@ class DottedUnderlineTextView(context: Context, appContext: AppContext) :
     var underlineStyle: String = "dotted"
     var underlineThicknessDp: Float = 1f
     var ranges: List<UnderlineDescriptor>? = null
+      private set
+
+    /** Raw plain-text content from the JS `text` prop. We cache it because
+     *  the displayed `.text` may be a SpannableString built from this + the
+     *  current ranges, and we need to rebuild whenever EITHER changes. */
+    private var rawText: String = ""
+
+    /** Public setter routed through `rebuildContent()` so backgroundColor /
+     *  per-range font weight / per-range textColor get re-applied on text
+     *  updates. */
+    fun setRawText(value: String) {
+      rawText = value
+      rebuildContent()
+    }
+
+    fun setRangesInternal(value: List<UnderlineDescriptor>?) {
+      ranges = value
+      rebuildContent()
+    }
+
+    /** Rebuild the displayed text. If any range carries a backgroundColor,
+     *  textColor, or bold fontWeight we wrap the text in a SpannableString
+     *  with matching spans. Otherwise we use the plain string (cheaper).
+     *  Underlines are drawn separately in `onDraw` (per-range, manual) for
+     *  pixel control. */
+    private fun rebuildContent() {
+      val rs = ranges
+      val needsSpannable = rs != null && rs.any {
+        it.backgroundColor != null || it.textColor != null || isBoldWeight(it.fontWeight)
+      }
+      if (!needsSpannable || rawText.isEmpty()) {
+        this.text = rawText
+        return
+      }
+      val spannable = SpannableString(rawText)
+      for (r in rs ?: emptyList()) {
+        val safeStart = r.start.coerceIn(0, rawText.length)
+        val safeEnd = r.end.coerceIn(safeStart, rawText.length)
+        if (safeEnd <= safeStart) continue
+        val flag = Spanned.SPAN_EXCLUSIVE_EXCLUSIVE
+        r.backgroundColor?.let {
+          spannable.setSpan(BackgroundColorSpan(it), safeStart, safeEnd, flag)
+        }
+        r.textColor?.let {
+          spannable.setSpan(ForegroundColorSpan(it), safeStart, safeEnd, flag)
+        }
+        if (isBoldWeight(r.fontWeight)) {
+          spannable.setSpan(StyleSpan(Typeface.BOLD), safeStart, safeEnd, flag)
+        }
+      }
+      this.text = spannable
+    }
+
+    /** Map a CSS-style weight string ("400" / "600" / "bold" / etc.) to
+     *  whether it should render bold on Android. Android's StyleSpan only
+     *  supports BOLD / NORMAL / ITALIC / BOLD_ITALIC, so anything ≥ 600
+     *  rounds to bold. */
+    private fun isBoldWeight(value: String?): Boolean {
+      if (value == null) return false
+      if (value == "bold") return true
+      val n = value.toIntOrNull() ?: return false
+      return n >= 600
+    }
 
     private val underlinePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
       style = Paint.Style.STROKE
@@ -231,6 +305,10 @@ class DottedUnderlineTextView(context: Context, appContext: AppContext) :
       density: Float,
       r: UnderlineDescriptor
     ) {
+      // Skip ranges that opted out of an underline (background/font-weight
+      // only — e.g. highlight backgrounds without decoration).
+      if (!r.hasUnderline) return
+
       val textLen = (text?.length ?: 0)
       if (textLen == 0) return
       val safeStart = r.start.coerceIn(0, textLen)

--- a/modules/dotted-underline-text/expo-module.config.json
+++ b/modules/dotted-underline-text/expo-module.config.json
@@ -1,0 +1,10 @@
+{
+  "platforms": ["ios", "android"],
+  "ios": {
+    "modules": ["DottedUnderlineTextModule"],
+    "podspecPath": "./ios/DottedUnderlineText.podspec"
+  },
+  "android": {
+    "modules": ["expo.modules.dottedunderlinetext.DottedUnderlineTextModule"]
+  }
+}

--- a/modules/dotted-underline-text/index.ts
+++ b/modules/dotted-underline-text/index.ts
@@ -1,0 +1,6 @@
+export { DottedUnderlineText } from './src/DottedUnderlineText';
+export type {
+  DottedUnderlineTextProps,
+  UnderlineRange,
+  UnderlineStyle,
+} from './src/DottedUnderlineText.types';

--- a/modules/dotted-underline-text/ios/DottedUnderlineText.podspec
+++ b/modules/dotted-underline-text/ios/DottedUnderlineText.podspec
@@ -1,0 +1,28 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '..', 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = 'DottedUnderlineText'
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = 'https://github.com/versemate/verse-mate-mobile'
+  s.platforms      = {
+    :ios => '15.1'
+  }
+  s.swift_version  = '5.9'
+  s.source         = { git: 'https://github.com/versemate/verse-mate-mobile.git' }
+  s.static_framework = true
+
+  s.dependency 'ExpoModulesCore'
+
+  s.pod_target_xcconfig = {
+    'DEFINES_MODULE' => 'YES',
+    'SWIFT_COMPILATION_MODE' => 'wholemodule'
+  }
+
+  s.source_files = "**/*.{h,m,swift}"
+end

--- a/modules/dotted-underline-text/ios/DottedUnderlineTextModule.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextModule.swift
@@ -11,6 +11,9 @@ struct UnderlineRangeRecord: Record {
   @Field var style: String?
   @Field var color: UIColor?
   @Field var thickness: Double?
+  @Field var backgroundColor: UIColor?
+  @Field var fontWeight: String?
+  @Field var textColor: UIColor?
 }
 
 public class DottedUnderlineTextModule: Module {
@@ -68,8 +71,11 @@ public class DottedUnderlineTextModule: Module {
           UnderlineRangeSpec(
             start: r.start,
             end: r.end,
-            style: r.style ?? "dotted",
-            color: r.color
+            style: r.style,
+            color: r.color,
+            backgroundColor: r.backgroundColor,
+            fontWeight: r.fontWeight,
+            textColor: r.textColor
           )
         }
       }

--- a/modules/dotted-underline-text/ios/DottedUnderlineTextModule.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextModule.swift
@@ -1,0 +1,84 @@
+import ExpoModulesCore
+import UIKit
+
+/**
+ * JS-side representation of `UnderlineRange`. Expo's `Record` machinery
+ * decodes plain JS objects into this when used as a Prop type.
+ */
+struct UnderlineRangeRecord: Record {
+  @Field var start: Int = 0
+  @Field var end: Int = 0
+  @Field var style: String?
+  @Field var color: UIColor?
+  @Field var thickness: Double?
+}
+
+public class DottedUnderlineTextModule: Module {
+  public func definition() -> ModuleDefinition {
+    Name("DottedUnderlineText")
+
+    View(DottedUnderlineTextView.self) {
+      Events("onPress", "onRangeTap")
+
+      Prop("text") { (view: DottedUnderlineTextView, value: String?) in
+        view.text = value ?? ""
+      }
+      Prop("fontSize") { (view: DottedUnderlineTextView, value: Double?) in
+        if let v = value { view.fontSize = CGFloat(v) }
+      }
+      Prop("color") { (view: DottedUnderlineTextView, value: UIColor?) in
+        if let v = value { view.textColor = v }
+      }
+      Prop("fontFamily") { (view: DottedUnderlineTextView, value: String?) in
+        view.fontFamily = value
+      }
+      Prop("fontWeight") { (view: DottedUnderlineTextView, value: String?) in
+        view.fontWeight = value
+      }
+      Prop("letterSpacing") { (view: DottedUnderlineTextView, value: Double?) in
+        view.letterSpacing = CGFloat(value ?? 0)
+      }
+      Prop("lineHeight") { (view: DottedUnderlineTextView, value: Double?) in
+        view.lineHeight = CGFloat(value ?? 0)
+      }
+      Prop("textAlign") { (view: DottedUnderlineTextView, value: String?) in
+        switch value {
+        case "center": view.textAlign = .center
+        case "right":  view.textAlign = .right
+        case "left":   view.textAlign = .left
+        case "justify": view.textAlign = .justified
+        default:       view.textAlign = .natural
+        }
+      }
+      Prop("underlineColor") { (view: DottedUnderlineTextView, value: UIColor?) in
+        view.underlineColor = value
+      }
+      Prop("underlineStyle") { (view: DottedUnderlineTextView, value: String?) in
+        view.underlineStyle = value ?? "dotted"
+      }
+      Prop("underlineThickness") { (view: DottedUnderlineTextView, value: Double?) in
+        view.underlineThickness = CGFloat(value ?? 1)
+      }
+      Prop("ranges") { (view: DottedUnderlineTextView, value: [UnderlineRangeRecord]?) in
+        guard let value = value else {
+          view.ranges = nil
+          return
+        }
+        view.ranges = value.map { r in
+          UnderlineRangeSpec(
+            start: r.start,
+            end: r.end,
+            style: r.style ?? "dotted",
+            color: r.color
+          )
+        }
+      }
+      Prop("selectable") { (view: DottedUnderlineTextView, value: Bool?) in
+        view.selectable = value ?? true
+      }
+      Prop("accessibilityLabel") { (view: DottedUnderlineTextView, value: String?) in
+        view.accessibilityLabel = value
+      }
+    }
+  }
+}

--- a/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
@@ -9,8 +9,12 @@ import UIKit
 public struct UnderlineRangeSpec {
   public var start: Int
   public var end: Int
-  public var style: String
+  /// `nil` = no underline. `"dotted"` or `"solid"` when underline is desired.
+  public var style: String?
   public var color: UIColor?
+  public var backgroundColor: UIColor?
+  public var fontWeight: String?
+  public var textColor: UIColor?
 }
 
 /**
@@ -167,22 +171,23 @@ public final class DottedUnderlineTextView: ExpoView {
 
   // MARK: - Attributed string build
 
-  private func resolvedFont() -> UIFont {
-    let weight: UIFont.Weight = {
-      switch fontWeight {
-      case "100": return .ultraLight
-      case "200": return .thin
-      case "300": return .light
-      case "400", "normal", nil: return .regular
-      case "500": return .medium
-      case "600": return .semibold
-      case "700", "bold": return .bold
-      case "800": return .heavy
-      case "900": return .black
-      default: return .regular
-      }
-    }()
+  private func weightFromString(_ value: String?) -> UIFont.Weight {
+    switch value {
+    case "100": return .ultraLight
+    case "200": return .thin
+    case "300": return .light
+    case "400", "normal", nil: return .regular
+    case "500": return .medium
+    case "600": return .semibold
+    case "700", "bold": return .bold
+    case "800": return .heavy
+    case "900": return .black
+    default: return .regular
+    }
+  }
 
+  private func font(forWeight weightString: String?) -> UIFont {
+    let weight = weightFromString(weightString)
     if let family = fontFamily, !family.isEmpty,
        let descriptor = UIFont(name: family, size: fontSize)?.fontDescriptor {
       let traits: [UIFontDescriptor.TraitKey: Any] = [.weight: weight]
@@ -190,6 +195,10 @@ public final class DottedUnderlineTextView: ExpoView {
       return UIFont(descriptor: merged, size: fontSize)
     }
     return UIFont.systemFont(ofSize: fontSize, weight: weight)
+  }
+
+  private func resolvedFont() -> UIFont {
+    return font(forWeight: fontWeight)
   }
 
   private func updateAttributedText() {
@@ -220,27 +229,50 @@ public final class DottedUnderlineTextView: ExpoView {
     let mutable = NSMutableAttributedString(string: text, attributes: baseAttrs)
 
     if let rs = ranges, !rs.isEmpty {
-      // Per-range mode — add underline attributes only on the specified
-      // sub-strings. No whole-text underline in this mode.
+      // Per-range mode — apply underline + background + per-range font/color
+      // only on the specified sub-strings. No whole-text underline in this
+      // mode. A range with no `style` (nil) but a `backgroundColor` is a
+      // pure highlight; a range with both gets an underline AND a highlight.
       let nsstring = text as NSString
       for r in rs {
         let safeStart = max(0, min(r.start, nsstring.length))
         let safeEnd = max(safeStart, min(r.end, nsstring.length))
         if safeEnd <= safeStart { continue }
         let nsRange = NSRange(location: safeStart, length: safeEnd - safeStart)
-        let baseStyle = NSUnderlineStyle.single
-        let raw: Int = r.style == "dotted"
-          ? baseStyle.union(.patternDot).rawValue
-          : baseStyle.rawValue
-        var rangeAttrs: [NSAttributedString.Key: Any] = [
-          .underlineStyle: raw,
-        ]
-        if let c = r.color {
-          rangeAttrs[.underlineColor] = c
-        } else if let c = underlineColor {
-          rangeAttrs[.underlineColor] = c
+        var rangeAttrs: [NSAttributedString.Key: Any] = [:]
+
+        // Underline (optional)
+        if let style = r.style {
+          let baseStyle = NSUnderlineStyle.single
+          let raw: Int = style == "dotted"
+            ? baseStyle.union(.patternDot).rawValue
+            : baseStyle.rawValue
+          rangeAttrs[.underlineStyle] = raw
+          if let c = r.color {
+            rangeAttrs[.underlineColor] = c
+          } else if let c = underlineColor {
+            rangeAttrs[.underlineColor] = c
+          }
         }
-        mutable.addAttributes(rangeAttrs, range: nsRange)
+
+        // Background fill (highlight)
+        if let bg = r.backgroundColor {
+          rangeAttrs[.backgroundColor] = bg
+        }
+
+        // Per-range text color (e.g. theme tier brightening)
+        if let fg = r.textColor {
+          rangeAttrs[.foregroundColor] = fg
+        }
+
+        // Per-range font weight (e.g. theme tier semibold)
+        if let weight = r.fontWeight {
+          rangeAttrs[.font] = font(forWeight: weight)
+        }
+
+        if !rangeAttrs.isEmpty {
+          mutable.addAttributes(rangeAttrs, range: nsRange)
+        }
       }
     } else {
       // Whole-text mode — add a single underline attribute across the string.

--- a/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
@@ -1,0 +1,267 @@
+import ExpoModulesCore
+import UIKit
+
+/**
+ * One decoration range. Mirrors `UnderlineRange` on the JS side. `style`
+ * is "dotted" or "solid"; `thickness` is honoured on Android only (iOS has
+ * no per-range underline-stroke-width attribute on NSAttributedString).
+ */
+public struct UnderlineRangeSpec {
+  public var start: Int
+  public var end: Int
+  public var style: String
+  public var color: UIColor?
+}
+
+/**
+ * UILabel-backed native view that renders text with a CSS-style dotted or
+ * solid underline using NSAttributedString. We expose an `onPress`
+ * EventDispatcher that fires when the user taps anywhere on the label,
+ * plus `onRangeTap` (with the matched range index) when the tap lands
+ * inside one of the `ranges`.
+ *
+ * Using NSUnderlineStyle.single.union(.patternDot) gives us a true dotted
+ * underline that matches the web (`text-decoration-style: dotted`).
+ *
+ * Tap detection inside a specific range is done by reconstructing an
+ * `NSLayoutManager` whose geometry matches the label and asking it for the
+ * character index at the touch point. (We use the label's intrinsic frame
+ * because that's what RN sized the underlying view to.)
+ */
+public final class DottedUnderlineTextView: ExpoView {
+  let onPress = EventDispatcher()
+  let onRangeTap = EventDispatcher()
+
+  // Backing label; configured for selectable interaction below.
+  private let label: UILabel = {
+    let l = UILabel()
+    l.numberOfLines = 0
+    l.translatesAutoresizingMaskIntoConstraints = false
+    l.isUserInteractionEnabled = true
+    return l
+  }()
+
+  // Stored prop values; we rebuild the attributed string whenever any of
+  // these change so the native view stays in sync with the JS props.
+  var text: String = "" { didSet { updateAttributedText() } }
+  var fontSize: CGFloat = 17 { didSet { updateAttributedText() } }
+  var textColor: UIColor = .label { didSet { updateAttributedText() } }
+  var fontFamily: String? { didSet { updateAttributedText() } }
+  var fontWeight: String? { didSet { updateAttributedText() } }
+  var letterSpacing: CGFloat = 0 { didSet { updateAttributedText() } }
+  var lineHeight: CGFloat = 0 { didSet { updateAttributedText() } }
+  var textAlign: NSTextAlignment = .natural { didSet { updateAttributedText() } }
+  var underlineColor: UIColor? { didSet { updateAttributedText() } }
+  var underlineStyle: String = "dotted" { didSet { updateAttributedText() } }
+  var underlineThickness: CGFloat = 1 { didSet { updateAttributedText() } }
+  var ranges: [UnderlineRangeSpec]? { didSet { updateAttributedText() } }
+  var selectable: Bool = true {
+    didSet {
+      // Enabling selection requires swapping to a UITextView; we keep the
+      // simple UILabel path for now and rely on iOS long-press copy via
+      // the menu controller (added below). Most callers just need tap +
+      // long-press, which UILabel + tap recognizer provides.
+    }
+  }
+
+  public required init(appContext: AppContext? = nil) {
+    super.init(appContext: appContext)
+    addSubview(label)
+    NSLayoutConstraint.activate([
+      label.topAnchor.constraint(equalTo: topAnchor),
+      label.leadingAnchor.constraint(equalTo: leadingAnchor),
+      label.trailingAnchor.constraint(equalTo: trailingAnchor),
+      label.bottomAnchor.constraint(equalTo: bottomAnchor),
+    ])
+
+    let tap = UITapGestureRecognizer(target: self, action: #selector(handleTap(_:)))
+    addGestureRecognizer(tap)
+
+    let longPress = UILongPressGestureRecognizer(target: self, action: #selector(handleLongPress))
+    addGestureRecognizer(longPress)
+  }
+
+  @objc private func handleTap(_ gr: UITapGestureRecognizer) {
+    // Resolve the character index under the tap and check whether it lies
+    // inside any underlined range. If so, fire onRangeTap with the index of
+    // the matched range; otherwise fall through to the generic onPress.
+    let point = gr.location(in: label)
+    if let attr = label.attributedText, let rs = ranges, !rs.isEmpty {
+      let charIndex = characterIndex(at: point, in: attr)
+      if charIndex >= 0 {
+        for (i, r) in rs.enumerated() {
+          if charIndex >= r.start && charIndex < r.end {
+            onRangeTap(["index": i])
+            return
+          }
+        }
+      }
+    }
+    onPress()
+  }
+
+  /**
+   * Find the character index in `attr` that sits under `point` in label's
+   * coordinate space. Returns -1 when the point is outside the layout area.
+   *
+   * We build a one-shot NSLayoutManager whose container size matches the
+   * label so the layout we measure is exactly what's drawn on screen.
+   */
+  private func characterIndex(at point: CGPoint, in attr: NSAttributedString) -> Int {
+    let storage = NSTextStorage(attributedString: attr)
+    let layoutManager = NSLayoutManager()
+    let container = NSTextContainer(size: label.bounds.size)
+    container.lineFragmentPadding = 0
+    container.maximumNumberOfLines = label.numberOfLines
+    container.lineBreakMode = label.lineBreakMode
+    layoutManager.addTextContainer(container)
+    storage.addLayoutManager(layoutManager)
+
+    // Adjust point for label vertical centering: UILabel centers text
+    // vertically when its bounds are taller than the rendered text.
+    var adjusted = point
+    let usedRect = layoutManager.usedRect(for: container)
+    let dy = (label.bounds.height - usedRect.height) * 0.5
+    if dy > 0 {
+      adjusted.y -= dy
+    }
+
+    guard adjusted.x >= 0,
+          adjusted.y >= 0,
+          adjusted.x <= label.bounds.width,
+          adjusted.y <= usedRect.height else {
+      return -1
+    }
+
+    let charIndex = layoutManager.characterIndex(
+      for: adjusted,
+      in: container,
+      fractionOfDistanceBetweenInsertionPoints: nil
+    )
+    return charIndex
+  }
+
+  // Long-press shows the standard copy menu so users can grab the verse text,
+  // matching RN <Text selectable> behaviour.
+  @objc private func handleLongPress(_ gr: UILongPressGestureRecognizer) {
+    guard selectable, gr.state == .began else { return }
+    becomeFirstResponder()
+    let menu = UIMenuController.shared
+    if #available(iOS 13.0, *) {
+      menu.showMenu(from: self, rect: bounds)
+    } else {
+      menu.setTargetRect(bounds, in: self)
+      menu.setMenuVisible(true, animated: true)
+    }
+  }
+
+  public override var canBecomeFirstResponder: Bool { selectable }
+
+  public override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
+    return action == #selector(copy(_:))
+  }
+
+  public override func copy(_ sender: Any?) {
+    UIPasteboard.general.string = text
+  }
+
+  // MARK: - Attributed string build
+
+  private func resolvedFont() -> UIFont {
+    let weight: UIFont.Weight = {
+      switch fontWeight {
+      case "100": return .ultraLight
+      case "200": return .thin
+      case "300": return .light
+      case "400", "normal", nil: return .regular
+      case "500": return .medium
+      case "600": return .semibold
+      case "700", "bold": return .bold
+      case "800": return .heavy
+      case "900": return .black
+      default: return .regular
+      }
+    }()
+
+    if let family = fontFamily, !family.isEmpty,
+       let descriptor = UIFont(name: family, size: fontSize)?.fontDescriptor {
+      let traits: [UIFontDescriptor.TraitKey: Any] = [.weight: weight]
+      let merged = descriptor.addingAttributes([.traits: traits])
+      return UIFont(descriptor: merged, size: fontSize)
+    }
+    return UIFont.systemFont(ofSize: fontSize, weight: weight)
+  }
+
+  private func updateAttributedText() {
+    let font = resolvedFont()
+
+    // Base attributes — applied to the entire string.
+    var baseAttrs: [NSAttributedString.Key: Any] = [
+      .font: font,
+      .foregroundColor: textColor,
+    ]
+
+    if letterSpacing != 0 {
+      baseAttrs[.kern] = letterSpacing
+    }
+
+    if lineHeight > 0 {
+      let paragraph = NSMutableParagraphStyle()
+      paragraph.minimumLineHeight = lineHeight
+      paragraph.maximumLineHeight = lineHeight
+      paragraph.alignment = textAlign
+      baseAttrs[.paragraphStyle] = paragraph
+    } else if textAlign != .natural {
+      let paragraph = NSMutableParagraphStyle()
+      paragraph.alignment = textAlign
+      baseAttrs[.paragraphStyle] = paragraph
+    }
+
+    let mutable = NSMutableAttributedString(string: text, attributes: baseAttrs)
+
+    if let rs = ranges, !rs.isEmpty {
+      // Per-range mode — add underline attributes only on the specified
+      // sub-strings. No whole-text underline in this mode.
+      let nsstring = text as NSString
+      for r in rs {
+        let safeStart = max(0, min(r.start, nsstring.length))
+        let safeEnd = max(safeStart, min(r.end, nsstring.length))
+        if safeEnd <= safeStart { continue }
+        let nsRange = NSRange(location: safeStart, length: safeEnd - safeStart)
+        let baseStyle = NSUnderlineStyle.single
+        let raw: Int = r.style == "dotted"
+          ? baseStyle.union(.patternDot).rawValue
+          : baseStyle.rawValue
+        var rangeAttrs: [NSAttributedString.Key: Any] = [
+          .underlineStyle: raw,
+        ]
+        if let c = r.color {
+          rangeAttrs[.underlineColor] = c
+        } else if let c = underlineColor {
+          rangeAttrs[.underlineColor] = c
+        }
+        mutable.addAttributes(rangeAttrs, range: nsRange)
+      }
+    } else {
+      // Whole-text mode — add a single underline attribute across the string.
+      let baseStyle = NSUnderlineStyle.single
+      let underlineRaw: Int = underlineStyle == "dotted"
+        ? baseStyle.union(.patternDot).rawValue
+        : baseStyle.rawValue
+      let length = (text as NSString).length
+      if length > 0 {
+        var underlineAttrs: [NSAttributedString.Key: Any] = [
+          .underlineStyle: underlineRaw,
+          .underlineColor: underlineColor ?? textColor,
+        ]
+        mutable.addAttributes(underlineAttrs, range: NSRange(location: 0, length: length))
+      }
+    }
+
+    // Note: iOS does NOT expose a dedicated underline-stroke-width attribute,
+    // so `underlineThickness` is mostly honoured on Android. The dot density
+    // of .patternDot is implicit. We document this in the JS types.
+
+    label.attributedText = mutable
+  }
+}

--- a/modules/dotted-underline-text/package.json
+++ b/modules/dotted-underline-text/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@versemate/dotted-underline-text",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "types": "index.ts",
+  "description": "Native Text view with CSS-style dotted underlines that render identically on iOS and Android",
+  "license": "MIT",
+  "author": "VerseMate"
+}

--- a/modules/dotted-underline-text/src/DottedUnderlineText.tsx
+++ b/modules/dotted-underline-text/src/DottedUnderlineText.tsx
@@ -166,10 +166,35 @@ export function DottedUnderlineText(props: DottedUnderlineTextProps) {
     testID,
     onPress,
     onRangeTap: handleRangeTap,
-    // Forward the rest of the style for layout (margin, padding, width, etc.).
-    // The native view extends ExpoView/UIView so layout props are applied by RN.
-    style,
+    // Forward layout-related style only. We strip attributes that are also
+    // forwarded as explicit props (color, fontSize, fontFamily, fontWeight,
+    // lineHeight, letterSpacing, textAlign, backgroundColor) because RN's
+    // ViewManager bridge converts them to native processed values (e.g. hex
+    // string → Int color on Android) and tries to set them on our ExpoView
+    // via the same prop name — colliding with our string-typed `Prop("color")`
+    // binding and failing with `Cannot cast Double to String`.
+    style: stripTextStyleAttrs(flat),
   };
 
   return <NativeDottedUnderlineTextView {...nativeProps} />;
+}
+
+/**
+ * Strip ONLY the color attributes from a flattened style. RN's Android view-
+ * bridge converts hex strings to processed Int colors before forwarding, then
+ * tries to set them as our `Prop("color")` / `Prop("backgroundColor")` binding
+ * with the Int value — colliding with the explicit string-typed color we
+ * already pass as a top-level prop. Stripping these from the style avoids the
+ * double-forward + cast failure.
+ *
+ * Other text attributes (fontSize, lineHeight, fontFamily, textAlign, etc.)
+ * are KEPT in the forwarded style so Yoga can size the ExpoView correctly —
+ * stripping them collapses the view to 0 height. They're also still forwarded
+ * as explicit native props, but numeric props don't have the string→Int cast
+ * collision that color props do.
+ */
+function stripTextStyleAttrs(flat: TextStyle | undefined): TextStyle | undefined {
+  if (!flat) return flat;
+  const { color: _color, backgroundColor: _bg, ...rest } = flat;
+  return rest;
 }

--- a/modules/dotted-underline-text/src/DottedUnderlineText.tsx
+++ b/modules/dotted-underline-text/src/DottedUnderlineText.tsx
@@ -54,6 +54,9 @@ export function DottedUnderlineText(props: DottedUnderlineTextProps) {
       style: r.style,
       color: r.color,
       thickness: r.thickness,
+      backgroundColor: r.backgroundColor,
+      fontWeight: r.fontWeight,
+      textColor: r.textColor,
     }));
   }, [ranges]);
 
@@ -68,17 +71,26 @@ export function DottedUnderlineText(props: DottedUnderlineTextProps) {
         if (r.start > cursor) {
           nodes.push(<Text key={`p-${cursor}`}>{resolvedText.slice(cursor, r.start)}</Text>);
         }
-        const styleForRange: TextStyle =
-          (r.style ?? underlineStyle) === 'solid' || Platform.OS !== 'ios'
-            ? {
-                textDecorationLine: 'underline',
-                textDecorationColor: r.color ?? underlineColor,
-              }
-            : {
-                textDecorationLine: 'underline',
-                textDecorationStyle: 'dotted',
-                textDecorationColor: r.color ?? underlineColor,
-              };
+        // Build the per-range fallback style. `style` may be omitted now
+        // (background-only range). On iOS we can still get the dotted
+        // pattern; Android always renders solid (RN limitation).
+        const styleForRange: TextStyle = {};
+        if (r.style) {
+          styleForRange.textDecorationLine = 'underline';
+          styleForRange.textDecorationColor = r.color ?? underlineColor;
+          if (r.style === 'dotted' && Platform.OS === 'ios') {
+            styleForRange.textDecorationStyle = 'dotted';
+          }
+        }
+        if (r.backgroundColor) {
+          styleForRange.backgroundColor = r.backgroundColor;
+        }
+        if (r.fontWeight) {
+          styleForRange.fontWeight = r.fontWeight as TextStyle['fontWeight'];
+        }
+        if (r.textColor) {
+          styleForRange.color = r.textColor;
+        }
         nodes.push(
           <Text
             key={`r-${i}-${r.start}`}

--- a/modules/dotted-underline-text/src/DottedUnderlineText.tsx
+++ b/modules/dotted-underline-text/src/DottedUnderlineText.tsx
@@ -1,0 +1,163 @@
+import { Children, type ReactNode, useMemo } from 'react';
+import { Platform, StyleSheet, Text, type TextStyle } from 'react-native';
+import type { DottedUnderlineTextProps, UnderlineRange } from './DottedUnderlineText.types';
+import {
+  getNativeDottedUnderlineTextView,
+  type NativeDottedUnderlineTextProps,
+  type NativeUnderlineRange,
+} from './DottedUnderlineTextModule';
+
+/**
+ * Flatten any string/number children into a single string. We do NOT support
+ * nested React elements — the native side renders one attributed string per
+ * view. Callers that need rich content should compose multiple
+ * `<DottedUnderlineText>` siblings.
+ */
+function childrenToText(children: ReactNode): string {
+  let out = '';
+  Children.forEach(children, (child) => {
+    if (typeof child === 'string' || typeof child === 'number') {
+      out += String(child);
+    }
+  });
+  return out;
+}
+
+export function DottedUnderlineText(props: DottedUnderlineTextProps) {
+  const {
+    children,
+    text,
+    style,
+    underlineColor,
+    underlineStyle = 'dotted',
+    underlineThickness = 1,
+    ranges,
+    onRangeTap,
+    selectable = true,
+    onPress,
+    accessibilityLabel,
+    testID,
+  } = props;
+
+  const resolvedText = text ?? childrenToText(children);
+  const flat = StyleSheet.flatten(style) as TextStyle | undefined;
+  const NativeDottedUnderlineTextView =
+    Platform.OS === 'web' ? null : getNativeDottedUnderlineTextView();
+
+  // Strip the `isTheme` client-side flag before forwarding to native — the
+  // bridge has no concept of it and Expo would reject unknown range fields.
+  const nativeRanges: NativeUnderlineRange[] | undefined = useMemo(() => {
+    if (!ranges) return undefined;
+    return ranges.map((r: UnderlineRange) => ({
+      start: r.start,
+      end: r.end,
+      style: r.style,
+      color: r.color,
+      thickness: r.thickness,
+    }));
+  }, [ranges]);
+
+  // ---- Fallback: web, Expo Go, or anywhere the native view didn't register.
+  if (!NativeDottedUnderlineTextView) {
+    // When `ranges` is provided, render each range inline so the fallback
+    // path still shows decoration (used by Jest tests and the web bundle).
+    if (ranges && ranges.length > 0) {
+      const nodes: ReactNode[] = [];
+      let cursor = 0;
+      ranges.forEach((r, i) => {
+        if (r.start > cursor) {
+          nodes.push(<Text key={`p-${cursor}`}>{resolvedText.slice(cursor, r.start)}</Text>);
+        }
+        const styleForRange: TextStyle =
+          (r.style ?? underlineStyle) === 'solid' || Platform.OS !== 'ios'
+            ? {
+                textDecorationLine: 'underline',
+                textDecorationColor: r.color ?? underlineColor,
+              }
+            : {
+                textDecorationLine: 'underline',
+                textDecorationStyle: 'dotted',
+                textDecorationColor: r.color ?? underlineColor,
+              };
+        nodes.push(
+          <Text
+            key={`r-${i}-${r.start}`}
+            style={styleForRange}
+            onPress={onRangeTap ? () => onRangeTap(i) : undefined}
+          >
+            {resolvedText.slice(r.start, r.end)}
+          </Text>
+        );
+        cursor = r.end;
+      });
+      if (cursor < resolvedText.length) {
+        nodes.push(<Text key={`p-tail`}>{resolvedText.slice(cursor)}</Text>);
+      }
+      return (
+        <Text
+          accessibilityLabel={accessibilityLabel}
+          onPress={onPress}
+          selectable={selectable}
+          style={style}
+          testID={testID}
+        >
+          {nodes}
+        </Text>
+      );
+    }
+
+    const fallbackUnderline: TextStyle =
+      underlineStyle === 'solid' || Platform.OS !== 'ios'
+        ? { textDecorationLine: 'underline', textDecorationColor: underlineColor }
+        : {
+            textDecorationLine: 'underline',
+            textDecorationStyle: 'dotted',
+            textDecorationColor: underlineColor,
+          };
+
+    return (
+      <Text
+        accessibilityLabel={accessibilityLabel}
+        onPress={onPress}
+        selectable={selectable}
+        style={[style, fallbackUnderline]}
+        testID={testID}
+      >
+        {resolvedText}
+      </Text>
+    );
+  }
+
+  // ---- Native path (iOS + Android).
+  const handleRangeTap = onRangeTap
+    ? (e: { nativeEvent: { index: number } }) => onRangeTap(e.nativeEvent.index)
+    : undefined;
+
+  const nativeProps: NativeDottedUnderlineTextProps = {
+    text: resolvedText,
+    fontSize: typeof flat?.fontSize === 'number' ? flat.fontSize : undefined,
+    color: typeof flat?.color === 'string' ? flat.color : undefined,
+    fontFamily: flat?.fontFamily,
+    fontWeight:
+      typeof flat?.fontWeight === 'string' || typeof flat?.fontWeight === 'number'
+        ? String(flat.fontWeight)
+        : undefined,
+    letterSpacing: typeof flat?.letterSpacing === 'number' ? flat.letterSpacing : undefined,
+    lineHeight: typeof flat?.lineHeight === 'number' ? flat.lineHeight : undefined,
+    textAlign: flat?.textAlign,
+    underlineColor: underlineColor ?? (typeof flat?.color === 'string' ? flat.color : undefined),
+    underlineStyle,
+    underlineThickness,
+    ranges: nativeRanges,
+    selectable,
+    accessibilityLabel: accessibilityLabel ?? resolvedText,
+    testID,
+    onPress,
+    onRangeTap: handleRangeTap,
+    // Forward the rest of the style for layout (margin, padding, width, etc.).
+    // The native view extends ExpoView/UIView so layout props are applied by RN.
+    style,
+  };
+
+  return <NativeDottedUnderlineTextView {...nativeProps} />;
+}

--- a/modules/dotted-underline-text/src/DottedUnderlineText.types.ts
+++ b/modules/dotted-underline-text/src/DottedUnderlineText.types.ts
@@ -1,0 +1,103 @@
+import type { ReactNode } from 'react';
+import type { StyleProp, TextStyle } from 'react-native';
+
+export type UnderlineStyle = 'dotted' | 'solid';
+
+/**
+ * A single decoration range to apply to a sub-string of the view's text.
+ *
+ * Ranges are character indices into `text` (start inclusive, end exclusive,
+ * same convention as `String.slice`). Ranges should not overlap.
+ *
+ * NOTE on iOS thickness: NSAttributedString has no per-range underline-stroke-
+ * width attribute, so `thickness` is honoured on Android only. On iOS the
+ * underline keeps the platform's default stroke width.
+ */
+export interface UnderlineRange {
+  start: number;
+  end: number;
+  style?: UnderlineStyle;
+  color?: string;
+  /** Android only — iOS ignores this (see note above). */
+  thickness?: number;
+  /**
+   * Optional client-side flag forwarded back via `onRangeTap` callbacks.
+   * Not used by the native side; useful for the caller to discriminate
+   * between visual tiers (e.g. theme vs regular) without keeping a side
+   * map.
+   */
+  isTheme?: boolean;
+}
+
+export interface DottedUnderlineTextProps {
+  /**
+   * Text content. Only string children are supported (the native side renders
+   * a single attributed/measured string, not nested React elements).
+   */
+  children?: ReactNode;
+
+  /**
+   * Optional pre-resolved text. Useful when callers want to pass text via a
+   * prop instead of children (e.g. when composing imperatively).
+   * If both `text` and `children` are provided, `text` wins.
+   */
+  text?: string;
+
+  /**
+   * Standard RN style. `fontSize`, `color`, `fontFamily`, `fontWeight`,
+   * `letterSpacing`, `lineHeight`, and `textAlign` are forwarded to the
+   * native view. Layout props (width/height/margin/padding) work as expected
+   * because the native view participates in the RN layout system.
+   */
+  style?: StyleProp<TextStyle>;
+
+  /** Hex/rgba color for the underline stroke. Defaults to the text color. */
+  underlineColor?: string;
+
+  /**
+   * Underline pattern. `'dotted'` renders a repeating dot pattern that is
+   * pixel-consistent across iOS (`NSUnderlineStyle.patternDot`) and Android
+   * (custom `DashPathEffect` in `onDraw`). `'solid'` falls back to the
+   * platform's normal single underline.
+   *
+   * Used when `ranges` is not provided. When `ranges` is provided, each
+   * range carries its own `style` and this top-level value is ignored.
+   */
+  underlineStyle?: UnderlineStyle;
+
+  /**
+   * Stroke thickness in dp/pt. Default 1. Android-only when applied to the
+   * whole text. Per-range thickness is also Android-only.
+   */
+  underlineThickness?: number;
+
+  /**
+   * Per-range decoration specs. When provided (even an empty array), the
+   * whole-text `underlineStyle` / `underlineColor` / `underlineThickness`
+   * props are ignored and the view draws ONLY the specified ranges.
+   * Ranges should not overlap.
+   */
+  ranges?: UnderlineRange[];
+
+  /**
+   * Called when the user taps inside one of the `ranges`. `rangeIndex` is the
+   * position of the matched range in the `ranges` array. Fires before / instead
+   * of `onPress` when the tap lands inside a range.
+   */
+  onRangeTap?: (rangeIndex: number) => void;
+
+  /**
+   * Whether the user can long-press to select / copy. Defaults to `true` so
+   * the component behaves like RN `<Text selectable>`.
+   */
+  selectable?: boolean;
+
+  /** Tap handler for taps OUTSIDE any underlined range. */
+  onPress?: () => void;
+
+  /** Accessibility label override. If unset, the text content is used. */
+  accessibilityLabel?: string;
+
+  /** TestID for E2E. */
+  testID?: string;
+}

--- a/modules/dotted-underline-text/src/DottedUnderlineText.types.ts
+++ b/modules/dotted-underline-text/src/DottedUnderlineText.types.ts
@@ -16,6 +16,11 @@ export type UnderlineStyle = 'dotted' | 'solid';
 export interface UnderlineRange {
   start: number;
   end: number;
+  /**
+   * Underline pattern for this range. When omitted, the range has no
+   * underline (useful when only `backgroundColor` / per-range font is set —
+   * e.g. for highlight backgrounds without decoration).
+   */
   style?: UnderlineStyle;
   color?: string;
   /** Android only — iOS ignores this (see note above). */
@@ -27,6 +32,23 @@ export interface UnderlineRange {
    * map.
    */
   isTheme?: boolean;
+  /**
+   * Per-range background fill (e.g. user highlight color). Drawn behind
+   * the text, behind the underline. Color string is parsed by the native
+   * side (hex `#RRGGBB`, `#RRGGBBAA`, or rgba()).
+   */
+  backgroundColor?: string;
+  /**
+   * Per-range font weight. Override the view-wide `fontWeight` prop on
+   * this range only — useful for `theme` tier lex words that should
+   * appear in semibold/bold within an otherwise-regular verse.
+   */
+  fontWeight?: string;
+  /**
+   * Per-range text color. Lets a single range render with a brighter /
+   * different color from the rest of the verse (e.g. theme tier).
+   */
+  textColor?: string;
 }
 
 export interface DottedUnderlineTextProps {

--- a/modules/dotted-underline-text/src/DottedUnderlineTextModule.ts
+++ b/modules/dotted-underline-text/src/DottedUnderlineTextModule.ts
@@ -1,0 +1,64 @@
+import { requireNativeViewManager } from 'expo-modules-core';
+import type { ComponentType } from 'react';
+
+/**
+ * JS-side prop shape for the native view. Mirrors the `Prop(...)` entries
+ * declared in `DottedUnderlineTextModule.kt` and `DottedUnderlineTextModule.swift`.
+ */
+export type NativeUnderlineRange = {
+  start: number;
+  end: number;
+  style?: 'dotted' | 'solid';
+  color?: string;
+  thickness?: number;
+};
+
+export type NativeDottedUnderlineTextProps = {
+  text: string;
+  fontSize?: number;
+  color?: string;
+  fontFamily?: string;
+  fontWeight?: string;
+  letterSpacing?: number;
+  lineHeight?: number;
+  textAlign?: 'auto' | 'left' | 'right' | 'center' | 'justify';
+  underlineColor?: string;
+  underlineStyle?: 'dotted' | 'solid';
+  underlineThickness?: number;
+  /**
+   * Per-range decoration specs. When present, the whole-text underline props
+   * are ignored and the native view draws only these ranges.
+   */
+  ranges?: NativeUnderlineRange[];
+  selectable?: boolean;
+  accessibilityLabel?: string;
+  testID?: string;
+  onPress?: () => void;
+  onRangeTap?: (event: { nativeEvent: { index: number } }) => void;
+  style?: unknown;
+};
+
+/**
+ * Lazily resolves the native view component. We cannot call
+ * `requireNativeViewManager` at module top-level because the web stub of
+ * `expo-modules-core` throws an `UnavailabilityError` synchronously, which
+ * would crash any web bundle that even imports this file.
+ *
+ * Returns `null` if the native view is not registered (web, Expo Go without
+ * a custom dev client, jest, etc.). The React wrapper falls back to plain
+ * `<Text>` in that case.
+ */
+let cachedNativeView: ComponentType<NativeDottedUnderlineTextProps> | null | undefined;
+
+export function getNativeDottedUnderlineTextView(): ComponentType<NativeDottedUnderlineTextProps> | null {
+  if (cachedNativeView !== undefined) {
+    return cachedNativeView;
+  }
+  try {
+    cachedNativeView =
+      requireNativeViewManager<NativeDottedUnderlineTextProps>('DottedUnderlineText');
+  } catch {
+    cachedNativeView = null;
+  }
+  return cachedNativeView;
+}

--- a/modules/dotted-underline-text/src/DottedUnderlineTextModule.ts
+++ b/modules/dotted-underline-text/src/DottedUnderlineTextModule.ts
@@ -11,6 +11,9 @@ export type NativeUnderlineRange = {
   style?: 'dotted' | 'solid';
   color?: string;
   thickness?: number;
+  backgroundColor?: string;
+  fontWeight?: string;
+  textColor?: string;
 };
 
 export type NativeDottedUnderlineTextProps = {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",
+    "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#26012e6790ad734e203f9901efe029d729133409",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",


### PR DESCRIPTION
## Summary

Andy's post-merge feedback (DM 2026-05-21 ~17:00 UTC, after PR #328 build landed). Four items + the previously-untracked Kotlin/Swift dotted-underline module that should have shipped earlier.

## Commits

### `3a8e53f` — commit local Expo module for native dotted underlines
The `modules/dotted-underline-text/` scaffolding from earlier was sitting **untracked** in the working tree — never made it into any branch. Committed now so the Kotlin (Android) + Swift (iOS) implementations ship to the EAS build and Andy can test the Android side. Wired up via `@versemate/dotted-underline-text@file:./modules/dotted-underline-text` in `package.json`.

Note: HighlightedText is **not yet wired** to use this — the current per-word `<Text>` rendering can't host a native `View` decoration. Restructuring HighlightedText to use the per-range native view is a follow-up.

### `a5eea49` — four UX fixes from Andy's round 4 DM

**#1 StudyPanel pill alignment** — re-added `bulletTag.marginTop: 4`. The cap-height correction was in round 2 (a925ee4) but accidentally dropped when round 3 (a05a4c8) restored the side-by-side row layout. Pills now sit at the body text's first-line cap-height instead of floating above it.

**LexiconPopover drag-to-dismiss restored** — the second-pass commit (f3a7669) rewrote the gesture handling from `PanResponder` to `react-native-gesture-handler v2`, which broke drag entirely for the user ("not draggable, not at all anymore"). Reverted to the original `PanResponder` two-zone setup: always-on handle/header strip + scroll-top-gated body drag.

**LexiconPopover no spring on open** — Andy: "you added a spring animation to it when it opens, why??? delete that shit". Replaced both the open-spring and snap-back-spring with `Animated.timing` (220ms open, 150ms snap). Close stays spring (ends off-screen).

**#3 YouTube single-tap to play** — Andy: "we have to click twice on video to watch". Removed the in-app thumbnail-with-play-button overlay. `YoutubePlayer` now mounts directly with `play={false}`; first tap on YouTube's own iframe play button starts playback. The error fallback ("Open in YouTube") is still wired up.

**#4 iOS visuals rotation** — Andy: "can't rotate (on iOS)" even though it works on Android. Root cause: Expo's `orientation: 'default'` ships `UISupportedInterfaceOrientations` as portrait-only on iPhone in Info.plist; `expo-screen-orientation.unlockAsync()` can't override the Info.plist superset at runtime. Declared all four orientations explicitly in `app.config.js` → ios.infoPlist. Non-Visuals screens stay portrait (nothing else calls `unlockAsync`).

## Items still pending

**#2 Dotted underline on Android = solid line** — Andy approved a solid-thin-line fallback. NOT done in this PR: now that the native module is shipped, we want to test if the Kotlin path actually works on Android first. If yes, both platforms can stay dotted (via the new module). If no, swap iOS to solid too. Decision deferred until you've tested a fresh debug APK.

## Test plan

- [ ] Tap a dotted lex word → modal slides up with NO spring bounce
- [ ] Drag the modal from the gold notch → dismisses
- [ ] Drag the modal from the lemma/header strip → dismisses
- [ ] Scroll inside the modal body normally — scrolling works
- [ ] At top of scroll, drag down → dismisses
- [ ] Tap the BibleProject video card on a chapter with video (e.g. Genesis) → YouTube player loads; single tap on its play button starts playback
- [ ] Switch to Insight → Study tab — pills (2:2, 2:8-9, etc.) align with the first-line cap-height of their body text
- [ ] iOS only: open Visuals tab + rotate device → app rotates to landscape (works on Android already)
- [ ] On Android: install fresh debug APK, verify native module loads (Kotlin path) — exact wiring into HighlightedText comes next

🤖 Generated with [Claude Code](https://claude.com/claude-code)