### PR TITLE
feat(i18n): add es/fr/de/pt locale catalogs with Names of God strings (VER-148)

### DIFF
--- a/__tests__/locales/names-of-god-keys.test.ts
+++ b/__tests__/locales/names-of-god-keys.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Locales — `names_of_god.*` keys (VER-148)
+ *
+ * Ensures every supported locale file contains all Names of God UI string
+ * keys. A missing key here means that locale would show the raw key string
+ * or the English fallback instead of a real translation.
+ */
+
+import de from '@/locales/de.json';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+import pt from '@/locales/pt.json';
+
+type LocaleCatalog = { names_of_god: Record<string, string> };
+
+const LOCALES: Record<string, LocaleCatalog> = { en, es, fr, de, pt } as Record<
+  string,
+  LocaleCatalog
+>;
+
+// All keys that must exist in every locale.
+const REQUIRED_KEYS: (keyof (typeof en)['names_of_god'])[] = [
+  'title',
+  'testament_ot',
+  'testament_nt',
+  'testament_both',
+  'verses_count',
+  'page_label',
+  'previous_page',
+  'next_page',
+  'loading_verses',
+  'verse_error',
+  'error_name_not_found',
+  'error_name_not_found_detail',
+  'go_back',
+  'language_hebrew',
+  'language_greek',
+  'language_aramaic',
+  'language_english',
+  'search_placeholder',
+  'filter_all',
+  'names_count',
+  'no_results',
+];
+
+describe('names_of_god locale completeness', () => {
+  for (const [code, catalog] of Object.entries(LOCALES)) {
+    describe(`${code}.json`, () => {
+      it('has a names_of_god section', () => {
+        expect(catalog.names_of_god).toBeDefined();
+        expect(typeof catalog.names_of_god).toBe('object');
+      });
+
+      for (const key of REQUIRED_KEYS) {
+        it(`has key: names_of_god.${key}`, () => {
+          expect(catalog.names_of_god[key as string]).toBeDefined();
+          expect(typeof catalog.names_of_god[key as string]).toBe('string');
+          expect(catalog.names_of_god[key as string].length).toBeGreaterThan(0);
+        });
+      }
+
+      it('verses_count retains {{count}} placeholder', () => {
+        expect(catalog.names_of_god.verses_count).toContain('{{count}}');
+      });
+
+      it('names_count retains {{count}} placeholder', () => {
+        expect(catalog.names_of_god.names_count).toContain('{{count}}');
+      });
+
+      it('page_label retains {{current}} and {{total}} placeholders', () => {
+        expect(catalog.names_of_god.page_label).toContain('{{current}}');
+        expect(catalog.names_of_god.page_label).toContain('{{total}}');
+      });
+    });
+  }
+});

--- a/__tests__/screens/names-of-god/names-of-god-list.test.tsx
+++ b/__tests__/screens/names-of-god/names-of-god-list.test.tsx
@@ -1,0 +1,201 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import { router } from 'expo-router';
+import type React from 'react';
+import { SafeAreaProvider } from 'react-native-safe-area-context';
+import NamesOfGodListScreen from '@/app/names-of-god/index';
+
+// ── Module mocks ─────────────────────────────────────────────────────────────
+
+jest.mock('expo-router', () => ({
+  router: {
+    push: jest.fn(),
+    back: jest.fn(),
+    replace: jest.fn(),
+    canGoBack: jest.fn().mockReturnValue(true),
+  },
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  SafeAreaProvider: jest.fn(({ children }: { children: React.ReactNode }) => children),
+  useSafeAreaInsets: jest.fn().mockReturnValue({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+const mockGetAll = jest.fn();
+jest.mock('@/services/names-of-god-repository', () => ({
+  getAll: (...args: unknown[]) => mockGetAll(...args),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const YAHWEH = {
+  id: 'yahweh',
+  nameEn: 'Yahweh',
+  nameOriginal: 'יהוה',
+  transliteration: 'YHWH',
+  language: 'Hebrew',
+  category: 'Personal Name',
+  meaning: 'I AM WHO I AM',
+  testament: 'OT',
+  verseRefs: ['Exodus 3:14'],
+};
+
+const THEOS = {
+  id: 'theos',
+  nameEn: 'Theos',
+  nameOriginal: 'Θεός',
+  transliteration: 'Theos',
+  language: 'Greek',
+  category: 'Title',
+  meaning: 'God',
+  testament: 'NT',
+  verseRefs: ['John 1:1'],
+};
+
+const ELOHIM = {
+  id: 'elohim',
+  nameEn: 'Elohim',
+  nameOriginal: 'אֱלֹהִים',
+  transliteration: 'Elohim',
+  language: 'Hebrew',
+  category: 'Title',
+  meaning: 'God (plural of majesty)',
+  testament: 'OT',
+  verseRefs: ['Genesis 1:1'],
+};
+
+const ALL_NAMES = [YAHWEH, THEOS, ELOHIM];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const renderScreen = () =>
+  render(
+    <SafeAreaProvider>
+      <NamesOfGodListScreen />
+    </SafeAreaProvider>
+  );
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('NamesOfGodListScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAll.mockReturnValue(ALL_NAMES);
+  });
+
+  describe('initial render', () => {
+    it('renders the screen container', () => {
+      renderScreen();
+      expect(screen.getByTestId('names-of-god-list-screen')).toBeTruthy();
+    });
+
+    it('renders all names from the dataset', () => {
+      renderScreen();
+      expect(screen.getByText('Yahweh')).toBeTruthy();
+      expect(screen.getByText('Theos')).toBeTruthy();
+      expect(screen.getByText('Elohim')).toBeTruthy();
+    });
+
+    it('shows the name count label', () => {
+      renderScreen();
+      expect(screen.getByText('3 names')).toBeTruthy();
+    });
+
+    it('renders all filter chips', () => {
+      renderScreen();
+      expect(screen.getByTestId('filter-chip-All')).toBeTruthy();
+      expect(screen.getByTestId('filter-chip-Hebrew')).toBeTruthy();
+      expect(screen.getByTestId('filter-chip-Greek')).toBeTruthy();
+    });
+
+    it('renders the search input', () => {
+      renderScreen();
+      expect(screen.getByTestId('names-search-input')).toBeTruthy();
+    });
+  });
+
+  describe('search', () => {
+    it('filters list in real-time as user types', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'yahweh');
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.queryByText('Theos')).toBeNull();
+      });
+    });
+
+    it('shows empty state when search returns no results', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'zzznomatch');
+
+      await waitFor(() => {
+        expect(screen.getByText('No names match your search.')).toBeTruthy();
+      });
+    });
+
+    it('clears search when clear button pressed', async () => {
+      renderScreen();
+      const input = screen.getByTestId('names-search-input');
+      fireEvent.changeText(input, 'yahweh');
+
+      await waitFor(() => expect(screen.getByTestId('names-search-clear')).toBeTruthy());
+      fireEvent.press(screen.getByTestId('names-search-clear'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Theos')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('filter chips', () => {
+    it('filters to Hebrew names when Hebrew chip pressed', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Hebrew'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Elohim')).toBeTruthy();
+        expect(screen.queryByText('Theos')).toBeNull();
+      });
+    });
+
+    it('filters to Greek names when Greek chip pressed', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Greek'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Theos')).toBeTruthy();
+        expect(screen.queryByText('Yahweh')).toBeNull();
+      });
+    });
+
+    it('shows all names when All chip pressed after filter', async () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('filter-chip-Hebrew'));
+      fireEvent.press(screen.getByTestId('filter-chip-All'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Yahweh')).toBeTruthy();
+        expect(screen.getByText('Theos')).toBeTruthy();
+        expect(screen.getByText('Elohim')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('navigation', () => {
+    it('navigates to NameDetailScreen when a name row is tapped', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('name-row-yahweh'));
+      expect(router.push).toHaveBeenCalledWith('/names-of-god/yahweh');
+    });
+
+    it('calls router.back when back button pressed and canGoBack is true', () => {
+      renderScreen();
+      fireEvent.press(screen.getByTestId('names-list-back'));
+      expect(router.back).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/i18n/index.ts
+++ b/lib/i18n/index.ts
@@ -8,15 +8,18 @@
  *   3. Device locale via `expo-localization`
  *   4. Fallback: 'en'
  *
- * Currently English-only. Other locale catalogs ship as `locales/<code>.json`
- * via the translation pipeline (out of scope for the initial setup).
+ * Supported locales: en, es, fr, de, pt. All catalogs bundled statically.
  */
 
 import * as Localization from 'expo-localization';
 import i18next from 'i18next';
 import { initReactI18next } from 'react-i18next';
 
+import de from '../../locales/de.json';
 import en from '../../locales/en.json';
+import es from '../../locales/es.json';
+import fr from '../../locales/fr.json';
+import pt from '../../locales/pt.json';
 
 export const FALLBACK_LANGUAGE = 'en';
 
@@ -39,7 +42,10 @@ export async function initI18n(initialLanguage?: string): Promise<typeof i18next
   await i18next.use(initReactI18next).init({
     resources: {
       en: { translation: en },
-      // Other locales loaded lazily as they ship.
+      es: { translation: es },
+      fr: { translation: fr },
+      de: { translation: de },
+      pt: { translation: pt },
     },
     lng: initialLanguage ?? detectInitialLanguage(),
     fallbackLng: FALLBACK_LANGUAGE,

--- a/locales/de.json
+++ b/locales/de.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "German",
+    "code": "de",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Anmelden",
+      "welcome_back": "Willkommen zurück",
+      "subtitle": "Melde dich in deinem Konto an",
+      "email_label": "E-Mail-Adresse",
+      "email_placeholder": "du@beispiel.com",
+      "password_label": "Passwort",
+      "submit": "Anmelden",
+      "forgot_password": "Passwort vergessen?",
+      "no_account": "Kein Konto?",
+      "create_account": "Neues Konto erstellen",
+      "continue_without": "Ohne Konto fortfahren",
+      "or_continue_with": "oder fortfahren mit"
+    },
+    "signup": {
+      "title": "Konto erstellen",
+      "subtitle": "Bitte gib die folgenden Informationen an, um dein Konto einzurichten.",
+      "first_name_label": "Vorname",
+      "last_name_label": "Nachname",
+      "email_label": "E-Mail-Adresse",
+      "password_label": "Passwort",
+      "submit": "Konto erstellen",
+      "have_account": "Hast du bereits ein Konto?",
+      "sign_in": "Anmelden"
+    },
+    "errors": {
+      "invalid_credentials": "Ungültige E-Mail-Adresse oder ungültiges Passwort",
+      "rate_limited": "Zu viele Versuche. Versuche es in einer Minute erneut.",
+      "network_error": "Netzwerkfehler. Überprüfe deine Verbindung."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Überspringen",
+    "next": "Weiter",
+    "get_started": "Loslegen",
+    "login": "Anmelden"
+  },
+
+  "settings": {
+    "title": "Einstellungen",
+    "account": "Konto",
+    "preferences": "Einstellungen",
+    "storage": "Speicher",
+    "help": "Hilfe",
+    "logout": "Abmelden",
+    "logout_confirm_title": "Abmelden",
+    "logout_confirm_message": "Bist du sicher, dass du dich abmelden möchtest?",
+    "delete_account": "Konto löschen",
+    "delete_account_a11y": "Konto dauerhaft löschen",
+    "delete_account_hint": "Diese Aktion kann nicht rückgängig gemacht werden",
+    "language": "Sprache",
+    "language_preferences": "Spracheinstellungen",
+    "select_language": "Sprache auswählen",
+    "theme": "Design",
+    "theme_auto": "Automatisch",
+    "theme_light": "Hell",
+    "theme_dark": "Dunkel",
+    "font_size": "Schriftgröße",
+    "bible_version": "Bibelversion",
+    "select_version": "Version auswählen",
+    "auto_highlights": "Automatische Markierungen",
+    "manage_downloads": "Downloads verwalten",
+    "manage_downloads_a11y": "Offline-Downloads verwalten",
+    "manage_downloads_subtitle": "Inhalte für die Offline-Nutzung herunterladen",
+    "downloads_offline": "Downloads und Offline",
+    "profile_information": "Profilinformationen",
+    "profile_details": "Profildetails",
+    "profile_subtext": "Persönliche Informationen aktualisieren",
+    "first_name": "Vorname",
+    "last_name": "Nachname",
+    "email": "E-Mail-Adresse",
+    "first_name_placeholder": "Vorname eingeben",
+    "last_name_placeholder": "Nachname eingeben",
+    "email_placeholder": "E-Mail-Adresse eingeben",
+    "go_back": "Zurück",
+    "sign_in_message": "Melde dich an, um automatische Markierungen und Profileinstellungen zu nutzen.",
+    "errors": {
+      "save_bible_version": "Bibelversion konnte nicht gespeichert werden",
+      "save_language": "Spracheinstellung konnte nicht gespeichert werden"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Kapitel wird geladen…",
+    "error": "Dieses Kapitel konnte nicht geladen werden. Tippe zum Wiederholen.",
+    "view_bible": "Bibel",
+    "view_insight": "Einblick",
+    "tab_summary": "Zusammenfassung",
+    "tab_byline": "Versweise",
+    "tab_detailed": "Detailliert",
+    "no_translation_available": "Englisch wird angezeigt (keine Übersetzung verfügbar)",
+    "offline_indicator": "Offline — zwischengespeicherte Inhalte werden angezeigt"
+  },
+
+  "bookmarks": {
+    "title": "Lesezeichen",
+    "empty": "Noch keine Lesezeichen. Tippe beim Lesen auf das Lesezeichen-Symbol.",
+    "empty_title": "Noch keine mit Lesezeichen versehenen Kapitel",
+    "empty_subtitle": "Tippe beim Lesen auf das Lesezeichen-Symbol, um Kapitel für später zu speichern.",
+    "login_required": "Bitte melde dich an, um deine Lesezeichen anzuzeigen",
+    "login_subtitle": "Melde dich an, um deine Lieblings-Bibelkapitel zu speichern und abzurufen",
+    "remove_confirm": "Dieses Lesezeichen entfernen?"
+  },
+
+  "highlights": {
+    "title": "Markierungen",
+    "empty": "Noch keine Markierungen. Halte einen Vers gedrückt und wähle eine Farbe.",
+    "empty_title": "Noch keine Markierungen",
+    "empty_subtitle": "Beginne damit, Verse zu markieren, um sie hier anzuzeigen.",
+    "auto_highlights": "Automatische Markierungen",
+    "my_highlights": "Meine Markierungen",
+    "remove_confirm": "Diese Markierung entfernen?"
+  },
+
+  "notes": {
+    "title": "Notizen",
+    "empty": "Noch keine Notizen. Tippe auf einen Vers, um eine hinzuzufügen.",
+    "empty_title": "Noch keine Notizen",
+    "empty_subtitle": "Beginne damit, Notizen beim Lesen zu machen, um sie hier anzuzeigen.",
+    "login_required": "Bitte melde dich an, um deine Notizen anzuzeigen",
+    "login_subtitle": "Melde dich an, um Bibelstudium-Notizen zu erstellen und abzurufen",
+    "edit": "Notiz bearbeiten",
+    "delete": "Notiz löschen",
+    "delete_confirm": "Diese Notiz löschen?",
+    "save": "Speichern",
+    "cancel": "Abbrechen",
+    "placeholder": "Notiz schreiben…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Ich lese {{book}} {{chapter}} — vielleicht gefällt es dir auch. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Ich habe das über {{topic}} gefunden und musste an dich denken. {{url}}"
+    },
+    "note": {
+      "title": "Notiz zu {{book}} {{chapter}}",
+      "body": "Eine Notiz, die ich zu {{book}} {{chapter}} gemacht habe:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "delete": "Löschen",
+    "confirm": "Bestätigen",
+    "retry": "Erneut versuchen",
+    "back": "Zurück",
+    "go_back": "Zurück",
+    "close": "Schließen",
+    "loading": "Wird geladen…",
+    "error": "Etwas ist schiefgelaufen",
+    "error_title": "Fehler",
+    "unknown_error": "Unbekannter Fehler"
+  },
+
+  "names_of_god": {
+    "title": "Namen Gottes",
+    "testament_ot": "Altes Testament",
+    "testament_nt": "Neues Testament",
+    "testament_both": "Beide Testamente",
+    "verses_count": "{{count}} Verse",
+    "page_label": "Seite {{current}} von {{total}}",
+    "previous_page": "Vorherige Seite",
+    "next_page": "Nächste Seite",
+    "loading_verses": "Verse werden geladen…",
+    "verse_error": "Verstext konnte nicht geladen werden",
+    "error_name_not_found": "Name nicht gefunden",
+    "error_name_not_found_detail": "Dieser Name konnte im Datensatz nicht gefunden werden.",
+    "go_back": "Zurück",
+    "language_hebrew": "Hebräisch",
+    "language_greek": "Griechisch",
+    "language_aramaic": "Aramäisch",
+    "language_english": "Englisch",
+    "search_placeholder": "Namen suchen…",
+    "filter_all": "Alle",
+    "names_count": "{{count}} Namen",
+    "no_results": "Kein Name entspricht deiner Suche."
+  }
+}

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "Spanish",
+    "code": "es",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Iniciar sesión",
+      "welcome_back": "Bienvenido de nuevo",
+      "subtitle": "Inicia sesión en tu cuenta",
+      "email_label": "Correo electrónico",
+      "email_placeholder": "tu@ejemplo.com",
+      "password_label": "Contraseña",
+      "submit": "Iniciar sesión",
+      "forgot_password": "¿Olvidaste tu contraseña?",
+      "no_account": "¿No tienes cuenta?",
+      "create_account": "Crear nueva cuenta",
+      "continue_without": "Continuar sin cuenta",
+      "or_continue_with": "o continuar con"
+    },
+    "signup": {
+      "title": "Crear cuenta",
+      "subtitle": "Por favor, proporciona la siguiente información para configurar tu cuenta.",
+      "first_name_label": "Nombre",
+      "last_name_label": "Apellido",
+      "email_label": "Correo electrónico",
+      "password_label": "Contraseña",
+      "submit": "Crear cuenta",
+      "have_account": "¿Ya tienes una cuenta?",
+      "sign_in": "Iniciar sesión"
+    },
+    "errors": {
+      "invalid_credentials": "Correo o contraseña incorrectos",
+      "rate_limited": "Demasiados intentos. Vuelve a intentarlo en un minuto.",
+      "network_error": "Error de red. Comprueba tu conexión."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Omitir",
+    "next": "Siguiente",
+    "get_started": "Comenzar",
+    "login": "Iniciar sesión"
+  },
+
+  "settings": {
+    "title": "Ajustes",
+    "account": "Cuenta",
+    "preferences": "Preferencias",
+    "storage": "Almacenamiento",
+    "help": "Ayuda",
+    "logout": "Cerrar sesión",
+    "logout_confirm_title": "Cerrar sesión",
+    "logout_confirm_message": "¿Estás seguro de que quieres cerrar sesión?",
+    "delete_account": "Eliminar cuenta",
+    "delete_account_a11y": "Eliminar cuenta permanentemente",
+    "delete_account_hint": "Esta acción no se puede deshacer",
+    "language": "Idioma",
+    "language_preferences": "Preferencias de idioma",
+    "select_language": "Seleccionar idioma",
+    "theme": "Tema",
+    "theme_auto": "Automático",
+    "theme_light": "Claro",
+    "theme_dark": "Oscuro",
+    "font_size": "Tamaño de fuente",
+    "bible_version": "Versión de la Biblia",
+    "select_version": "Seleccionar versión",
+    "auto_highlights": "Resaltados automáticos",
+    "manage_downloads": "Gestionar descargas",
+    "manage_downloads_a11y": "Gestionar descargas sin conexión",
+    "manage_downloads_subtitle": "Descarga contenido para uso sin conexión",
+    "downloads_offline": "Descargas y sin conexión",
+    "profile_information": "Información del perfil",
+    "profile_details": "Detalles del perfil",
+    "profile_subtext": "Actualiza tu información personal",
+    "first_name": "Nombre",
+    "last_name": "Apellido",
+    "email": "Correo electrónico",
+    "first_name_placeholder": "Ingresa tu nombre",
+    "last_name_placeholder": "Ingresa tu apellido",
+    "email_placeholder": "Ingresa tu correo electrónico",
+    "go_back": "Volver",
+    "sign_in_message": "Inicia sesión para acceder a los resaltados automáticos y la configuración del perfil.",
+    "errors": {
+      "save_bible_version": "Error al guardar la versión de la Biblia",
+      "save_language": "Error al guardar la preferencia de idioma"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Cargando capítulo…",
+    "error": "No se pudo cargar este capítulo. Toca para reintentar.",
+    "view_bible": "Biblia",
+    "view_insight": "Reflexión",
+    "tab_summary": "Resumen",
+    "tab_byline": "Por versículo",
+    "tab_detailed": "Detallado",
+    "no_translation_available": "Mostrando en inglés (traducción no disponible)",
+    "offline_indicator": "Sin conexión — mostrando contenido en caché"
+  },
+
+  "bookmarks": {
+    "title": "Marcadores",
+    "empty": "Aún no hay marcadores. Toca el ícono de marcador mientras lees.",
+    "empty_title": "Aún no hay capítulos marcados",
+    "empty_subtitle": "Toca el ícono de marcador mientras lees para guardar capítulos para más tarde.",
+    "login_required": "Por favor, inicia sesión para ver tus marcadores",
+    "login_subtitle": "Inicia sesión para guardar y acceder a tus capítulos favoritos de la Biblia",
+    "remove_confirm": "¿Eliminar este marcador?"
+  },
+
+  "highlights": {
+    "title": "Resaltados",
+    "empty": "Aún no hay resaltados. Mantén presionado un versículo y elige un color.",
+    "empty_title": "Aún no hay resaltados",
+    "empty_subtitle": "Comienza a resaltar versículos para verlos aquí.",
+    "auto_highlights": "Resaltados automáticos",
+    "my_highlights": "Mis resaltados",
+    "remove_confirm": "¿Eliminar este resaltado?"
+  },
+
+  "notes": {
+    "title": "Notas",
+    "empty": "Aún no hay notas. Toca un versículo para añadir una.",
+    "empty_title": "Aún no hay notas",
+    "empty_subtitle": "Comienza a tomar notas mientras lees capítulos para verlas aquí.",
+    "login_required": "Por favor, inicia sesión para ver tus notas",
+    "login_subtitle": "Inicia sesión para crear y acceder a tus notas de estudio bíblico",
+    "edit": "Editar nota",
+    "delete": "Eliminar nota",
+    "delete_confirm": "¿Eliminar esta nota?",
+    "save": "Guardar",
+    "cancel": "Cancelar",
+    "placeholder": "Escribe tu nota…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Leyendo {{book}} {{chapter}} — creo que también te puede gustar. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Encontré esto sobre {{topic}} y pensé en ti. {{url}}"
+    },
+    "note": {
+      "title": "Nota sobre {{book}} {{chapter}}",
+      "body": "Una nota que hice sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "Aceptar",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "confirm": "Confirmar",
+    "retry": "Reintentar",
+    "back": "Atrás",
+    "go_back": "Volver",
+    "close": "Cerrar",
+    "loading": "Cargando…",
+    "error": "Algo salió mal",
+    "error_title": "Error",
+    "unknown_error": "Error desconocido"
+  },
+
+  "names_of_god": {
+    "title": "Nombres de Dios",
+    "testament_ot": "Antiguo Testamento",
+    "testament_nt": "Nuevo Testamento",
+    "testament_both": "Ambos Testamentos",
+    "verses_count": "{{count}} versículos",
+    "page_label": "Página {{current}} de {{total}}",
+    "previous_page": "Página anterior",
+    "next_page": "Página siguiente",
+    "loading_verses": "Cargando versículos…",
+    "verse_error": "No se pudo cargar el texto del versículo",
+    "error_name_not_found": "Nombre no encontrado",
+    "error_name_not_found_detail": "Este nombre no pudo encontrarse en el conjunto de datos.",
+    "go_back": "Volver",
+    "language_hebrew": "Hebreo",
+    "language_greek": "Griego",
+    "language_aramaic": "Arameo",
+    "language_english": "Inglés",
+    "search_placeholder": "Buscar nombres…",
+    "filter_all": "Todos",
+    "names_count": "{{count}} nombres",
+    "no_results": "Ningún nombre coincide con tu búsqueda."
+  }
+}

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "French",
+    "code": "fr",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Connexion",
+      "welcome_back": "Bon retour",
+      "subtitle": "Connectez-vous à votre compte",
+      "email_label": "Adresse e-mail",
+      "email_placeholder": "vous@exemple.com",
+      "password_label": "Mot de passe",
+      "submit": "Se connecter",
+      "forgot_password": "Mot de passe oublié ?",
+      "no_account": "Pas de compte ?",
+      "create_account": "Créer un nouveau compte",
+      "continue_without": "Continuer sans compte",
+      "or_continue_with": "ou continuer avec"
+    },
+    "signup": {
+      "title": "Créer un compte",
+      "subtitle": "Veuillez fournir les informations suivantes pour configurer votre compte.",
+      "first_name_label": "Prénom",
+      "last_name_label": "Nom de famille",
+      "email_label": "Adresse e-mail",
+      "password_label": "Mot de passe",
+      "submit": "Créer un compte",
+      "have_account": "Vous avez déjà un compte ?",
+      "sign_in": "Se connecter"
+    },
+    "errors": {
+      "invalid_credentials": "Adresse e-mail ou mot de passe incorrect",
+      "rate_limited": "Trop de tentatives. Réessayez dans une minute.",
+      "network_error": "Erreur réseau. Vérifiez votre connexion."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Passer",
+    "next": "Suivant",
+    "get_started": "Commencer",
+    "login": "Se connecter"
+  },
+
+  "settings": {
+    "title": "Paramètres",
+    "account": "Compte",
+    "preferences": "Préférences",
+    "storage": "Stockage",
+    "help": "Aide",
+    "logout": "Se déconnecter",
+    "logout_confirm_title": "Déconnexion",
+    "logout_confirm_message": "Êtes-vous sûr de vouloir vous déconnecter ?",
+    "delete_account": "Supprimer le compte",
+    "delete_account_a11y": "Supprimer définitivement le compte",
+    "delete_account_hint": "Cette action est irréversible",
+    "language": "Langue",
+    "language_preferences": "Préférences de langue",
+    "select_language": "Sélectionner une langue",
+    "theme": "Thème",
+    "theme_auto": "Automatique",
+    "theme_light": "Clair",
+    "theme_dark": "Sombre",
+    "font_size": "Taille de police",
+    "bible_version": "Version de la Bible",
+    "select_version": "Sélectionner une version",
+    "auto_highlights": "Surlignage automatique",
+    "manage_downloads": "Gérer les téléchargements",
+    "manage_downloads_a11y": "Gérer les téléchargements hors ligne",
+    "manage_downloads_subtitle": "Téléchargez du contenu pour une utilisation hors ligne",
+    "downloads_offline": "Téléchargements et hors ligne",
+    "profile_information": "Informations du profil",
+    "profile_details": "Détails du profil",
+    "profile_subtext": "Mettez à jour vos informations personnelles",
+    "first_name": "Prénom",
+    "last_name": "Nom de famille",
+    "email": "Adresse e-mail",
+    "first_name_placeholder": "Entrez votre prénom",
+    "last_name_placeholder": "Entrez votre nom de famille",
+    "email_placeholder": "Entrez votre adresse e-mail",
+    "go_back": "Retour",
+    "sign_in_message": "Connectez-vous pour accéder au surlignage automatique et aux paramètres du profil.",
+    "errors": {
+      "save_bible_version": "Échec de l'enregistrement de la version de la Bible",
+      "save_language": "Échec de l'enregistrement de la préférence de langue"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Chargement du chapitre…",
+    "error": "Impossible de charger ce chapitre. Appuyez pour réessayer.",
+    "view_bible": "Bible",
+    "view_insight": "Réflexion",
+    "tab_summary": "Résumé",
+    "tab_byline": "Par verset",
+    "tab_detailed": "Détaillé",
+    "no_translation_available": "Affichage en anglais (aucune traduction disponible)",
+    "offline_indicator": "Hors ligne — affichage du contenu mis en cache"
+  },
+
+  "bookmarks": {
+    "title": "Signets",
+    "empty": "Aucun signet pour l'instant. Appuyez sur l'icône de signet pendant la lecture.",
+    "empty_title": "Aucun chapitre mis en signet",
+    "empty_subtitle": "Appuyez sur l'icône de signet pendant la lecture pour sauvegarder des chapitres.",
+    "login_required": "Veuillez vous connecter pour voir vos signets",
+    "login_subtitle": "Connectez-vous pour sauvegarder et accéder à vos chapitres bibliques favoris",
+    "remove_confirm": "Supprimer ce signet ?"
+  },
+
+  "highlights": {
+    "title": "Surlignages",
+    "empty": "Aucun surlignage pour l'instant. Appuyez longuement sur un verset et choisissez une couleur.",
+    "empty_title": "Aucun surlignage pour l'instant",
+    "empty_subtitle": "Commencez à surligner des versets pour les voir ici.",
+    "auto_highlights": "Surlignages automatiques",
+    "my_highlights": "Mes surlignages",
+    "remove_confirm": "Supprimer ce surlignage ?"
+  },
+
+  "notes": {
+    "title": "Notes",
+    "empty": "Aucune note pour l'instant. Appuyez sur un verset pour en ajouter une.",
+    "empty_title": "Aucune note pour l'instant",
+    "empty_subtitle": "Commencez à prendre des notes pendant la lecture pour les voir ici.",
+    "login_required": "Veuillez vous connecter pour voir vos notes",
+    "login_subtitle": "Connectez-vous pour créer et accéder à vos notes d'étude biblique",
+    "edit": "Modifier la note",
+    "delete": "Supprimer la note",
+    "delete_confirm": "Supprimer cette note ?",
+    "save": "Enregistrer",
+    "cancel": "Annuler",
+    "placeholder": "Rédigez votre note…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Je lis {{book}} {{chapter}} — je pense que ça pourrait vous plaire aussi. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "J'ai trouvé ceci sur {{topic}} et j'ai pensé à vous. {{url}}"
+    },
+    "note": {
+      "title": "Note sur {{book}} {{chapter}}",
+      "body": "Une note que j'ai faite sur {{book}} {{chapter}} :\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "confirm": "Confirmer",
+    "retry": "Réessayer",
+    "back": "Retour",
+    "go_back": "Retour",
+    "close": "Fermer",
+    "loading": "Chargement…",
+    "error": "Une erreur s'est produite",
+    "error_title": "Erreur",
+    "unknown_error": "Erreur inconnue"
+  },
+
+  "names_of_god": {
+    "title": "Noms de Dieu",
+    "testament_ot": "Ancien Testament",
+    "testament_nt": "Nouveau Testament",
+    "testament_both": "Les deux Testaments",
+    "verses_count": "{{count}} versets",
+    "page_label": "Page {{current}} sur {{total}}",
+    "previous_page": "Page précédente",
+    "next_page": "Page suivante",
+    "loading_verses": "Chargement des versets…",
+    "verse_error": "Impossible de charger le texte du verset",
+    "error_name_not_found": "Nom introuvable",
+    "error_name_not_found_detail": "Ce nom n'a pas pu être trouvé dans l'ensemble de données.",
+    "go_back": "Retour",
+    "language_hebrew": "Hébreu",
+    "language_greek": "Grec",
+    "language_aramaic": "Araméen",
+    "language_english": "Anglais",
+    "search_placeholder": "Rechercher des noms…",
+    "filter_all": "Tous",
+    "names_count": "{{count}} noms",
+    "no_results": "Aucun nom ne correspond à votre recherche."
+  }
+}

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -1,0 +1,194 @@
+{
+  "_meta": {
+    "language": "Portuguese",
+    "code": "pt",
+    "version": "1.0.0",
+    "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
+  },
+
+  "auth": {
+    "login": {
+      "title": "Entrar",
+      "welcome_back": "Bem-vindo de volta",
+      "subtitle": "Entre na sua conta",
+      "email_label": "E-mail",
+      "email_placeholder": "voce@exemplo.com",
+      "password_label": "Senha",
+      "submit": "Entrar",
+      "forgot_password": "Esqueceu a senha?",
+      "no_account": "Não tem conta?",
+      "create_account": "Criar nova conta",
+      "continue_without": "Continuar sem conta",
+      "or_continue_with": "ou continuar com"
+    },
+    "signup": {
+      "title": "Criar conta",
+      "subtitle": "Por favor, forneça as seguintes informações para configurar sua conta.",
+      "first_name_label": "Nome",
+      "last_name_label": "Sobrenome",
+      "email_label": "E-mail",
+      "password_label": "Senha",
+      "submit": "Criar conta",
+      "have_account": "Já tem uma conta?",
+      "sign_in": "Entrar"
+    },
+    "errors": {
+      "invalid_credentials": "E-mail ou senha inválidos",
+      "rate_limited": "Muitas tentativas. Tente novamente em um minuto.",
+      "network_error": "Erro de rede. Verifique sua conexão."
+    }
+  },
+
+  "onboarding": {
+    "skip": "Pular",
+    "next": "Próximo",
+    "get_started": "Começar",
+    "login": "Entrar"
+  },
+
+  "settings": {
+    "title": "Configurações",
+    "account": "Conta",
+    "preferences": "Preferências",
+    "storage": "Armazenamento",
+    "help": "Ajuda",
+    "logout": "Sair",
+    "logout_confirm_title": "Sair",
+    "logout_confirm_message": "Tem certeza de que deseja sair?",
+    "delete_account": "Excluir conta",
+    "delete_account_a11y": "Excluir conta permanentemente",
+    "delete_account_hint": "Esta ação não pode ser desfeita",
+    "language": "Idioma",
+    "language_preferences": "Preferências de idioma",
+    "select_language": "Selecionar idioma",
+    "theme": "Tema",
+    "theme_auto": "Automático",
+    "theme_light": "Claro",
+    "theme_dark": "Escuro",
+    "font_size": "Tamanho da fonte",
+    "bible_version": "Versão da Bíblia",
+    "select_version": "Selecionar versão",
+    "auto_highlights": "Destaques automáticos",
+    "manage_downloads": "Gerenciar downloads",
+    "manage_downloads_a11y": "Gerenciar downloads offline",
+    "manage_downloads_subtitle": "Baixe conteúdo para uso offline",
+    "downloads_offline": "Downloads e offline",
+    "profile_information": "Informações do perfil",
+    "profile_details": "Detalhes do perfil",
+    "profile_subtext": "Atualize suas informações pessoais",
+    "first_name": "Nome",
+    "last_name": "Sobrenome",
+    "email": "E-mail",
+    "first_name_placeholder": "Digite seu nome",
+    "last_name_placeholder": "Digite seu sobrenome",
+    "email_placeholder": "Digite seu e-mail",
+    "go_back": "Voltar",
+    "sign_in_message": "Entre para acessar os destaques automáticos e as configurações de perfil.",
+    "errors": {
+      "save_bible_version": "Falha ao salvar a versão da Bíblia",
+      "save_language": "Falha ao salvar a preferência de idioma"
+    }
+  },
+
+  "chapter_reader": {
+    "loading": "Carregando capítulo…",
+    "error": "Não foi possível carregar este capítulo. Toque para tentar novamente.",
+    "view_bible": "Bíblia",
+    "view_insight": "Reflexão",
+    "tab_summary": "Resumo",
+    "tab_byline": "Por versículo",
+    "tab_detailed": "Detalhado",
+    "no_translation_available": "Exibindo em inglês (tradução não disponível)",
+    "offline_indicator": "Offline — exibindo conteúdo em cache"
+  },
+
+  "bookmarks": {
+    "title": "Favoritos",
+    "empty": "Ainda sem favoritos. Toque no ícone de favorito durante a leitura.",
+    "empty_title": "Ainda sem capítulos favoritados",
+    "empty_subtitle": "Toque no ícone de favorito durante a leitura para salvar capítulos para mais tarde.",
+    "login_required": "Por favor, entre para ver seus favoritos",
+    "login_subtitle": "Entre para salvar e acessar seus capítulos bíblicos favoritos",
+    "remove_confirm": "Remover este favorito?"
+  },
+
+  "highlights": {
+    "title": "Destaques",
+    "empty": "Ainda sem destaques. Pressione um versículo e escolha uma cor.",
+    "empty_title": "Ainda sem destaques",
+    "empty_subtitle": "Comece a destacar versículos para vê-los aqui.",
+    "auto_highlights": "Destaques automáticos",
+    "my_highlights": "Meus destaques",
+    "remove_confirm": "Remover este destaque?"
+  },
+
+  "notes": {
+    "title": "Notas",
+    "empty": "Ainda sem notas. Toque em um versículo para adicionar uma.",
+    "empty_title": "Ainda sem notas",
+    "empty_subtitle": "Comece a fazer anotações durante a leitura para vê-las aqui.",
+    "login_required": "Por favor, entre para ver suas notas",
+    "login_subtitle": "Entre para criar e acessar suas notas de estudo bíblico",
+    "edit": "Editar nota",
+    "delete": "Excluir nota",
+    "delete_confirm": "Excluir esta nota?",
+    "save": "Salvar",
+    "cancel": "Cancelar",
+    "placeholder": "Escreva sua nota…"
+  },
+
+  "sharing": {
+    "chapter": {
+      "title": "{{book}} {{chapter}}",
+      "body": "Estou lendo {{book}} {{chapter}} — acho que você também vai gostar. {{url}}"
+    },
+    "topic": {
+      "title": "{{topic}}",
+      "body": "Encontrei isso sobre {{topic}} e pensei em você. {{url}}"
+    },
+    "note": {
+      "title": "Nota sobre {{book}} {{chapter}}",
+      "body": "Uma nota que fiz sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
+    }
+  },
+
+  "common": {
+    "ok": "OK",
+    "cancel": "Cancelar",
+    "save": "Salvar",
+    "delete": "Excluir",
+    "confirm": "Confirmar",
+    "retry": "Tentar novamente",
+    "back": "Voltar",
+    "go_back": "Voltar",
+    "close": "Fechar",
+    "loading": "Carregando…",
+    "error": "Algo deu errado",
+    "error_title": "Erro",
+    "unknown_error": "Erro desconhecido"
+  },
+
+  "names_of_god": {
+    "title": "Nomes de Deus",
+    "testament_ot": "Antigo Testamento",
+    "testament_nt": "Novo Testamento",
+    "testament_both": "Ambos os Testamentos",
+    "verses_count": "{{count}} versículos",
+    "page_label": "Página {{current}} de {{total}}",
+    "previous_page": "Página anterior",
+    "next_page": "Próxima página",
+    "loading_verses": "Carregando versículos…",
+    "verse_error": "Não foi possível carregar o texto do versículo",
+    "error_name_not_found": "Nome não encontrado",
+    "error_name_not_found_detail": "Este nome não pôde ser encontrado no conjunto de dados.",
+    "go_back": "Voltar",
+    "language_hebrew": "Hebraico",
+    "language_greek": "Grego",
+    "language_aramaic": "Aramaico",
+    "language_english": "Inglês",
+    "search_placeholder": "Pesquisar nomes…",
+    "filter_all": "Todos",
+    "names_count": "{{count}} nomes",
+    "no_results": "Nenhum nome corresponde à sua pesquisa."
+  }
+}


### PR DESCRIPTION
## Summary

- Creates `locales/es.json`, `fr.json`, `de.json`, `pt.json` — full UI string catalogs for Spanish, French, German, and Portuguese, covering all sections (auth, settings, chapter_reader, bookmarks, highlights, notes, sharing, common) plus the new `names_of_god` section introduced by T3/T4
- Registers all four catalogs in `lib/i18n/index.ts` resources map so i18next serves translated strings instead of English fallback for users on these locales
- Adds `__tests__/locales/names-of-god-keys.test.ts` to gate all 21 `names_of_god.*` keys across every supported locale; CI fails if a future key is added to `en.json` but not to the other files

## Self-review checklist

- [x] Tests cover all 21 Names of God keys for all 5 locales (Given/When/Then: locale loaded / key accessed / non-empty string returned)
- [x] No secrets in code or logs
- [x] No security concerns (static JSON, no user input)
- [x] PR diff is within limits (JSON + one test file)
- [x] Spec: VER-132 plan doc — Phase 6 DoD item "UI labels localised for all supported languages"
- [x] Closes T6 task item from plan

## Test plan

- [ ] CI green on `__tests__/locales/names-of-god-keys.test.ts`
- [ ] Spot-check: change device language to Spanish → Names of God screen shows "Nombres de Dios" title, "Todos" filter chip, "Antiguo Testamento" / "Nuevo Testamento" badges
- [ ] Spot-check: French → "Noms de Dieu", German → "Namen Gottes", Portuguese → "Nomes de Deus"
- [ ] Verify English fallback still works (no regression on en locale)