### PR TITLE
fix(dotted-underline): rename shadowing font local in DottedUnderlineTextView

### DIFF
--- a/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
+++ b/modules/dotted-underline-text/ios/DottedUnderlineTextView.swift
@@ -202,11 +202,15 @@ public final class DottedUnderlineTextView: ExpoView {
   }
 
   private func updateAttributedText() {
-    let font = resolvedFont()
+    // NOTE: avoid naming this `font` — that would shadow the
+    // `font(forWeight:)` method in this scope and Swift 6 / Xcode 26
+    // refuses to resolve the method call further down (cannot call
+    // value of non-function type 'UIFont').
+    let baseFont = resolvedFont()
 
     // Base attributes — applied to the entire string.
     var baseAttrs: [NSAttributedString.Key: Any] = [
-      .font: font,
+      .font: baseFont,
       .foregroundColor: textColor,
     ]
 


### PR DESCRIPTION
## Summary

Fixes the iOS preview build that started failing in `modules/dotted-underline-text/ios/DottedUnderlineTextView.swift:270` with:

> cannot call value of non-function type 'UIFont'

Inside `updateAttributedText()` we had:

```swift
let font = resolvedFont()
// ...
rangeAttrs[.font] = font(forWeight: weight)   // line 270 — fails
```

Swift 6 / Xcode 26 (`iPhoneOS26.0.sdk`) refuses to resolve `font(forWeight:)` as a method call once a local `let font: UIFont` shadows it in the same scope. Older toolchains were lenient here so this only surfaced when the iOS preview lane was bumped. Rename the local to `baseFont` and update the single base-attribute reference accordingly — the per-range `font(forWeight:)` call now resolves to the method again.

No behavior change.

## Test plan

- [ ] EAS Preview Build (iOS) succeeds for this branch
- [ ] After merge, main's EAS Preview Build (iOS) succeeds and Andy can install a fresh TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)