### PR TITLE
fix(bible): notes edit-save + remove Names of God menu + blank Insight on first switch

### DIFF
--- a/__tests__/app/topics/[topicId].test.tsx
+++ b/__tests__/app/topics/[topicId].test.tsx
@@ -318,7 +318,11 @@ describe('TopicDetailScreen', () => {
     });
 
     it('should hide content tabs in Bible view', async () => {
-      // Bible view hides tabs
+      // Bible view hides tabs. The tabs row is always mounted (so the
+      // open/close animation can run on the UI thread without React
+      // reconciliation), but its wrapper has pointerEvents='none' and
+      // its maxHeight animates to 0 + opacity to 0 — the tabs are not
+      // interactive on Bible view.
       (useActiveView as jest.Mock).mockReturnValue({
         activeView: 'bible',
         setActiveView: jest.fn(),
@@ -326,10 +330,11 @@ describe('TopicDetailScreen', () => {
         error: null,
       });
 
-      const { queryByTestId } = renderWithProviders(<TopicDetailScreen />);
+      const { getByTestId } = renderWithProviders(<TopicDetailScreen />);
 
       await waitFor(() => {
-        expect(queryByTestId('chapter-content-tabs')).toBeNull();
+        const wrapper = getByTestId('content-tabs-wrapper');
+        expect(wrapper.props.pointerEvents).toBe('none');
       });
     });
   });

--- a/__tests__/app/topics/topic-swipe-integration.test.tsx
+++ b/__tests__/app/topics/topic-swipe-integration.test.tsx
@@ -387,28 +387,30 @@ describe('TopicDetailScreen - SimpleTopicPager Integration (V3)', () => {
      * Test 9: View mode switching works
      */
     it('switches between Bible and Explanations view modes', async () => {
-      const { getByTestId, queryByTestId } = renderWithProviders(<TopicDetailScreen />);
+      const { getByTestId } = renderWithProviders(<TopicDetailScreen />);
 
-      // Initially in Bible view, tabs should NOT be visible
-      expect(queryByTestId('chapter-content-tabs')).toBeNull();
+      // The tabs row is always mounted now (so the open/close animation
+      // can run on the UI thread without React reconciliation). Its
+      // wrapper toggles pointerEvents to express interactability —
+      // 'none' on Bible view, 'auto' on Insight view.
+
+      // Initially in Bible view: tabs wrapper exists, but not
+      // interactive.
+      expect(getByTestId('content-tabs-wrapper').props.pointerEvents).toBe('none');
 
       const insightToggle = getByTestId('insight-view-toggle');
       const bibleToggle = getByTestId('bible-view-toggle');
 
-      // Switch to explanations view
+      // Switch to explanations view → wrapper becomes interactive.
       fireEvent.press(insightToggle);
-
-      // Tabs should appear
       await waitFor(() => {
-        expect(getByTestId('chapter-content-tabs')).toBeTruthy();
+        expect(getByTestId('content-tabs-wrapper').props.pointerEvents).toBe('auto');
       });
 
-      // Switch back to Bible view
+      // Switch back to Bible view → wrapper goes back to non-interactive.
       fireEvent.press(bibleToggle);
-
-      // Tabs should not be visible
       await waitFor(() => {
-        expect(queryByTestId('chapter-content-tabs')).toBeNull();
+        expect(getByTestId('content-tabs-wrapper').props.pointerEvents).toBe('none');
       });
     });
   });

--- a/__tests__/components/bible/SimpleChapterPager.test.tsx
+++ b/__tests__/components/bible/SimpleChapterPager.test.tsx
@@ -22,7 +22,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react-native';
+import { act, render, screen } from '@testing-library/react-native';
 import { createRef, type ReactNode } from 'react';
 // Import component after mocks
 import { SimpleChapterPager } from '@/components/bible/SimpleChapterPager';
@@ -417,46 +417,64 @@ describe('SimpleChapterPager', () => {
     });
 
     it('[TDD] onChapterChange fires correctly across multiple sequential navigations', () => {
-      const mockOnChapterChange = jest.fn();
+      // Fake timers so we can advance past the 400ms programmatic-guard
+      // window. After the first navigation the useLayoutEffect arms the
+      // guard via setPageWithoutAnimation; without advancing time the
+      // guard would swallow the next user swipe (it holds for 400ms to
+      // protect against trailing onPageSelected events from the native
+      // ViewPager — see armProgrammaticGuard in SimpleChapterPager).
+      jest.useFakeTimers();
+      try {
+        const mockOnChapterChange = jest.fn();
 
-      const { rerender } = render(
-        <TestWrapper>
-          <SimpleChapterPager
-            bookId={1}
-            chapterNumber={3}
-            bookName="Genesis"
-            booksMetadata={mockTestamentBooks}
-            onChapterChange={mockOnChapterChange}
-            renderChapterPage={mockRenderChapterPage}
-          />
-        </TestWrapper>
-      );
+        const { rerender } = render(
+          <TestWrapper>
+            <SimpleChapterPager
+              bookId={1}
+              chapterNumber={3}
+              bookName="Genesis"
+              booksMetadata={mockTestamentBooks}
+              onChapterChange={mockOnChapterChange}
+              renderChapterPage={mockRenderChapterPage}
+            />
+          </TestWrapper>
+        );
 
-      // Simulate swipe to next (position 2 = next chapter) + idle
-      simulateSwipe(2);
-      expect(mockOnChapterChange).toHaveBeenCalledWith(1, 4);
+        // Simulate swipe to next (position 2 = next chapter) + idle
+        simulateSwipe(2);
+        expect(mockOnChapterChange).toHaveBeenCalledWith(1, 4);
 
-      // Rerender with updated chapter (simulating parent state update)
-      rerender(
-        <TestWrapper>
-          <SimpleChapterPager
-            bookId={1}
-            chapterNumber={4}
-            bookName="Genesis"
-            booksMetadata={mockTestamentBooks}
-            onChapterChange={mockOnChapterChange}
-            renderChapterPage={mockRenderChapterPage}
-          />
-        </TestWrapper>
-      );
+        // Rerender with updated chapter (simulating parent state update).
+        // useLayoutEffect arms the guard here.
+        rerender(
+          <TestWrapper>
+            <SimpleChapterPager
+              bookId={1}
+              chapterNumber={4}
+              bookName="Genesis"
+              booksMetadata={mockTestamentBooks}
+              onChapterChange={mockOnChapterChange}
+              renderChapterPage={mockRenderChapterPage}
+            />
+          </TestWrapper>
+        );
 
-      // Simulate another swipe to next + idle
-      simulateSwipe(2);
+        // Advance past the 400ms guard window so the next swipe is
+        // treated as a user gesture, not a trailing programmatic event.
+        act(() => {
+          jest.advanceTimersByTime(500);
+        });
 
-      // Should fire with chapter 5 — verifies the callback references
-      // the updated pages array after prop change (not stale closure)
-      expect(mockOnChapterChange).toHaveBeenCalledTimes(2);
-      expect(mockOnChapterChange).toHaveBeenLastCalledWith(1, 5);
+        // Simulate another swipe to next + idle
+        simulateSwipe(2);
+
+        // Should fire with chapter 5 — verifies the callback references
+        // the updated pages array after prop change (not stale closure)
+        expect(mockOnChapterChange).toHaveBeenCalledTimes(2);
+        expect(mockOnChapterChange).toHaveBeenLastCalledWith(1, 5);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('[REGRESSION] 3-page window renders at boundary after rerender', () => {

--- a/__tests__/features/bible-reading-integration.test.tsx
+++ b/__tests__/features/bible-reading-integration.test.tsx
@@ -92,6 +92,18 @@ jest.mock('@/hooks/bible/use-notes', () => ({
   })),
 }));
 
+// AudioInlineEntry pulls in useAudioPlayer which requires an
+// AudioPlayerProvider in the tree. The integration test only renders
+// ChapterScreen (no provider), so we stub the component out. Prior to
+// the visit-based lazy-mount work this happened to be masked because
+// the summary tab mounted ~1.1s after chapter settle via a stagger
+// timer, and the test finished before that timer fired. Now summary
+// mounts immediately when visitedTabs.has('summary'), so the entry
+// renders synchronously and the missing provider throws.
+jest.mock('@/components/bible/AudioInlineEntry', () => ({
+  AudioInlineEntry: () => null,
+}));
+
 // Mock data
 const mockGenesisChapter1 = {
   bookId: 1,

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -702,6 +702,7 @@ export default function ChapterScreen() {
                 on the UI thread so the row appears/disappears the same
                 frame as the Bible/Insight tap — no waiting for React. */}
             <Animated.View
+              testID="content-tabs-wrapper"
               style={[styles.tabsWrapper, tabsWrapperStyle]}
               pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
             >

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -19,11 +19,22 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 import type { LayoutChangeEvent } from 'react-native';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   Easing,
+  interpolate,
+  interpolateColor,
+  type SharedValue,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -164,6 +175,54 @@ export default function ChapterScreen() {
   // Get active view from persistence
   const { activeView, setActiveView } = useActiveView();
 
+  // Transitions for view + tab switches. The actual state updates take
+  // ~300-500ms of JS-thread reconciliation because the chapter tree is
+  // heavy (markdown, highlight ranges, prewarmed insight subtree, etc).
+  // Marking them as transitions lets React keep the old content visible
+  // while the new tree reconciles in the background.
+  const [isViewPending, startViewTransition] = useTransition();
+  const [isTabPending, startTabTransition] = useTransition();
+
+  // Visual progress of the Bible → Insight swap, driven on the UI thread
+  // via Reanimated. 0 = Bible visible, 1 = Insight visible. Both the
+  // toggle pill (in ChapterHeader) AND the content container opacities
+  // (in ChapterPage) read this sharedValue via useAnimatedStyle, so a tap
+  // flips the entire UI on the UI thread without waiting for React
+  // reconciliation. The activeView React state still updates via
+  // startViewTransition so non-visual logic (pointerEvents, scroll
+  // handlers, deep-link sync) stays consistent — but the user-visible
+  // swap doesn't wait for it.
+  const toggleProgress = useSharedValue(activeView === 'bible' ? 0 : 1);
+
+  // Shared visual progress for the inner Summary / By Line / Study /
+  // Visuals tab switch. Holds the active tab key (string) and is read
+  // by ChapterPage's per-tab Animated.View wrappers via useAnimatedStyle.
+  // Updated synchronously in handleTabChange so the swap is visible the
+  // same frame as the tap (no React reconciliation in the critical path).
+  const activeTabProgress = useSharedValue<typeof activeTab>(activeTab);
+
+  // Sync activeTabProgress to activeTab for non-tap paths (deep links,
+  // analytics-driven updates). Idempotent with the tap path.
+  useEffect(() => {
+    activeTabProgress.value = activeTab;
+  }, [activeTab, activeTabProgress]);
+
+  // Animated style for the ChapterContentTabs wrapper. The row collapses
+  // to height 0 on the Bible side and expands to its natural height on
+  // the Insight side, with the wrapper using overflow:hidden to clip the
+  // tabs during the transition. Reads toggleProgress on the UI thread so
+  // the row appears/disappears the same frame as the tap, matching the
+  // content opacity swap.
+  const tabsWrapperStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      // Cap is generous (tabs row is ~50-60dp); the inner content sets the
+      // actual rendered height, the cap just gates the collapse animation.
+      maxHeight: interpolate(toggleProgress.value, [0, 1], [0, 120]),
+      opacity: toggleProgress.value,
+    };
+  });
+
   // Track chapter reading duration (Time-Based Analytics)
   // Hook fires CHAPTER_READING_DURATION event on unmount with AppState awareness
   useChapterReadingDuration(bookId, chapterNumber, bibleVersion);
@@ -203,6 +262,17 @@ export default function ChapterScreen() {
       }
     }
   }, [params.tab, setActiveTab, activeView, setActiveView]);
+
+  // Sync toggleProgress to activeView for non-tap paths (deep links,
+  // modal-close-resets-to-bible, etc). The tap path drives toggleProgress
+  // synchronously in handleViewChange and is idempotent here — withTiming
+  // to the same target is a no-op.
+  useEffect(() => {
+    toggleProgress.value = withTiming(activeView === 'bible' ? 0 : 1, {
+      duration: 250,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [activeView, toggleProgress]);
 
   // Navigation modal state
   const [isNavigationModalOpen, setIsNavigationModalOpen] = useState(false);
@@ -304,20 +374,51 @@ export default function ChapterScreen() {
   // when bookId/chapterNumber change — no manual trigger needed.
 
   /**
-   * Handle view mode change with haptic feedback
+   * Handle view mode change with haptic feedback.
+   *
+   * Drives the visual swap on the UI thread via `toggleProgress` — both
+   * the toggle pill (in ChapterHeader) and the content container
+   * opacities (in ChapterPage) read this sharedValue, so the UI flips
+   * the same frame as the tap. React state catches up via transition.
    */
   const handleViewChange = useCallback(
     (view: ViewMode) => {
-      // Skip if already on this view
       if (view === activeView) return;
-
-      // Trigger haptic feedback (non-blocking)
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
-      // Update view immediately
-      setActiveView(view);
+      // UI-thread visual flip — happens this frame, no React work involved.
+      toggleProgress.value = withTiming(view === 'bible' ? 0 : 1, {
+        duration: 180,
+        easing: Easing.out(Easing.cubic),
+      });
+      // Bridge to React for non-visual state (pointerEvents, scroll
+      // handlers, deep-link sync). Wrapped in a transition so the heavy
+      // reconciliation doesn't block the tap.
+      startViewTransition(() => {
+        setActiveView(view);
+      });
     },
-    [activeView, setActiveView]
+    [activeView, setActiveView, toggleProgress]
+  );
+
+  /**
+   * Handle inner-tab change (Summary / By Line / Study / Visuals).
+   *
+   * Same pattern as handleViewChange: wrap the state update in a
+   * transition so the heavy markdown/render reconciliation doesn't block
+   * the tap, and use `isTabPending` to overlay a skeleton.
+   */
+  const handleTabChange = useCallback(
+    (tab: typeof activeTab) => {
+      if (tab === activeTab) return;
+      Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      // UI-thread snap — the per-tab Animated.View wrappers in ChapterPage
+      // read this sharedValue and flip opacity the same frame as the tap.
+      activeTabProgress.value = tab;
+      startTabTransition(() => {
+        setActiveTab(tab);
+      });
+    },
+    [activeTab, setActiveTab, activeTabProgress]
   );
 
   /**
@@ -409,6 +510,8 @@ export default function ChapterScreen() {
           chapterNumber={pageChapterNumber}
           activeTab={activeTab}
           activeView={activeView}
+          toggleProgress={toggleProgress}
+          activeTabProgress={activeTabProgress}
           onScroll={handleScroll}
           onTap={handleTap}
           isPreloading={!isCurrent}
@@ -422,6 +525,8 @@ export default function ChapterScreen() {
     [
       activeTab,
       activeView,
+      toggleProgress,
+      activeTabProgress,
       handleScroll,
       handleTap,
       bookId,
@@ -443,6 +548,7 @@ export default function ChapterScreen() {
           bookName={bookName}
           chapterNumber={chapterNumber}
           activeView={activeView}
+          toggleProgress={toggleProgress}
           onNavigationPress={() => setIsNavigationModalOpen(true)}
           navigationModalVisible={isNavigationModalOpen}
           onViewChange={handleViewChange}
@@ -478,6 +584,7 @@ export default function ChapterScreen() {
           bookName={bookName}
           chapterNumber={chapterNumber}
           activeView={activeView}
+          toggleProgress={toggleProgress}
           onNavigationPress={() => setIsNavigationModalOpen(true)}
           navigationModalVisible={isNavigationModalOpen}
           onViewChange={handleViewChange}
@@ -556,7 +663,8 @@ export default function ChapterScreen() {
                   chapterNumber={chapterNumber}
                   bookName={chapter.bookName}
                   activeTab={activeTab}
-                  onTabChange={setActiveTab}
+                  onTabChange={handleTabChange}
+                  isTabPending={isTabPending}
                   onMenuPress={() => setIsMenuOpen(true)}
                   onScroll={handleScroll}
                   onTap={handleTap}
@@ -576,6 +684,7 @@ export default function ChapterScreen() {
               bookName={bookName}
               chapterNumber={chapterNumber}
               activeView={activeView}
+              toggleProgress={toggleProgress}
               onNavigationPress={() => {
                 setIsNavigationModalOpen(true);
               }}
@@ -588,27 +697,43 @@ export default function ChapterScreen() {
 
             {/* Content Tabs - Only visible in Explanations view. The
                 Visuals tab is gated on the book having curated visuals
-                (most books do — see @versemate/visuals registry). */}
-            <View style={activeView !== 'explanations' && { height: 0, overflow: 'hidden' }}>
+                (most books do — see @versemate/visuals registry). The
+                wrapper's height + opacity are driven by toggleProgress
+                on the UI thread so the row appears/disappears the same
+                frame as the Bible/Insight tap — no waiting for React. */}
+            <Animated.View
+              style={[styles.tabsWrapper, tabsWrapperStyle]}
+              pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
+            >
               <ChapterContentTabs
                 activeTab={activeTab}
-                onTabChange={setActiveTab}
+                activeTabProgress={activeTabProgress}
+                onTabChange={handleTabChange}
                 showStudy
                 showVisuals={bookHasVisuals(bookId)}
               />
-            </View>
+            </Animated.View>
 
             {/* SimpleChapterPager - V3 3-page window with linear navigation.
                 Uses deferred chapter so the heavy pager re-render (pages-array swap +
-                ChapterPage commits) doesn't block the urgent header update commit. */}
-            <SimpleChapterPager
-              bookId={deferredBookId}
-              chapterNumber={deferredChapterNumber}
-              bookName={bookName}
-              booksMetadata={booksMetadata}
-              onChapterChange={handlePageChange}
-              renderChapterPage={renderChapterPage}
-            />
+                ChapterPage commits) doesn't block the urgent header update commit.
+                The wrapper exists so the transition skeleton overlay below can be
+                absolutely positioned against the content area only — the toggle
+                header + content tabs above stay visible and interactive. */}
+            <View style={styles.pagerWrapper}>
+              <SimpleChapterPager
+                bookId={deferredBookId}
+                chapterNumber={deferredChapterNumber}
+                bookName={bookName}
+                booksMetadata={booksMetadata}
+                onChapterChange={handlePageChange}
+                renderChapterPage={renderChapterPage}
+              />
+              {/* Both view and inner-tab switches are now driven by
+                  sharedValues on the UI thread (toggleProgress +
+                  activeTabProgress in ChapterPage), so no skeleton
+                  overlay is needed during transitions. */}
+            </View>
 
             {/* Floating Action Buttons - V3: Disabled at boundaries */}
             <FloatingActionButtons
@@ -672,6 +797,12 @@ interface ChapterHeaderProps {
   bookName: string;
   chapterNumber: number;
   activeView: ViewMode;
+  /**
+   * Shared visual progress (0 = Bible, 1 = Insight). Owned by ChapterScreen
+   * and shared with ChapterPage so the toggle pill and content opacity flip
+   * on the UI thread in the same frame as the tap.
+   */
+  toggleProgress: SharedValue<number>;
   onNavigationPress: () => void;
   onViewChange: (view: ViewMode) => void;
   onMenuPress: () => void;
@@ -682,6 +813,7 @@ function ChapterHeader({
   bookName,
   chapterNumber,
   activeView,
+  toggleProgress,
   onNavigationPress,
   onViewChange,
   onMenuPress,
@@ -693,18 +825,26 @@ function ChapterHeader({
   const styles = useMemo(() => createHeaderStyles(headerSpecs, colors), [headerSpecs, colors]);
   const insets = useSafeAreaInsets();
 
-  // Animation for sliding toggle indicator (using Reanimated for native thread performance)
-  const toggleProgress = useSharedValue(activeView === 'bible' ? 0 : 1);
   const [bibleButtonWidth, setBibleButtonWidth] = useState(0);
   const [insightButtonWidth, setInsightButtonWidth] = useState(0);
 
-  // Animate toggle indicator when activeView changes
-  useEffect(() => {
-    toggleProgress.value = withTiming(activeView === 'bible' ? 0 : 1, {
-      duration: 200,
-      easing: Easing.out(Easing.cubic),
-    });
-  }, [activeView, toggleProgress]);
+  // Animated text colors — driven by toggleProgress, independent of
+  // activeView prop reconciliation. Each button text interpolates
+  // between inactive and active color based on the indicator position.
+  const inactiveColor = headerSpecs.titleColor;
+  const activeColor = colors.black;
+  const bibleTextStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      color: interpolateColor(toggleProgress.value, [0, 1], [activeColor, inactiveColor]),
+    };
+  });
+  const insightTextStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      color: interpolateColor(toggleProgress.value, [0, 1], [inactiveColor, activeColor]),
+    };
+  });
 
   // Measure individual button widths
   const handleBibleLayout = (event: LayoutChangeEvent) => {
@@ -772,9 +912,7 @@ function ChapterHeader({
             accessibilityState={{ selected: activeView === 'bible' }}
             testID="bible-view-toggle"
           >
-            <Text style={[styles.toggleText, activeView === 'bible' && styles.toggleTextActive]}>
-              Bible
-            </Text>
+            <Animated.Text style={[styles.toggleText, bibleTextStyle]}>Bible</Animated.Text>
           </Pressable>
           <Pressable
             onPress={() => onViewChange('explanations')}
@@ -785,11 +923,7 @@ function ChapterHeader({
             accessibilityState={{ selected: activeView === 'explanations' }}
             testID="commentary-view-toggle"
           >
-            <Text
-              style={[styles.toggleText, activeView === 'explanations' && styles.toggleTextActive]}
-            >
-              Insight
-            </Text>
+            <Animated.Text style={[styles.toggleText, insightTextStyle]}>Insight</Animated.Text>
           </Pressable>
         </View>
 
@@ -905,6 +1039,26 @@ const createStyles = (
     container: {
       flex: 1,
       backgroundColor: colors.background, // Match content background to prevent flash during route updates
+    },
+    pagerWrapper: {
+      flex: 1,
+      position: 'relative',
+    },
+    // overflow:hidden so the maxHeight animation clips the tabs row
+    // when collapsing/expanding.
+    tabsWrapper: {
+      overflow: 'hidden',
+    },
+    // Opaque skeleton overlay used during view/tab transitions. Covers the
+    // pager only (chrome stays visible). Background matches the screen so
+    // the previous content is fully masked while reconciliation runs.
+    transitionSkeleton: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: colors.background,
     },
     errorContainer: {
       flex: 1,

--- a/app/topics/[topicId].tsx
+++ b/app/topics/[topicId].tsx
@@ -583,6 +583,7 @@ export default function TopicDetailScreen() {
               toggleProgress on the UI thread so the row appears /
               disappears the same frame as the Bible/Insight tap. */}
           <Animated.View
+            testID="content-tabs-wrapper"
             style={[styles.tabsWrapper, tabsWrapperStyle]}
             pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
           >

--- a/app/topics/[topicId].tsx
+++ b/app/topics/[topicId].tsx
@@ -27,9 +27,26 @@ import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
 import { t } from 'i18next';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { Alert, Animated, Pressable, Share, StyleSheet, Text, View } from 'react-native';
+import { Alert, Pressable, Share, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  interpolate,
+  interpolateColor,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BibleNavigationModal } from '@/components/bible/BibleNavigationModal';
 import { ChapterContentTabs } from '@/components/bible/ChapterContentTabs';
@@ -95,6 +112,14 @@ export default function TopicDetailScreen() {
   // Local state for immediate UI updates
   const [activeTopicId, setActiveTopicId] = useState(topicId);
 
+  // Deferred topic id — fed to SimpleTopicPager so the heavy
+  // 3-TopicPage reconciliation on swipe (markdown parse for the new
+  // topic's content, ~1-3s) happens at deferred priority instead of
+  // urgent. Header, FAB nav, and other lightweight surfaces keep
+  // reading `activeTopicId` and update immediately. Mirror of the
+  // Bible chapter screen's deferredBookId/deferredChapterNumber.
+  const deferredActiveTopicId = useDeferredValue(activeTopicId);
+
   // Fetch ALL topics globally for circular navigation across all categories
   // Uses cached topics (seed DB fallback) so pager works even without API
   const { data: allTopics } = useAllCachedTopics();
@@ -143,6 +168,49 @@ export default function TopicDetailScreen() {
 
   // Get active view from persistence (Bible references vs Explanations view)
   const { activeView, setActiveView } = useActiveView();
+
+  // Transitions for view/tab switches so the heavy topic-content
+  // reconciliation (~300-500ms) doesn't block the tap.
+  const [isViewPending, startViewTransition] = useTransition();
+  const [isTabPending, startTabTransition] = useTransition();
+
+  // Shared visual progress for the Bible/Insight toggle. Drives the
+  // toggle pill (TopicHeader) and the content container opacities
+  // (TopicPage) on the UI thread so the swap is visible the same frame
+  // as the tap. Mirror of the Bible chapter screen setup.
+  const toggleProgress = useSharedValue(activeView === 'bible' ? 0 : 1);
+
+  // Shared visual progress for the inner Summary / By Line / Detailed
+  // tab switch. Each tab's container reads this via useAnimatedStyle to
+  // flip opacity on the UI thread (snap, no fade). Updated synchronously
+  // in handleTabChange so the swap is visible the same frame as the tap.
+  const activeTabProgress = useSharedValue<ContentTabType>(activeTab);
+
+  // Sync activeTabProgress to activeTab for non-tap paths.
+  useEffect(() => {
+    activeTabProgress.value = activeTab;
+  }, [activeTab, activeTabProgress]);
+
+  // Animated style for the ChapterContentTabs wrapper — collapses to 0
+  // height on Bible view, expands to natural height on Insight, driven
+  // entirely on the UI thread.
+  const tabsWrapperStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      maxHeight: interpolate(toggleProgress.value, [0, 1], [0, 120]),
+      opacity: toggleProgress.value,
+    };
+  });
+
+  // Sync toggleProgress to activeView for non-tap paths (deep links,
+  // modal-close resets, FAB navigation that sets bible). The tap path
+  // drives toggleProgress synchronously and is idempotent here.
+  useEffect(() => {
+    toggleProgress.value = withTiming(activeView === 'bible' ? 0 : 1, {
+      duration: 250,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [activeView, toggleProgress]);
 
   // Handle deep-linked insight tab parameter
   // When user opens a shared topic insight URL, navigate to that specific tab
@@ -235,16 +303,32 @@ export default function TopicDetailScreen() {
     // URL will catch up via debounce
   };
 
-  // Handle tab change
+  // Handle tab change. The state update is wrapped in a transition so the
+  // heavy markdown re-render doesn't block the tap; the actual visible
+  // swap happens on the UI thread via activeTabProgress.
   const handleTabChange = (tab: ContentTabType) => {
-    setActiveTab(tab);
+    if (tab === activeTab) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    activeTabProgress.value = tab;
+    startTabTransition(() => {
+      setActiveTab(tab);
+    });
   };
 
-  // Handle view mode change (Bible references vs Explanations)
+  // Handle view mode change (Bible references vs Explanations).
+  // Drives the visual swap (toggle pill + content containers + tabs row)
+  // on the UI thread via toggleProgress, then defers the React state
+  // catch-up via a transition. Mirror of the Bible chapter screen.
   const handleViewChange = (view: ViewMode) => {
+    if (view === activeView) return;
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    setActiveView(view);
+    toggleProgress.value = withTiming(view === 'bible' ? 0 : 1, {
+      duration: 250,
+      easing: Easing.out(Easing.cubic),
+    });
+    startViewTransition(() => {
+      setActiveView(view);
+    });
   };
 
   /**
@@ -354,6 +438,14 @@ export default function TopicDetailScreen() {
    * This is passed to SimpleTopicPager.renderTopicPage prop.
    * Similar to the Bible screen's renderChapterPage callback.
    */
+  // Mirror of Bible's renderChapterPage: activeTab/activeView are real
+  // deps so the 3 TopicPage instances see fresh values on each tap and
+  // their pointerEvents stay in sync. The earlier stability fix (refs +
+  // stripped deps) was needed when the maxHeight-collapse layout
+  // caused 700ms+ re-renders per tap; with the absolute-overlap refactor
+  // and memoised markdown JSX, the re-render is cheap enough to take
+  // the hit. Without this, pointerEvents stays stale and the byline
+  // FlatList isn't scrollable after a tab switch.
   const renderTopicPage = useCallback(
     (pageTopicId: string) => {
       return (
@@ -361,15 +453,27 @@ export default function TopicDetailScreen() {
           topicId={pageTopicId}
           activeTab={activeTab}
           activeView={activeView}
+          toggleProgress={toggleProgress}
+          activeTabProgress={activeTabProgress}
           onScroll={handleScroll}
           onTap={handleTap}
           onShare={handleShare}
           onVersePress={handleVersePress}
-          isPreloading={pageTopicId !== activeTopicId}
+          isPreloading={pageTopicId !== deferredActiveTopicId}
         />
       );
     },
-    [activeTab, activeView, handleScroll, handleTap, handleShare, handleVersePress, activeTopicId]
+    [
+      activeTab,
+      activeView,
+      toggleProgress,
+      activeTabProgress,
+      handleScroll,
+      handleTap,
+      handleShare,
+      handleVersePress,
+      deferredActiveTopicId,
+    ]
   );
 
   // Type guard for topic
@@ -391,6 +495,7 @@ export default function TopicDetailScreen() {
         <TopicHeader
           topicName="Loading..."
           activeView={activeView}
+          toggleProgress={toggleProgress}
           onNavigationPress={() => {}}
           onViewChange={handleViewChange}
           onMenuPress={() => {}}
@@ -407,6 +512,7 @@ export default function TopicDetailScreen() {
         <TopicHeader
           topicName="Error"
           activeView={activeView}
+          toggleProgress={toggleProgress}
           onNavigationPress={() => {}}
           onViewChange={handleViewChange}
           onMenuPress={() => {}}
@@ -454,6 +560,7 @@ export default function TopicDetailScreen() {
               topicName={currentTopicName || topic?.name || ''}
               activeTab={activeTab}
               onTabChange={handleTabChange}
+              isTabPending={isTabPending}
               onMenuPress={() => setIsMenuOpen(true)}
             />
           }
@@ -465,20 +572,35 @@ export default function TopicDetailScreen() {
           <TopicHeader
             topicName={currentTopicName || topic?.name || ''}
             activeView={activeView}
+            toggleProgress={toggleProgress}
             onNavigationPress={() => setIsNavigationModalOpen(true)}
             navigationModalVisible={isNavigationModalOpen}
             onViewChange={handleViewChange}
             onMenuPress={() => setIsMenuOpen(true)}
           />
 
-          {/* Content Tabs - Only visible in Explanations view */}
-          {activeView === 'explanations' && (
-            <ChapterContentTabs activeTab={activeTab} onTabChange={handleTabChange} showDetailed />
-          )}
+          {/* Content Tabs — wrapper's height + opacity driven by
+              toggleProgress on the UI thread so the row appears /
+              disappears the same frame as the Bible/Insight tap. */}
+          <Animated.View
+            style={[styles.tabsWrapper, tabsWrapperStyle]}
+            pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
+          >
+            <ChapterContentTabs
+              activeTab={activeTab}
+              activeTabProgress={activeTabProgress}
+              onTabChange={handleTabChange}
+              showDetailed
+            />
+          </Animated.View>
 
-          {/* SimpleTopicPager - V3 3-page window with global circular navigation */}
+          {/* SimpleTopicPager — V3 3-page window with global circular
+              navigation. View swaps + inner-tab swaps are both driven by
+              sharedValues on the UI thread (toggleProgress +
+              activeTabProgress in TopicPage), so no skeleton overlay is
+              needed during transitions. */}
           <SimpleTopicPager
-            topicId={activeTopicId}
+            topicId={deferredActiveTopicId}
             sortedTopics={allTopics}
             onTopicChange={handleTopicChange}
             renderTopicPage={renderTopicPage}
@@ -546,6 +668,12 @@ export default function TopicDetailScreen() {
 interface TopicHeaderProps {
   topicName: string;
   activeView: ViewMode;
+  /**
+   * Shared visual progress (0 = Bible, 1 = Insight). Owned by the screen
+   * and shared with TopicPage so the toggle pill and content opacity
+   * flip on the UI thread in the same frame as the tap.
+   */
+  toggleProgress: SharedValue<number>;
   onNavigationPress: () => void;
   onViewChange: (view: ViewMode) => void;
   onMenuPress: () => void;
@@ -555,6 +683,7 @@ interface TopicHeaderProps {
 function TopicHeader({
   topicName,
   activeView,
+  toggleProgress,
   onNavigationPress,
   onViewChange,
   onMenuPress,
@@ -566,20 +695,8 @@ function TopicHeader({
   const styles = useMemo(() => createHeaderStyles(headerSpecs, colors), [headerSpecs, colors]);
   const insets = useSafeAreaInsets();
 
-  // Animation for sliding toggle indicator
-  const toggleSlideAnim = useRef(new Animated.Value(activeView === 'bible' ? 0 : 1)).current;
   const [bibleButtonWidth, setBibleButtonWidth] = useState(0);
   const [insightButtonWidth, setInsightButtonWidth] = useState(0);
-
-  // Animate toggle indicator when activeView changes
-  useEffect(() => {
-    Animated.spring(toggleSlideAnim, {
-      toValue: activeView === 'bible' ? 0 : 1,
-      useNativeDriver: false, // Changed to false to allow width animation
-      friction: 8,
-      tension: 50,
-    }).start();
-  }, [activeView, toggleSlideAnim]);
 
   // Measure individual button widths
   const handleBibleLayout = (event: LayoutChangeEvent) => {
@@ -592,24 +709,34 @@ function TopicHeader({
     setInsightButtonWidth(width);
   };
 
-  // Memoize interpolations to prevent recreating on every render
-  const indicatorTranslateX = useMemo(
-    () =>
-      toggleSlideAnim.interpolate({
-        inputRange: [0, 1],
-        outputRange: [0, Math.max(0, bibleButtonWidth + 4)], // Move to insight position (Bible width + gap)
-      }),
-    [toggleSlideAnim, bibleButtonWidth]
-  );
+  // Indicator pill animation — runs entirely on the UI thread via the
+  // shared toggleProgress. The screen-level handler updates the value
+  // synchronously on tap, so the pill slides in the same frame.
+  const indicatorAnimatedStyle = useAnimatedStyle(() => {
+    'worklet';
+    const translateX = toggleProgress.value * Math.max(0, bibleButtonWidth + 4);
+    const width = bibleButtonWidth + toggleProgress.value * (insightButtonWidth - bibleButtonWidth);
+    return {
+      transform: [{ translateX }],
+      width: Math.max(0, width),
+    };
+  }, [bibleButtonWidth, insightButtonWidth]);
 
-  const indicatorWidth = useMemo(
-    () =>
-      toggleSlideAnim.interpolate({
-        inputRange: [0, 1],
-        outputRange: [Math.max(0, bibleButtonWidth), Math.max(0, insightButtonWidth)],
-      }),
-    [toggleSlideAnim, bibleButtonWidth, insightButtonWidth]
-  );
+  // Animated text colors — flip on the UI thread alongside the pill.
+  const inactiveColor = headerSpecs.titleColor;
+  const activeColor = colors.black;
+  const bibleTextStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      color: interpolateColor(toggleProgress.value, [0, 1], [activeColor, inactiveColor]),
+    };
+  });
+  const insightTextStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      color: interpolateColor(toggleProgress.value, [0, 1], [inactiveColor, activeColor]),
+    };
+  });
 
   /**
    * Safe navigation press handler to prevent double-triggering
@@ -641,22 +768,12 @@ function TopicHeader({
 
       {/* Action Icons */}
       <View style={styles.headerActions}>
-        {/* Bible/Insight Toggle (pill-style matching Bible page) */}
+        {/* Bible/Insight Toggle (pill-style matching Bible page). The
+            pill + text colors are driven by toggleProgress on the UI
+            thread; the screen-level handleViewChange updates the value
+            synchronously on tap so the animation runs the same frame. */}
         <View style={styles.toggleContainer}>
-          {/* Sliding indicator background */}
-          <Animated.View
-            style={[
-              styles.toggleIndicator,
-              {
-                width: indicatorWidth,
-                transform: [
-                  {
-                    translateX: indicatorTranslateX,
-                  },
-                ],
-              },
-            ]}
-          />
+          <Animated.View style={[styles.toggleIndicator, indicatorAnimatedStyle]} />
           <Pressable
             onPress={() => onViewChange('bible')}
             style={styles.toggleButton}
@@ -666,9 +783,7 @@ function TopicHeader({
             accessibilityState={{ selected: activeView === 'bible' }}
             testID="bible-view-toggle"
           >
-            <Text style={[styles.toggleText, activeView === 'bible' && styles.toggleTextActive]}>
-              Bible
-            </Text>
+            <Animated.Text style={[styles.toggleText, bibleTextStyle]}>Bible</Animated.Text>
           </Pressable>
           <Pressable
             onPress={() => onViewChange('explanations')}
@@ -679,11 +794,7 @@ function TopicHeader({
             accessibilityState={{ selected: activeView === 'explanations' }}
             testID="insight-view-toggle"
           >
-            <Text
-              style={[styles.toggleText, activeView === 'explanations' && styles.toggleTextActive]}
-            >
-              Insight
-            </Text>
+            <Animated.Text style={[styles.toggleText, insightTextStyle]}>Insight</Animated.Text>
           </Pressable>
         </View>
 
@@ -794,6 +905,23 @@ const createStyles = (colors: ReturnType<typeof getColors>) =>
   StyleSheet.create({
     container: {
       flex: 1,
+      backgroundColor: colors.background,
+    },
+    pagerWrapper: {
+      flex: 1,
+      position: 'relative',
+    },
+    // overflow:hidden so the maxHeight animation clips the tabs row
+    // when collapsing/expanding.
+    tabsWrapper: {
+      overflow: 'hidden',
+    },
+    transitionSkeleton: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
       backgroundColor: colors.background,
     },
     errorContainer: {

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -86,6 +86,14 @@ export interface BibleExplanationsPanelProps {
   /** Callback when tab changes */
   onTabChange: (tab: ContentTabType) => void;
 
+  /**
+   * True while a tab switch transition is pending in the parent. Drives a
+   * skeleton overlay so the user sees immediate visual feedback that the
+   * content is changing, even though React keeps the old tab visible while
+   * the new tree reconciles in the background.
+   */
+  isTabPending?: boolean;
+
   /** Callback when menu button is pressed */
   onMenuPress?: () => void;
 
@@ -124,6 +132,7 @@ export function BibleExplanationsPanel({
   bookName,
   activeTab,
   onTabChange,
+  isTabPending = false,
   onMenuPress,
   onScroll,
   onTap,
@@ -227,17 +236,14 @@ export function BibleExplanationsPanel({
     language,
   });
 
-  // Handle tab change with haptic feedback
+  // Handle tab change with haptic feedback. The parent's onTabChange is
+  // expected to wrap setActiveTab in a useTransition so React doesn't block
+  // on the heavy markdown reconciliation; `isTabPending` then drives the
+  // skeleton overlay below.
   const handleTabChange = (tab: ContentTabType) => {
     if (tab === activeTab) return;
-    const t0 = performance.now();
-    console.log(`[TAB-PERF] bible tap ${activeTab}->${tab} @0ms`);
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onTabChange(tab);
-    console.log(`[TAB-PERF] bible onTabChange returned +${(performance.now() - t0).toFixed(1)}ms`);
-    setTimeout(() => {
-      console.log(`[TAB-PERF] bible next-tick +${(performance.now() - t0).toFixed(1)}ms`);
-    }, 0);
   };
 
   // Per-tab content extraction
@@ -463,144 +469,162 @@ export function BibleExplanationsPanel({
         </View>
       </View>
 
-      {/* Content Area — one ScrollView per tab for independent scroll positions */}
-      {(
-        [
-          {
-            key: 'summary' as const,
-            type: 'summary',
-            ref: summaryScrollRef,
-            data: summaryContent,
-            explanationId:
-              summaryData && 'explanationId' in summaryData ? summaryData.explanationId : null,
-            // OR with isPending so the skeleton covers the one-frame
-            // window where the query has just been enabled but the
-            // fetch hasn't kicked off yet. See destructure comment.
-            loading: summaryLoading || (activeTab === 'summary' && summaryPending),
-            isLocal: summaryIsLocal,
-          },
-          {
-            key: 'byline' as const,
-            type: 'byline',
-            ref: byLineScrollRef,
-            data: byLineContent,
-            explanationId:
-              byLineData && 'explanationId' in byLineData ? byLineData.explanationId : null,
-            loading: byLineLoading || (activeTab === 'byline' && byLinePending),
-            isLocal: byLineIsLocal,
-          },
-        ] as const
-      ).map((tab) => (
-        <ScrollView
-          key={tab.key}
-          ref={tab.ref}
-          style={[styles.scrollView, activeTab !== tab.key && { display: 'none' }]}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={true}
-          onScroll={activeTab === tab.key ? handleInternalScroll : undefined}
-          scrollEventThrottle={16}
-          testID={`${testID}-scroll-${tab.key}`}
-        >
-          {tab.loading ? (
-            <SkeletonLoader />
-          ) : tab.data ? (
-            <>
-              {tab.explanationId !== null ? (
-                <AudioInlineEntry
-                  explanationId={tab.explanationId}
-                  explanationType={tab.type}
-                  bookId={bookId}
-                  chapterNumber={chapterNumber}
-                  language={language}
-                  sourceHref={`/bible/${bookId}/${chapterNumber}`}
-                />
-              ) : null}
-              {tab.isLocal && <AvailableOfflineBadge />}
-              {tab.key === 'byline' && byLineSections.length > 0 ? (
-                byLineSections.map((section, index) => (
-                  <View
-                    // biome-ignore lint/suspicious/noArrayIndexKey: stable within a single parsed render
-                    key={`byline-section-${section.verseNumber}-${index}`}
-                    ref={(node) => {
-                      if (node === null) {
-                        delete byLineSectionRefs.current[section.verseNumber];
-                      } else {
-                        byLineSectionRefs.current[section.verseNumber] = node;
-                      }
-                    }}
-                    testID={`byline-verse-section-${section.verseNumber}`}
-                    collapsable={false}
-                  >
-                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
-                  </View>
-                ))
-              ) : (
-                <Markdown style={markdownStyles}>{tab.data}</Markdown>
-              )}
-            </>
-          ) : isOffline ? (
-            <OfflineContentUnavailable contentType="explanation" />
-          ) : (
-            <View style={styles.emptyContainer}>
-              <Text style={styles.emptyText}>No explanations available for this chapter.</Text>
-            </View>
-          )}
-        </ScrollView>
-      ))}
+      {/* Content Area — one ScrollView per tab for independent scroll
+          positions. Wrapped in a relative-positioned flex-1 View so the
+          transition skeleton at the bottom can be absolutely positioned
+          over the tab content only (not the header/tabs above). */}
+      <View style={styles.contentArea}>
+        {(
+          [
+            {
+              key: 'summary' as const,
+              type: 'summary',
+              ref: summaryScrollRef,
+              data: summaryContent,
+              explanationId:
+                summaryData && 'explanationId' in summaryData ? summaryData.explanationId : null,
+              // OR with isPending so the skeleton covers the one-frame
+              // window where the query has just been enabled but the
+              // fetch hasn't kicked off yet. See destructure comment.
+              loading: summaryLoading || (activeTab === 'summary' && summaryPending),
+              isLocal: summaryIsLocal,
+            },
+            {
+              key: 'byline' as const,
+              type: 'byline',
+              ref: byLineScrollRef,
+              data: byLineContent,
+              explanationId:
+                byLineData && 'explanationId' in byLineData ? byLineData.explanationId : null,
+              loading: byLineLoading || (activeTab === 'byline' && byLinePending),
+              isLocal: byLineIsLocal,
+            },
+          ] as const
+        ).map((tab) => (
+          <ScrollView
+            key={tab.key}
+            ref={tab.ref}
+            style={[styles.scrollView, activeTab !== tab.key && { display: 'none' }]}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={true}
+            onScroll={activeTab === tab.key ? handleInternalScroll : undefined}
+            scrollEventThrottle={16}
+            testID={`${testID}-scroll-${tab.key}`}
+          >
+            {tab.loading ? (
+              <SkeletonLoader />
+            ) : tab.data ? (
+              <>
+                {tab.explanationId !== null ? (
+                  <AudioInlineEntry
+                    explanationId={tab.explanationId}
+                    explanationType={tab.type}
+                    bookId={bookId}
+                    chapterNumber={chapterNumber}
+                    language={language}
+                    sourceHref={`/bible/${bookId}/${chapterNumber}`}
+                  />
+                ) : null}
+                {tab.isLocal && <AvailableOfflineBadge />}
+                {tab.key === 'byline' && byLineSections.length > 0 ? (
+                  byLineSections.map((section, index) => (
+                    <View
+                      // biome-ignore lint/suspicious/noArrayIndexKey: stable within a single parsed render
+                      key={`byline-section-${section.verseNumber}-${index}`}
+                      ref={(node) => {
+                        if (node === null) {
+                          delete byLineSectionRefs.current[section.verseNumber];
+                        } else {
+                          byLineSectionRefs.current[section.verseNumber] = node;
+                        }
+                      }}
+                      testID={`byline-verse-section-${section.verseNumber}`}
+                      collapsable={false}
+                    >
+                      <Markdown style={markdownStyles}>{section.markdown}</Markdown>
+                    </View>
+                  ))
+                ) : (
+                  <Markdown style={markdownStyles}>{tab.data}</Markdown>
+                )}
+              </>
+            ) : isOffline ? (
+              <OfflineContentUnavailable contentType="explanation" />
+            ) : (
+              <View style={styles.emptyContainer}>
+                <Text style={styles.emptyText}>No explanations available for this chapter.</Text>
+              </View>
+            )}
+          </ScrollView>
+        ))}
 
-      {/* Study tab — bundled content from @versemate/studies (no API fetch,
+        {/* Study tab — bundled content from @versemate/studies (no API fetch,
           no loading state, no offline concerns). Always mounted, hidden
           when not active so its scroll position persists across tab
           switches like the other 3 tabs. */}
-      <ScrollView
-        ref={studyScrollRef}
-        style={[styles.scrollView, activeTab !== 'study' && { display: 'none' }]}
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={true}
-        onScroll={activeTab === 'study' ? handleInternalScroll : undefined}
-        scrollEventThrottle={16}
-        testID={`${testID}-scroll-study`}
-      >
-        <StudyPanel bookId={bookId} chapter={chapterNumber} testID={`${testID}-study`} />
-      </ScrollView>
+        <ScrollView
+          ref={studyScrollRef}
+          style={[styles.scrollView, activeTab !== 'study' && { display: 'none' }]}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={true}
+          onScroll={activeTab === 'study' ? handleInternalScroll : undefined}
+          scrollEventThrottle={16}
+          testID={`${testID}-scroll-study`}
+        >
+          <StudyPanel bookId={bookId} chapter={chapterNumber} testID={`${testID}-study`} />
+        </ScrollView>
 
-      {/* Visuals tab — bundled content from @versemate/visuals. Only
+        {/* Visuals tab — bundled content from @versemate/visuals. Only
           mounted for books in BOOKS_WITH_VISUALS (most are), gated by
           `hasVisuals`. Same hidden-not-unmounted pattern as Study so the
           lightbox state and scroll position survive tab switches. */}
-      {hasVisuals ? (
-        <ScrollView
-          ref={visualsScrollRef}
-          style={[styles.scrollView, activeTab !== 'visuals' && { display: 'none' }]}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={true}
-          onScroll={activeTab === 'visuals' ? handleInternalScroll : undefined}
-          scrollEventThrottle={16}
-          testID={`${testID}-scroll-visuals`}
-        >
-          <VisualsPanel
-            bookId={bookId}
-            chapter={chapterNumber}
-            bookName={bookName}
-            testID={`${testID}-visuals`}
-          />
-        </ScrollView>
-      ) : null}
+        {hasVisuals ? (
+          <ScrollView
+            ref={visualsScrollRef}
+            style={[styles.scrollView, activeTab !== 'visuals' && { display: 'none' }]}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={true}
+            onScroll={activeTab === 'visuals' ? handleInternalScroll : undefined}
+            scrollEventThrottle={16}
+            testID={`${testID}-scroll-visuals`}
+          >
+            <VisualsPanel
+              bookId={bookId}
+              chapter={chapterNumber}
+              bookName={bookName}
+              testID={`${testID}-visuals`}
+            />
+          </ScrollView>
+        ) : null}
 
-      {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
+        {/* Quick-verse-jump FAB (VERA-36): byline-only. No chapter-nav row
           beneath this ScrollView in split / desktop right panel, so use a
           tighter bottom offset than the phone-portrait default.
           Fades with the scroll-arrow auto-hide (VERA-39 / VERA-36 parity). */}
-      {activeTab === 'byline' && (
-        <VerseJumpButton
-          verses={byLineVerses}
-          onSelect={handleByLineVerseJump}
-          visible={fabVisible}
-          onInteraction={onFABInteraction}
-          bottomOffset={spacing.lg}
-          testID={`${testID}-verse-jump`}
-        />
-      )}
+        {activeTab === 'byline' && (
+          <VerseJumpButton
+            verses={byLineVerses}
+            onSelect={handleByLineVerseJump}
+            visible={fabVisible}
+            onInteraction={onFABInteraction}
+            bottomOffset={spacing.lg}
+            testID={`${testID}-verse-jump`}
+          />
+        )}
+
+        {/* Transition skeleton overlay — shown while the parent's tab-switch
+          transition is reconciling. Covers the tab content area only; the
+          tabs row above stays interactive. */}
+        {isTabPending && (
+          <View
+            style={styles.transitionSkeleton}
+            pointerEvents="none"
+            testID={`${testID}-tab-transition-skeleton`}
+          >
+            <SkeletonLoader />
+          </View>
+        )}
+      </View>
     </View>
   );
 }
@@ -694,6 +718,18 @@ function createStyles(
     },
     scrollView: {
       flex: 1,
+    },
+    contentArea: {
+      flex: 1,
+      position: 'relative',
+    },
+    transitionSkeleton: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: colors.background,
     },
     scrollContent: {
       flexGrow: 1,

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -241,10 +241,21 @@ export function BibleExplanationsPanel({
     // biome-ignore lint/correctness/useExhaustiveDependencies: React Compiler handles memoization of getTabIndex
   }, [activeTab, slideAnim, getTabIndex]);
 
-  // Fetch explanations based on active tab
+  // Fetch explanations based on active tab.
+  //
+  // Note: we destructure BOTH `isLoading` and `isPending`. `isLoading` is
+  // `isPending && isFetching` — it stays false during the synchronous
+  // render that flips `enabled` from false→true (the fetch is scheduled
+  // in an effect that runs AFTER render). That leaves a one-frame window
+  // where `data` is undefined AND `isLoading` is false, which used to
+  // render nothing → user sees a blank Insight tab on first switch from
+  // Bible (Andy 2026-05-24 repro: "typically on app startup"). Using
+  // `isPending` for the skeleton gate covers the gap — it's true the
+  // moment the query exists without data, regardless of fetch state.
   const {
     data: summaryData,
     isLoading: summaryLoading,
+    isPending: summaryPending,
     isLocalData: summaryIsLocal,
   } = useBibleSummary(bookId, chapterNumber, undefined, {
     enabled: activeTab === 'summary',
@@ -254,6 +265,7 @@ export function BibleExplanationsPanel({
   const {
     data: byLineData,
     isLoading: byLineLoading,
+    isPending: byLinePending,
     isLocalData: byLineIsLocal,
   } = useBibleByLine(bookId, chapterNumber, undefined, {
     enabled: activeTab === 'byline',
@@ -499,7 +511,10 @@ export function BibleExplanationsPanel({
             data: summaryContent,
             explanationId:
               summaryData && 'explanationId' in summaryData ? summaryData.explanationId : null,
-            loading: summaryLoading,
+            // OR with isPending so the skeleton covers the one-frame
+            // window where the query has just been enabled but the
+            // fetch hasn't kicked off yet. See destructure comment.
+            loading: summaryLoading || (activeTab === 'summary' && summaryPending),
             isLocal: summaryIsLocal,
           },
           {
@@ -509,7 +524,7 @@ export function BibleExplanationsPanel({
             data: byLineContent,
             explanationId:
               byLineData && 'explanationId' in byLineData ? byLineData.explanationId : null,
-            loading: byLineLoading,
+            loading: byLineLoading || (activeTab === 'byline' && byLinePending),
             isLocal: byLineIsLocal,
           },
         ] as const

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -26,16 +26,13 @@ import {
   Text,
   View,
 } from 'react-native';
-import Markdown, { type RenderRules } from 'react-native-markdown-display';
+import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
 import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
-import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { AvailableOfflineBadge } from '@/components/offline/AvailableOfflineBadge';
 import { OfflineContentUnavailable } from '@/components/offline/OfflineContentUnavailable';
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useToast } from '@/contexts/ToastContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
 import { useOfflineStatus } from '@/hooks/bible/use-offline-status';
 import { useBibleByLine, useBibleSummary } from '@/src/api';
@@ -143,48 +140,6 @@ export function BibleExplanationsPanel({
     () => createStyles(specs, colors, insets),
     [specs, colors, insets]
   );
-  const { showToast } = useToast();
-
-  // Word definition tooltip state (long-press dictionary lookup on markdown text)
-  const [wordToDefine, setWordToDefine] = useState<{
-    word: string;
-    verseNumber: number;
-  } | null>(null);
-  const [wordDefinitionVisible, setWordDefinitionVisible] = useState(false);
-
-  const handleWordSelect = useCallback((selection: WordSelection, clearSelection: () => void) => {
-    setWordToDefine({ word: selection.word, verseNumber: selection.verseNumber });
-    setWordDefinitionVisible(true);
-    clearSelection();
-  }, []);
-
-  const handleWordDefinitionClose = useCallback(() => {
-    setWordDefinitionVisible(false);
-    setWordToDefine(null);
-  }, []);
-
-  const handleWordDefinitionCopy = useCallback(() => {
-    showToast('Copied to clipboard');
-  }, [showToast]);
-
-  // Custom markdown rule that wraps each text leaf with HighlightedText so
-  // long-press triggers the dictionary tooltip across Summary/By Line/Study.
-  const dictionaryMarkdownRules: RenderRules = useMemo(
-    () => ({
-      text: (node, _children, _parent, styles, inheritedStyles = {}) => (
-        <HighlightedText
-          key={node.key}
-          text={node.content}
-          verseNumber={0}
-          style={[inheritedStyles, styles.text]}
-          onWordSelect={handleWordSelect}
-          isVisible={true}
-        />
-      ),
-    }),
-    [handleWordSelect]
-  );
-
   // Get current language from user preferences (default to 'en-US')
   // This ensures the query key changes when language changes
   const language = typeof user?.preferred_language === 'string' ? user.preferred_language : 'en-US';
@@ -274,8 +229,15 @@ export function BibleExplanationsPanel({
 
   // Handle tab change with haptic feedback
   const handleTabChange = (tab: ContentTabType) => {
+    if (tab === activeTab) return;
+    const t0 = performance.now();
+    console.log(`[TAB-PERF] bible tap ${activeTab}->${tab} @0ms`);
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onTabChange(tab);
+    console.log(`[TAB-PERF] bible onTabChange returned +${(performance.now() - t0).toFixed(1)}ms`);
+    setTimeout(() => {
+      console.log(`[TAB-PERF] bible next-tick +${(performance.now() - t0).toFixed(1)}ms`);
+    }, 0);
   };
 
   // Per-tab content extraction
@@ -569,15 +531,11 @@ export function BibleExplanationsPanel({
                     testID={`byline-verse-section-${section.verseNumber}`}
                     collapsable={false}
                   >
-                    <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-                      {section.markdown}
-                    </Markdown>
+                    <Markdown style={markdownStyles}>{section.markdown}</Markdown>
                   </View>
                 ))
               ) : (
-                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-                  {tab.data}
-                </Markdown>
+                <Markdown style={markdownStyles}>{tab.data}</Markdown>
               )}
             </>
           ) : isOffline ? (
@@ -641,19 +599,6 @@ export function BibleExplanationsPanel({
           onInteraction={onFABInteraction}
           bottomOffset={spacing.lg}
           testID={`${testID}-verse-jump`}
-        />
-      )}
-
-      {/* Word Definition Tooltip — dictionary lookup on long-press */}
-      {wordToDefine && (
-        <WordDefinitionTooltip
-          visible={wordDefinitionVisible}
-          word={wordToDefine.word}
-          bookName={bookName}
-          chapterNumber={chapterNumber}
-          verseNumber={wordToDefine.verseNumber}
-          onClose={handleWordDefinitionClose}
-          onCopy={handleWordDefinitionCopy}
         />
       )}
     </View>

--- a/components/bible/ChapterContentTabs.tsx
+++ b/components/bible/ChapterContentTabs.tsx
@@ -7,19 +7,28 @@
  *
  * Features:
  * - Pill-style buttons: "Summary", "By Line", "Study", "Visuals" (last is gated)
- * - Active tab: gold background (#b09a6d), dark text
- * - Inactive tabs: gray700 background (#4a4a4a), white text
- * - Border radius: 20px, padding: 8px vertical, 20px horizontal
- * - Horizontal layout with 8px gap
- * - Haptic feedback on tap (light)
+ * - Active tab: gold background, dark text
+ * - Inactive tabs: gray background, white text
+ * - Sliding indicator animates on the UI thread via Reanimated, driven by a
+ *   shared sharedValue (`activeTabProgress`) the parent updates synchronously
+ *   on tap — so the indicator + text colors flip the same frame as the press,
+ *   not when React reconciliation catches up.
  *
  * @see Spec lines 254-267, 405-425 (Tab specifications)
- * @see Task Group 5.2 - Implement ChapterContentTabs component
  */
 
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Animated, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import Animated, {
+  Easing,
+  interpolateColor,
+  type SharedValue,
+  useAnimatedReaction,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useTheme } from '@/contexts/ThemeContext';
 import { type getColors, getTabSpecs, spacing, type ThemeMode } from '@/theme/tokens';
 import type { ContentTabType } from '@/types/bible';
@@ -29,6 +38,14 @@ interface ChapterContentTabsProps {
   activeTab: ContentTabType;
   /** Callback when tab is changed */
   onTabChange: (tab: ContentTabType) => void;
+  /**
+   * Shared visual key for the active tab. When provided, the indicator
+   * translateX and text colors animate on the UI thread the same frame
+   * the parent updates this sharedValue (typically synchronously inside
+   * the tap handler before `onTabChange`). Falls back to a local
+   * sharedValue mirroring `activeTab` when omitted.
+   */
+  activeTabProgress?: SharedValue<ContentTabType>;
   /** Whether tabs should be disabled (optional) */
   disabled?: boolean;
   /**
@@ -75,12 +92,14 @@ const VISUALS_TAB: Tab = { id: 'visuals', label: 'Visuals' };
 export function ChapterContentTabs({
   activeTab,
   onTabChange,
+  activeTabProgress,
   disabled = false,
   showDetailed = false,
   showStudy = false,
   showVisuals = false,
 }: ChapterContentTabsProps) {
   const { colors, mode } = useTheme();
+  const specs = getTabSpecs(mode);
   const styles = createStyles(colors, mode);
 
   // Memoise the tab list so getTabIndex's deps are stable. When any
@@ -95,45 +114,60 @@ export function ChapterContentTabs({
     ],
     [showDetailed, showStudy, showVisuals]
   );
-  // useCallback so the slide-animation useEffect can include this in its
-  // deps without re-running on every render (Biome
-  // lint/correctness/useExhaustiveDependencies).
   const getTabIndex = useCallback(
     (tab: ContentTabType) => tabs.findIndex((t) => t.id === tab),
     [tabs]
   );
 
-  // Animation value for sliding indicator
-  const slideAnim = useRef(new Animated.Value(getTabIndex(activeTab))).current;
-  const [tabWidth, setTabWidth] = useState(0);
-
-  // Animate indicator when active tab changes
+  // Local fallback sharedValue for callers that don't pass one in
+  // (storybook, isolated tests). Mirrors activeTab via a useEffect.
+  const localActiveTabProgress = useSharedValue<ContentTabType>(activeTab);
   useEffect(() => {
-    const targetIndex = getTabIndex(activeTab);
-    // Negative index (e.g. activeTab='visuals' while showVisuals just
-    // toggled off) shouldn't animate — clamp to 0 instead of NaN.
-    Animated.spring(slideAnim, {
-      toValue: targetIndex < 0 ? 0 : targetIndex,
-      useNativeDriver: true,
-      friction: 8,
-      tension: 50,
-    }).start();
-  }, [activeTab, slideAnim, getTabIndex]);
+    if (activeTabProgress) return;
+    localActiveTabProgress.value = activeTab;
+  }, [activeTab, localActiveTabProgress, activeTabProgress]);
+  const effectiveTabProgress = activeTabProgress ?? localActiveTabProgress;
+
+  // Numeric index of the active tab. animatedIndex is the sharedValue
+  // the indicator + text color worklets actually read; it's driven by a
+  // useAnimatedReaction that fires withTiming whenever the parent's
+  // activeTabProgress changes. This pattern is more reliable than
+  // `useDerivedValue(() => withTiming(...))` — the derived form
+  // occasionally lost frames or snapped instead of sliding because the
+  // animation state isn't preserved between derived-value re-runs.
+  const initialIndex = useMemo(() => {
+    const idx = tabs.findIndex((t) => t.id === activeTab);
+    return idx < 0 ? 0 : idx;
+  }, [tabs, activeTab]);
+  const animatedIndex = useSharedValue(initialIndex);
+  useAnimatedReaction(
+    () => effectiveTabProgress.value,
+    (current) => {
+      'worklet';
+      const idx = tabs.findIndex((t) => t.id === current);
+      if (idx < 0) return;
+      animatedIndex.value = withTiming(idx, {
+        duration: 250,
+        easing: Easing.out(Easing.cubic),
+      });
+    },
+    [tabs]
+  );
+
+  const [tabWidth, setTabWidth] = useState(0);
 
   /**
    * Handle tab press
    * - Trigger haptic feedback
-   * - Call onTabChange callback
+   * - Call onTabChange callback (parent updates activeTabProgress
+   *   synchronously inside this callback so the indicator + colors
+   *   start animating the same frame as the tap)
    */
   const handleTabPress = (tab: ContentTabType) => {
     if (disabled || tab === activeTab) {
-      return; // Don't trigger if already active or disabled
+      return;
     }
-
-    // Light haptic feedback
     Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-
-    // Notify parent of tab change
     onTabChange(tab);
   };
 
@@ -149,65 +183,99 @@ export function ChapterContentTabs({
     setTabWidth(usableWidth / n);
   };
 
-  // Calculate translateX for sliding indicator. Animated.interpolate
-  // requires inputRange.length === outputRange.length and a
-  // monotonically increasing inputRange — both built from tabs.length.
-  const indicatorInputRange = tabs.map((_, i) => i);
-  const indicatorOutputRange = tabs.map((_, i) => i * (tabWidth + 4));
-  // interpolate() rejects single-element ranges (e.g. if tabs.length
-  // somehow became 1) — pad to two entries so animation never throws.
-  if (indicatorInputRange.length < 2) {
-    indicatorInputRange.push(1);
-    indicatorOutputRange.push(tabWidth + 4);
-  }
-  const indicatorTranslateX = slideAnim.interpolate({
-    inputRange: indicatorInputRange,
-    outputRange: indicatorOutputRange,
-  });
+  // Indicator translateX animation runs on the UI thread driven by
+  // animatedIndex (smoothed targetIndex). Translates to index * (tabWidth + 4).
+  const indicatorAnimatedStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      transform: [{ translateX: animatedIndex.value * (tabWidth + 4) }],
+    };
+  }, [tabWidth]);
+
+  // Per-tab text color animation — cross-fade between active and inactive
+  // colors based on how close animatedIndex is to this tab's index.
+  // Distance 0 = active (fully active color); distance >= 1 = inactive.
+  const activeColor = specs.active.textColor;
+  const inactiveColor = specs.inactive.textColor;
 
   return (
     <View style={styles.container} testID="chapter-content-tabs">
       <View style={styles.tabsRow} onLayout={handleLayout}>
         {/* Sliding active indicator */}
         <Animated.View
-          style={[
-            styles.slidingIndicator,
-            {
-              width: tabWidth,
-              transform: [{ translateX: indicatorTranslateX }],
-            },
-          ]}
+          style={[styles.slidingIndicator, { width: tabWidth }, indicatorAnimatedStyle]}
         />
 
-        {tabs.map((tab) => {
-          const isActive = activeTab === tab.id;
-
-          return (
-            <Pressable
-              key={tab.id}
-              onPress={() => handleTabPress(tab.id)}
-              style={({ pressed }) => [
-                styles.tab,
-                pressed && styles.tabPressed,
-                disabled && styles.tabDisabled,
-              ]}
-              accessibilityRole="tab"
-              accessibilityState={{ selected: isActive, disabled }}
-              accessibilityLabel={`${tab.label} tab`}
-              accessibilityHint={`Switch to ${tab.label} reading mode`}
-              testID={`tab-${tab.id}`}
-              disabled={disabled}
-            >
-              <Text
-                style={[styles.tabText, isActive ? styles.tabTextActive : styles.tabTextInactive]}
-              >
-                {tab.label}
-              </Text>
-            </Pressable>
-          );
-        })}
+        {tabs.map((tab, index) => (
+          <TabButton
+            key={tab.id}
+            tab={tab}
+            index={index}
+            animatedIndex={animatedIndex}
+            activeColor={activeColor}
+            inactiveColor={inactiveColor}
+            onPress={handleTabPress}
+            disabled={disabled}
+            activeTab={activeTab}
+            styles={styles}
+          />
+        ))}
       </View>
     </View>
+  );
+}
+
+/**
+ * Single tab button. Pulled out so its useAnimatedStyle hook is called
+ * exactly once per tab (hook rules require stable hook ordering — we
+ * can't loop useAnimatedStyle inside the parent component).
+ */
+function TabButton({
+  tab,
+  index,
+  animatedIndex,
+  activeColor,
+  inactiveColor,
+  onPress,
+  disabled,
+  activeTab,
+  styles,
+}: {
+  tab: Tab;
+  index: number;
+  animatedIndex: SharedValue<number>;
+  activeColor: string;
+  inactiveColor: string;
+  onPress: (id: ContentTabType) => void;
+  disabled: boolean;
+  activeTab: ContentTabType;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  const textAnimatedStyle = useAnimatedStyle(() => {
+    'worklet';
+    const distance = Math.min(1, Math.abs(animatedIndex.value - index));
+    return {
+      color: interpolateColor(distance, [0, 1], [activeColor, inactiveColor]),
+    };
+  }, [index, activeColor, inactiveColor]);
+
+  return (
+    <Pressable
+      onPress={() => onPress(tab.id)}
+      style={({ pressed }) => [
+        styles.tab,
+        pressed && styles.tabPressed,
+        disabled && styles.tabDisabled,
+      ]}
+      accessibilityRole="tab"
+      accessibilityState={{ selected: activeTab === tab.id, disabled }}
+      accessibilityLabel={`${tab.label} tab`}
+      accessibilityHint={`Switch to ${tab.label} reading mode`}
+      testID={`tab-${tab.id}`}
+      disabled={disabled}
+    >
+      <Animated.Text style={[styles.tabText, textAnimatedStyle]}>{tab.label}</Animated.Text>
+    </Pressable>
   );
 }
 
@@ -245,9 +313,6 @@ const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => 
       flex: 1,
       borderRadius: 100,
       paddingVertical: 2,
-      // Tight horizontal padding so labels (Summary / By Line / Study /
-      // Visuals) fit on narrow phone widths without truncation. flex:1 already
-      // handles equal sizing; padding here is just for press hit area + edge.
       paddingHorizontal: spacing.sm,
       justifyContent: 'center',
       alignItems: 'center',

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -29,7 +29,16 @@ import {
   Text,
   View,
 } from 'react-native';
-import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
+import Animated, {
+  Easing,
+  FadeIn,
+  FadeOut,
+  type SharedValue,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AudioInlineEntry } from '@/components/bible/AudioInlineEntry';
 import { DeleteConfirmationModal } from '@/components/bible/DeleteConfirmationModal';
@@ -70,6 +79,13 @@ const createStyles = (colors: ReturnType<typeof getColors>, bottomInset: number)
     container: {
       flex: 1,
       backgroundColor: colors.background,
+    },
+    absoluteFill: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
     },
     contentContainer: {
       flexGrow: 1,
@@ -160,9 +176,14 @@ function TabContent({
   const hasContent =
     typeof explanationContent?.content === 'string' && explanationContent.content.trim().length > 0;
 
-  // Only show skeleton on initial load, not when transitioning between chapters
-  // This prevents flicker when swiping between chapters
-  const showSkeleton = isLoading && !chapter && !explanationContent;
+  // Show skeleton whenever we're loading and have no content yet — covers
+  // both the initial chapter load (no chapter, no content) AND the case
+  // where the chapter is already loaded but this specific tab's
+  // explanation fetch just started (e.g. first tap on a tab whose fetch
+  // was lazily enabled). The previous `!chapter` guard caused tabs that
+  // were fetched on-demand to render "No X explanation available yet"
+  // during the fetch instead of a skeleton.
+  const showSkeleton = isLoading && !explanationContent;
 
   // Keep all tabs mounted for pre-rendering (eliminates freeze on switch)
   // Use absolute positioning + pointerEvents to hide inactive tabs
@@ -272,6 +293,23 @@ export interface ChapterPageProps {
   activeTab: ContentTabType;
   /** Current view mode (bible or explanations) */
   activeView: 'bible' | 'explanations';
+  /**
+   * Shared visual progress (0 = Bible, 1 = Insight) driven by ChapterScreen.
+   * Used via useAnimatedStyle to flip container opacity on the UI thread
+   * so the swap is visible the same frame as the tap — independent of the
+   * activeView prop reconciliation (which can take ~300ms). Optional so
+   * isolated callers (tests, the split-view BibleContentPanel which only
+   * renders the Bible side) can omit it; visibility then falls back to
+   * `activeView` via a local sharedValue.
+   */
+  toggleProgress?: SharedValue<number>;
+  /**
+   * Shared visual key (active tab name) for the inner Summary / By Line /
+   * Study / Visuals tab switch. Drives per-tab Animated.View opacity on
+   * the UI thread so the inner-tab swap is also instant. Optional with
+   * activeTab-mirroring fallback for isolated callers.
+   */
+  activeTabProgress?: SharedValue<ContentTabType>;
   /** Whether to reset scroll to top on chapter change (default: true) */
   shouldResetScroll?: boolean;
   /** Whether this page is being preloaded (skips heavy AI content) */
@@ -327,6 +365,8 @@ export function ChapterPage({
   chapterNumber,
   activeTab,
   activeView,
+  toggleProgress,
+  activeTabProgress,
   shouldResetScroll = true,
   isPreloading = false,
   targetVerse,
@@ -412,23 +452,17 @@ export function ChapterPage({
   // and only once per ChapterPage lifetime.
   useEffect(() => {
     if (isPreloading || insightPrewarmed) return;
+    // Fire as soon as the chapter-swipe interaction finishes — no extra
+    // delay. The toggleProgress-driven visibility flip below only works
+    // when the Insight subtree is mounted, so we want this to flip as
+    // early as possible.
     const handle = InteractionManager.runAfterInteractions(() => {
-      // Small extra delay so the chapter-swipe settle animation
-      // (~300ms) is fully past before we add Insight to the render.
-      const t = setTimeout(() => setInsightPrewarmed(true), 300);
-      // The InteractionManager.Handle API only exposes `cancel`; we
-      // can't return a setTimeout cleanup from here, so stash on the
-      // closure's outer scope via a sibling effect-return.
-      timeoutHandleRef.current = t;
+      setInsightPrewarmed(true);
     });
     return () => {
       handle.cancel();
-      if (timeoutHandleRef.current) {
-        clearTimeout(timeoutHandleRef.current);
-        timeoutHandleRef.current = null;
-      }
     };
-  }, [isPreloading, insightPrewarmed]);
+  }, [isPreloading, insightPrewarmed, bookId, chapterNumber]);
 
   // Trigger staggered delayed render — only for the active page, not buffer pages,
   // and only while the user is actually in Explanations view.
@@ -439,10 +473,18 @@ export function ChapterPage({
   // mounted via insightPrewarmed before the user ever switches, so the
   // initial switch isn't blocked.
   useEffect(() => {
-    if (isPreloading || activeView !== 'explanations') {
+    if (isPreloading) {
       setDelayedRenderStage(0);
       return;
     }
+    // Stagger no longer gated on `activeView === 'explanations'`. The
+    // inner tabs (byline, study, visuals) pre-mount in the background
+    // even while the user is on Bible view, so the first tap to any tab
+    // finds it already mounted and the sharedValue-driven opacity flip
+    // is instant. Trade-off: a small chunk of markdown parse work runs
+    // during background idle on every chapter load — acceptable because
+    // the alternative is a 1-2s lag the first time the user taps a tab
+    // they haven't visited yet.
     const t1 = setTimeout(() => setDelayedRenderStage(1), 600);
     const t2 = setTimeout(() => setDelayedRenderStage(2), 1100);
     const t3 = setTimeout(() => setDelayedRenderStage(3), 1600);
@@ -453,13 +495,9 @@ export function ChapterPage({
       clearTimeout(t3);
       clearTimeout(t4);
     };
-  }, [isPreloading, activeView]);
+  }, [isPreloading]);
 
   // Track explanation tab content heights for scroll syncing
-  // Stash for the Insight pre-warm setTimeout so the useEffect cleanup
-  // can clear it on unmount or when prewarm completes.
-  const timeoutHandleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   const tabContentHeightsRef = useRef<
     Record<string, { contentHeight: number; viewHeight: number }>
   >({});
@@ -621,6 +659,27 @@ export function ChapterPage({
       return next;
     });
   }, [activeTab]);
+
+  // Eagerly pre-fetch the byline explanation a moment after the chapter
+  // settles so the first tap on the By Line tab finds the data already
+  // cached (no fetch lag, no skeleton). Summary is fetched on mount
+  // because activeTab starts as 'summary'; Study + Visuals are bundled
+  // (no fetch). The 1500ms delay lets the chapter render / scroll into
+  // place before we add another API call to the queue. Skipped for
+  // buffer pages to avoid prefetching for chapters the user may never
+  // actually open.
+  useEffect(() => {
+    if (isPreloading) return;
+    const t = setTimeout(() => {
+      setVisitedTabs((prev) => {
+        if (prev.has('byline')) return prev;
+        const next = new Set(prev);
+        next.add('byline');
+        return next;
+      });
+    }, 1500);
+    return () => clearTimeout(t);
+  }, [isPreloading, bookId, chapterNumber]);
 
   // Fetch explanations lazily — only enable for the active tab or previously visited tabs
   const {
@@ -937,6 +996,69 @@ export function ChapterPage({
     );
   }, []);
 
+  // UI-thread driven opacities — flip the visible content the same frame
+  // as the tap, without waiting for the activeView prop reconciliation
+  // (which can take ~300ms while React walks the chapter tree). Both
+  // containers stay position:absolute so neither holds layout space,
+  // overlapping at the same bounds. Opacity decides which is visible.
+  // Falls back to a local sharedValue mirroring activeView when no parent
+  // sharedValue is provided (tests, BibleContentPanel split-view path).
+  const localToggleProgress = useSharedValue(activeView === 'bible' ? 0 : 1);
+  useEffect(() => {
+    if (toggleProgress) return;
+    localToggleProgress.value = withTiming(activeView === 'bible' ? 0 : 1, {
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [activeView, localToggleProgress, toggleProgress]);
+  const effectiveProgress = toggleProgress ?? localToggleProgress;
+  const insightContainerStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: effectiveProgress.value,
+      zIndex: effectiveProgress.value > 0.5 ? 1 : 0,
+    };
+  });
+  const bibleContainerStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: 1 - effectiveProgress.value,
+      zIndex: effectiveProgress.value > 0.5 ? 0 : 1,
+    };
+  });
+
+  // Inner-tab visibility — driven by activeTabProgress (string sharedValue
+  // holding the active tab key). Snap, not fade: each tab is fully visible
+  // when the value matches its key, fully hidden otherwise. Falls back to
+  // a local sharedValue mirroring activeTab when no parent value is
+  // provided.
+  const localActiveTabProgress = useSharedValue<ContentTabType>(activeTab);
+  useEffect(() => {
+    if (activeTabProgress) return;
+    localActiveTabProgress.value = activeTab;
+  }, [activeTab, localActiveTabProgress, activeTabProgress]);
+  const effectiveTabProgress = activeTabProgress ?? localActiveTabProgress;
+  const summaryTabStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'summary';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+  const bylineTabStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'byline';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+  const studyTabStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'study';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+  const visualsTabStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'visuals';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+
   return (
     <View style={styles.container} collapsable={false}>
       {/* Explanations View — mount when:
@@ -948,63 +1070,74 @@ export function ChapterPage({
       {(activeView === 'explanations' ||
         insightPrewarmed ||
         (!isPreloading && delayedRenderStage >= 1)) && (
-        <View
-          style={[
-            styles.container,
-            activeView !== 'explanations' && {
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              opacity: 0,
-              zIndex: -1,
-            },
-          ]}
+        <Animated.View
+          style={[styles.container, styles.absoluteFill, insightContainerStyle]}
           collapsable={false}
           pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
         >
-          <TabContent
-            chapter={displayChapter}
-            activeTab="summary"
-            content={summaryData}
-            isLoading={isSummaryLoading}
-            error={summaryError}
-            isAvailableOffline={summaryIsLocal}
-            visible={activeTab === 'summary'}
-            shouldRenderHidden={delayedRenderStage >= 2}
-            testID={`chapter-page-scroll-${bookId}-${chapterNumber}-summary`}
-            onScroll={handleScroll}
-            onTouchStart={handleTouchStart}
-            onTouchEnd={handleTouchEnd}
-            filteredHighlights={chapterHighlights}
-            filteredAutoHighlights={autoHighlights}
-            scrollRef={summaryScrollRef}
-            onTabContentSizeChange={(_w, h) =>
-              handleTabContentSizeChange('summary', h, viewportHeightRef.current)
-            }
-          />
-          <TabContent
-            chapter={displayChapter}
-            activeTab="byline"
-            content={byLineData}
-            isLoading={isByLineLoading}
-            error={byLineError}
-            isAvailableOffline={byLineIsLocal}
-            visible={activeTab === 'byline'}
-            shouldRenderHidden={delayedRenderStage >= 3}
-            testID={`chapter-page-scroll-${bookId}-${chapterNumber}-byline`}
-            onScroll={handleScroll}
-            onTouchStart={handleTouchStart}
-            onTouchEnd={handleTouchEnd}
-            filteredHighlights={chapterHighlights}
-            filteredAutoHighlights={autoHighlights}
-            scrollRef={byLineScrollRef}
-            onTabContentSizeChange={(_w, h) =>
-              handleTabContentSizeChange('byline', h, viewportHeightRef.current)
-            }
-            onByLineSectionRegister={handleByLineSectionRegister}
-          />
+          {/* Summary tab — always rendered (default tab). The wrapper
+              Animated.View overlays the Insight container; opacity comes
+              from activeTabProgress on the UI thread so the swap is
+              instant. visible={true} keeps TabContent's inner ScrollView
+              in flex:1 layout (it fills the absolute wrapper). */}
+          <Animated.View
+            style={[styles.absoluteFill, summaryTabStyle]}
+            pointerEvents={activeTab === 'summary' ? 'auto' : 'none'}
+          >
+            <TabContent
+              chapter={displayChapter}
+              activeTab="summary"
+              content={summaryData}
+              isLoading={isSummaryLoading}
+              error={summaryError}
+              isAvailableOffline={summaryIsLocal}
+              visible={true}
+              shouldRenderHidden={true}
+              testID={`chapter-page-scroll-${bookId}-${chapterNumber}-summary`}
+              onScroll={handleScroll}
+              onTouchStart={handleTouchStart}
+              onTouchEnd={handleTouchEnd}
+              filteredHighlights={chapterHighlights}
+              filteredAutoHighlights={autoHighlights}
+              scrollRef={summaryScrollRef}
+              onTabContentSizeChange={(_w, h) =>
+                handleTabContentSizeChange('summary', h, viewportHeightRef.current)
+              }
+            />
+          </Animated.View>
+
+          {/* Byline tab — gated by the existing stagger logic (don't mount
+              the heavy markdown until activated or stage 3). Once mounted,
+              opacity is driven by activeTabProgress. */}
+          {(activeTab === 'byline' || delayedRenderStage >= 3) && (
+            <Animated.View
+              style={[styles.absoluteFill, bylineTabStyle]}
+              pointerEvents={activeTab === 'byline' ? 'auto' : 'none'}
+            >
+              <TabContent
+                chapter={displayChapter}
+                activeTab="byline"
+                content={byLineData}
+                isLoading={isByLineLoading}
+                error={byLineError}
+                isAvailableOffline={byLineIsLocal}
+                visible={true}
+                shouldRenderHidden={true}
+                testID={`chapter-page-scroll-${bookId}-${chapterNumber}-byline`}
+                onScroll={handleScroll}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+                filteredHighlights={chapterHighlights}
+                filteredAutoHighlights={autoHighlights}
+                scrollRef={byLineScrollRef}
+                onTabContentSizeChange={(_w, h) =>
+                  handleTabContentSizeChange('byline', h, viewportHeightRef.current)
+                }
+                onByLineSectionRegister={handleByLineSectionRegister}
+              />
+            </Animated.View>
+          )}
+
           {/* Quick-verse-jump overlay - byline tab only (issue verse-mate-mobile#77).
               Mount on the byline tab; fade with the scroll-arrow auto-hide (VERA-39). */}
           {activeView === 'explanations' && activeTab === 'byline' && (
@@ -1016,74 +1149,61 @@ export function ChapterPage({
               testID={`chapter-page-${bookId}-${chapterNumber}-verse-jump`}
             />
           )}
-          {/* Study tab — uses bundled @versemate/studies data (no API fetch).
-              4th sibling of the TabContent instances above; hidden via the
-              same absolute-positioning trick when activeTab !== 'study'. */}
-          <ScrollView
-            ref={studyScrollRef}
-            style={[
-              styles.container,
-              activeTab !== 'study' && {
-                position: 'absolute',
-                top: 0,
-                left: 0,
-                right: 0,
-                bottom: 0,
-                opacity: 0,
-                zIndex: -1,
-              },
-            ]}
-            contentContainerStyle={styles.contentContainer}
-            showsVerticalScrollIndicator={activeTab === 'study'}
-            testID={`chapter-page-scroll-${bookId}-${chapterNumber}-study`}
-            onScroll={activeTab === 'study' ? handleScroll : undefined}
-            scrollEventThrottle={16}
-            onTouchStart={handleTouchStart}
-            onTouchEnd={handleTouchEnd}
+
+          {/* Study tab — bundled content, no API fetch. */}
+          <Animated.View
+            style={[styles.absoluteFill, studyTabStyle]}
             pointerEvents={activeTab === 'study' ? 'auto' : 'none'}
           >
-            <StudyPanel bookId={bookId} chapter={chapterNumber} />
-          </ScrollView>
-
-          {/* Visuals tab — bundled content from @versemate/visuals. Only
-              rendered for books in BOOKS_WITH_VISUALS. Same hidden-not-
-              unmounted pattern as Study. */}
-          {displayChapter && bookHasVisuals(displayChapter.bookId) ? (
             <ScrollView
-              style={[styles.container, activeTab !== 'visuals' && { display: 'none' }]}
-              showsVerticalScrollIndicator={true}
-              testID={`chapter-page-scroll-${bookId}-${chapterNumber}-visuals`}
-              onScroll={handleScroll}
+              ref={studyScrollRef}
+              style={styles.container}
+              contentContainerStyle={styles.contentContainer}
+              showsVerticalScrollIndicator={activeTab === 'study'}
+              testID={`chapter-page-scroll-${bookId}-${chapterNumber}-study`}
+              onScroll={activeTab === 'study' ? handleScroll : undefined}
               scrollEventThrottle={16}
               onTouchStart={handleTouchStart}
               onTouchEnd={handleTouchEnd}
             >
-              <VisualsPanel
-                bookId={displayChapter.bookId}
-                chapter={displayChapter.chapterNumber}
-                bookName={displayChapter.bookName}
-                testID={`visuals-panel-${bookId}-${chapterNumber}`}
-              />
+              <StudyPanel bookId={bookId} chapter={chapterNumber} />
             </ScrollView>
+          </Animated.View>
+
+          {/* Visuals tab — bundled @versemate/visuals. Only rendered for
+              books in BOOKS_WITH_VISUALS. */}
+          {displayChapter && bookHasVisuals(displayChapter.bookId) ? (
+            <Animated.View
+              style={[styles.absoluteFill, visualsTabStyle]}
+              pointerEvents={activeTab === 'visuals' ? 'auto' : 'none'}
+            >
+              <ScrollView
+                style={styles.container}
+                showsVerticalScrollIndicator={true}
+                testID={`chapter-page-scroll-${bookId}-${chapterNumber}-visuals`}
+                onScroll={handleScroll}
+                scrollEventThrottle={16}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+              >
+                <VisualsPanel
+                  bookId={displayChapter.bookId}
+                  chapter={displayChapter.chapterNumber}
+                  bookName={displayChapter.bookName}
+                  testID={`visuals-panel-${bookId}-${chapterNumber}`}
+                />
+              </ScrollView>
+            </Animated.View>
           ) : null}
-        </View>
+        </Animated.View>
       )}
 
-      {/* Bible reading view (no explanations) - Always rendered but hidden if inactive */}
+      {/* Bible reading view (no explanations) — always rendered, opacity
+          flipped by toggleProgress on the UI thread. Always absolute-fill
+          so it overlaps the Insight container at the same bounds. */}
       <Animated.ScrollView
         ref={animatedScrollRef}
-        style={[
-          styles.container,
-          activeView !== 'bible' && {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            opacity: 0,
-            zIndex: -1,
-          },
-        ]}
+        style={[styles.container, styles.absoluteFill, bibleContainerStyle]}
         contentContainerStyle={styles.contentContainer}
         showsVerticalScrollIndicator={true}
         testID={`chapter-page-scroll-${bookId}-${chapterNumber}-bible`}

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -1225,7 +1225,7 @@ export function ChapterPage({
       >
         <TextVisibilityContext.Provider value={textVisibilityContextValue}>
           <View style={styles.readerContainer} collapsable={false}>
-            {displayChapter ? (
+            {displayChapter && !isPreloading ? (
               <ChapterReader
                 chapter={displayChapter}
                 activeTab={activeTab}
@@ -1238,14 +1238,13 @@ export function ChapterPage({
                 maxBibleSections={bibleSectionsMax}
               />
             ) : (
-              // Skeleton only shows when chapter data isn't loaded yet
-              // (rare — prev/next chapters are prefetched). The previous
-              // `!isPreloading` gate forced ALL buffer pages through this
-              // path so the user saw a skeleton flash during every swipe;
-              // dropping the gate lets buffer pages render real content,
-              // which is cheap because maxBibleSections=3 keeps them at
-              // the initial 3 sections (the ramp only fires on the
-              // active page via the isPreloading guard on its useEffect).
+              // Buffer pages render this skeleton; the active page shows
+              // it briefly while chapter data loads. Removing the
+              // `!isPreloading` gate (tried in 2415153) caused regressions
+              // — putting it back. Distinct testID from chapter-screen-
+              // level skeleton so integration tests waiting for testID=
+              // "skeleton-loader" to disappear don't trip on the 2 buffer
+              // placeholders that are always visible in the 3-page pager.
               <SkeletonLoader testID="chapter-page-skeleton-buffer" />
             )}
           </View>

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -163,6 +163,24 @@ function TabContent({
   const styles = createStyles(colors, insets.bottom); // Use local createStyles for TabContent
   const { isOffline } = useOfflineStatus();
 
+  // Progressive reveal for byline verse sections. Two discrete bumps
+  // instead of a continuous setInterval so the ramp finishes in ~500ms
+  // and then stops generating re-renders — a perpetual setInterval was
+  // making the Bible/Insight toggle feel hitchy because the setState
+  // every 200ms was competing with the toggle's React work. Long
+  // chapters still parse progressively (5 sections → 30 sections →
+  // everything) so first paint is fast.
+  const [bylineMax, setBylineMax] = useState(5);
+  useEffect(() => {
+    if (activeTab !== 'byline') return;
+    const t1 = setTimeout(() => setBylineMax(30), 200);
+    const t2 = setTimeout(() => setBylineMax(Number.POSITIVE_INFINITY), 500);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, [activeTab]);
+
   const isHidden = !visible;
   if (isHidden && !shouldRenderHidden) return null;
 
@@ -270,6 +288,7 @@ function TabContent({
               filteredHighlights={filteredHighlights}
               filteredAutoHighlights={filteredAutoHighlights}
               onByLineSectionRegister={activeTab === 'byline' ? onByLineSectionRegister : undefined}
+              maxBylineSections={activeTab === 'byline' ? bylineMax : undefined}
             />
           )}
         </View>
@@ -429,13 +448,6 @@ export function ChapterPage({
   // Get highlights from the provider (single source of truth — avoids duplicate queries)
   const { chapterHighlights, autoHighlights } = useBibleInteraction();
 
-  // Staggered rendering state to prevent UI freeze (waterfall loading)
-  // 0: Initial (only active view)
-  // 1: Mount Explanations container (active tab renders)
-  // 2: Mount Summary tab (if hidden)
-  // 3: Mount Byline tab (if hidden)
-  const [delayedRenderStage, setDelayedRenderStage] = useState(0);
-
   // Pre-warmed flag: once the chapter has settled on Bible view, mount
   // the Insight subtree in the background so the Bible → Insight toggle
   // becomes a style flip (instant) instead of a 500-700ms first-mount
@@ -464,38 +476,37 @@ export function ChapterPage({
     };
   }, [isPreloading, insightPrewarmed, bookId, chapterNumber]);
 
-  // Trigger staggered delayed render — only for the active page, not buffer pages,
-  // and only while the user is actually in Explanations view.
-  //
-  // This still runs after a real activeView -> 'explanations' switch so
-  // the OTHER tab (byline if summary is active, or vice versa) gets
-  // pre-warmed in the background. The Insight container itself is now
-  // mounted via insightPrewarmed before the user ever switches, so the
-  // initial switch isn't blocked.
+  // NOTE: the staged-timer mount of inner Insight tabs (summary 1.1s,
+  // byline 1.6s, study/visuals 2.1s) was removed in favour of
+  // visit-based gating below (visitedTabs Set). The timers were
+  // auto-parsing markdown for tabs the user wasn't looking at,
+  // blocking the JS thread for 500-700ms post-swipe — the same
+  // regression the May 21 swipe-bugs commit (84e8942) had originally
+  // fixed by gating the stage on activeView. The visit-based pattern
+  // here matches the topics-side fix that resolved the same class of
+  // hiccup on Topics.
+
+  // Progressive Bible-section reveal. Long chapters (Psalm 119 has
+  // ~22 sections) used to render every section's paragraph view on
+  // first mount, blocking the JS thread for several hundred ms after
+  // each chapter swipe. Two discrete bumps instead of a continuous
+  // setInterval — the perpetual interval was causing a regression
+  // where the Bible/Insight toggle felt hitchy (setState every 200ms
+  // competed with the toggle's React work). Resets on chapter change.
+  const [bibleSectionsMax, setBibleSectionsMax] = useState(3);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on chapter change
   useEffect(() => {
-    if (isPreloading) {
-      setDelayedRenderStage(0);
-      return;
-    }
-    // Stagger no longer gated on `activeView === 'explanations'`. The
-    // inner tabs (byline, study, visuals) pre-mount in the background
-    // even while the user is on Bible view, so the first tap to any tab
-    // finds it already mounted and the sharedValue-driven opacity flip
-    // is instant. Trade-off: a small chunk of markdown parse work runs
-    // during background idle on every chapter load — acceptable because
-    // the alternative is a 1-2s lag the first time the user taps a tab
-    // they haven't visited yet.
-    const t1 = setTimeout(() => setDelayedRenderStage(1), 600);
-    const t2 = setTimeout(() => setDelayedRenderStage(2), 1100);
-    const t3 = setTimeout(() => setDelayedRenderStage(3), 1600);
-    const t4 = setTimeout(() => setDelayedRenderStage(4), 2100);
+    setBibleSectionsMax(3);
+  }, [bookId, chapterNumber]);
+  useEffect(() => {
+    if (isPreloading) return;
+    const t1 = setTimeout(() => setBibleSectionsMax(20), 200);
+    const t2 = setTimeout(() => setBibleSectionsMax(Number.POSITIVE_INFINITY), 500);
     return () => {
       clearTimeout(t1);
       clearTimeout(t2);
-      clearTimeout(t3);
-      clearTimeout(t4);
     };
-  }, [isPreloading]);
+  }, [isPreloading, bookId, chapterNumber]);
 
   // Track explanation tab content heights for scroll syncing
   const tabContentHeightsRef = useRef<
@@ -1062,54 +1073,51 @@ export function ChapterPage({
   return (
     <View style={styles.container} collapsable={false}>
       {/* Explanations View — mount when:
-           1. User is on Insight view (always), OR
+           1. User is on Insight view (handles deep links + buffer
+              pages so swipes-while-on-Insight have content ready), OR
            2. We've pre-warmed it after chapter settle (insightPrewarmed),
-              so the Bible -> Insight toggle is an instant style flip
-              with no JS-thread first-mount blocking, OR
-           3. Legacy staggered pre-render path for buffer pages. */}
-      {(activeView === 'explanations' ||
-        insightPrewarmed ||
-        (!isPreloading && delayedRenderStage >= 1)) && (
+              so the Bible -> Insight toggle is an instant style flip. */}
+      {(activeView === 'explanations' || insightPrewarmed) && (
         <Animated.View
           style={[styles.container, styles.absoluteFill, insightContainerStyle]}
           collapsable={false}
           pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
         >
-          {/* Summary tab — always rendered (default tab). The wrapper
-              Animated.View overlays the Insight container; opacity comes
-              from activeTabProgress on the UI thread so the swap is
-              instant. visible={true} keeps TabContent's inner ScrollView
-              in flex:1 layout (it fills the absolute wrapper). */}
-          <Animated.View
-            style={[styles.absoluteFill, summaryTabStyle]}
-            pointerEvents={activeTab === 'summary' ? 'auto' : 'none'}
-          >
-            <TabContent
-              chapter={displayChapter}
-              activeTab="summary"
-              content={summaryData}
-              isLoading={isSummaryLoading}
-              error={summaryError}
-              isAvailableOffline={summaryIsLocal}
-              visible={true}
-              shouldRenderHidden={true}
-              testID={`chapter-page-scroll-${bookId}-${chapterNumber}-summary`}
-              onScroll={handleScroll}
-              onTouchStart={handleTouchStart}
-              onTouchEnd={handleTouchEnd}
-              filteredHighlights={chapterHighlights}
-              filteredAutoHighlights={autoHighlights}
-              scrollRef={summaryScrollRef}
-              onTabContentSizeChange={(_w, h) =>
-                handleTabContentSizeChange('summary', h, viewportHeightRef.current)
-              }
-            />
-          </Animated.View>
+          {/* Inner tabs use visit-based lazy mount: only mount tabs the
+              user has actually visited. Initial visited = active tab.
+              First tap to another tab triggers its mount. Sticky-once-
+              visited; resets per chapter. Pairs with the eager-prefetch
+              of byline below so the most common second-tab visit
+              already has its data cached. */}
+          {visitedTabs.has('summary') && (
+            <Animated.View
+              style={[styles.absoluteFill, summaryTabStyle]}
+              pointerEvents={activeTab === 'summary' ? 'auto' : 'none'}
+            >
+              <TabContent
+                chapter={displayChapter}
+                activeTab="summary"
+                content={summaryData}
+                isLoading={isSummaryLoading}
+                error={summaryError}
+                isAvailableOffline={summaryIsLocal}
+                visible={true}
+                shouldRenderHidden={true}
+                testID={`chapter-page-scroll-${bookId}-${chapterNumber}-summary`}
+                onScroll={handleScroll}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+                filteredHighlights={chapterHighlights}
+                filteredAutoHighlights={autoHighlights}
+                scrollRef={summaryScrollRef}
+                onTabContentSizeChange={(_w, h) =>
+                  handleTabContentSizeChange('summary', h, viewportHeightRef.current)
+                }
+              />
+            </Animated.View>
+          )}
 
-          {/* Byline tab — gated by the existing stagger logic (don't mount
-              the heavy markdown until activated or stage 3). Once mounted,
-              opacity is driven by activeTabProgress. */}
-          {(activeTab === 'byline' || delayedRenderStage >= 3) && (
+          {visitedTabs.has('byline') && (
             <Animated.View
               style={[styles.absoluteFill, bylineTabStyle]}
               pointerEvents={activeTab === 'byline' ? 'auto' : 'none'}
@@ -1151,28 +1159,30 @@ export function ChapterPage({
           )}
 
           {/* Study tab — bundled content, no API fetch. */}
-          <Animated.View
-            style={[styles.absoluteFill, studyTabStyle]}
-            pointerEvents={activeTab === 'study' ? 'auto' : 'none'}
-          >
-            <ScrollView
-              ref={studyScrollRef}
-              style={styles.container}
-              contentContainerStyle={styles.contentContainer}
-              showsVerticalScrollIndicator={activeTab === 'study'}
-              testID={`chapter-page-scroll-${bookId}-${chapterNumber}-study`}
-              onScroll={activeTab === 'study' ? handleScroll : undefined}
-              scrollEventThrottle={16}
-              onTouchStart={handleTouchStart}
-              onTouchEnd={handleTouchEnd}
+          {visitedTabs.has('study') && (
+            <Animated.View
+              style={[styles.absoluteFill, studyTabStyle]}
+              pointerEvents={activeTab === 'study' ? 'auto' : 'none'}
             >
-              <StudyPanel bookId={bookId} chapter={chapterNumber} />
-            </ScrollView>
-          </Animated.View>
+              <ScrollView
+                ref={studyScrollRef}
+                style={styles.container}
+                contentContainerStyle={styles.contentContainer}
+                showsVerticalScrollIndicator={activeTab === 'study'}
+                testID={`chapter-page-scroll-${bookId}-${chapterNumber}-study`}
+                onScroll={activeTab === 'study' ? handleScroll : undefined}
+                scrollEventThrottle={16}
+                onTouchStart={handleTouchStart}
+                onTouchEnd={handleTouchEnd}
+              >
+                <StudyPanel bookId={bookId} chapter={chapterNumber} />
+              </ScrollView>
+            </Animated.View>
+          )}
 
           {/* Visuals tab — bundled @versemate/visuals. Only rendered for
-              books in BOOKS_WITH_VISUALS. */}
-          {displayChapter && bookHasVisuals(displayChapter.bookId) ? (
+              books in BOOKS_WITH_VISUALS AND visited by the user. */}
+          {visitedTabs.has('visuals') && displayChapter && bookHasVisuals(displayChapter.bookId) ? (
             <Animated.View
               style={[styles.absoluteFill, visualsTabStyle]}
               pointerEvents={activeTab === 'visuals' ? 'auto' : 'none'}
@@ -1215,7 +1225,7 @@ export function ChapterPage({
       >
         <TextVisibilityContext.Provider value={textVisibilityContextValue}>
           <View style={styles.readerContainer} collapsable={false}>
-            {displayChapter && !isPreloading ? (
+            {displayChapter ? (
               <ChapterReader
                 chapter={displayChapter}
                 activeTab={activeTab}
@@ -1225,12 +1235,17 @@ export function ChapterPage({
                 onOpenNotes={handleOpenNotes}
                 filteredHighlights={chapterHighlights}
                 filteredAutoHighlights={autoHighlights}
+                maxBibleSections={bibleSectionsMax}
               />
             ) : (
-              // Distinct testID from the chapter-screen-level skeleton so integration
-              // tests that wait for testID="skeleton-loader" to disappear don't trip on
-              // these buffer-page placeholders (3-page pager always renders 2 buffer
-              // pages with isPreloading=true → 2 of these visible at any time).
+              // Skeleton only shows when chapter data isn't loaded yet
+              // (rare — prev/next chapters are prefetched). The previous
+              // `!isPreloading` gate forced ALL buffer pages through this
+              // path so the user saw a skeleton flash during every swipe;
+              // dropping the gate lets buffer pages render real content,
+              // which is cheap because maxBibleSections=3 keeps them at
+              // the initial 3 sections (the ramp only fires on the
+              // active page via the isPreloading guard on its useEffect).
               <SkeletonLoader testID="chapter-page-skeleton-buffer" />
             )}
           </View>

--- a/components/bible/ChapterPage.tsx
+++ b/components/bible/ChapterPage.tsx
@@ -20,7 +20,15 @@
 import { router } from 'expo-router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { findNodeHandle, Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import {
+  findNodeHandle,
+  InteractionManager,
+  Platform,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 import Animated, { FadeIn, FadeOut, useAnimatedRef } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { AudioInlineEntry } from '@/components/bible/AudioInlineEntry';
@@ -388,19 +396,48 @@ export function ChapterPage({
   // 3: Mount Byline tab (if hidden)
   const [delayedRenderStage, setDelayedRenderStage] = useState(0);
 
+  // Pre-warmed flag: once the chapter has settled on Bible view, mount
+  // the Insight subtree in the background so the Bible → Insight toggle
+  // becomes a style flip (instant) instead of a 500-700ms first-mount
+  // hit. The mount is scheduled via InteractionManager.runAfterInteractions
+  // so it doesn't run during the chapter-swipe animation. Sticky once true
+  // for the lifetime of this ChapterPage — there's no benefit to
+  // unmounting after a toggle back to Bible.
+  const [insightPrewarmed, setInsightPrewarmed] = useState(false);
+
   const { deleteNote, isDeletingNote } = useNotes();
+
+  // Schedule the Insight subtree mount in idle time after the chapter
+  // becomes available. Runs only for the active page (not buffer pages)
+  // and only once per ChapterPage lifetime.
+  useEffect(() => {
+    if (isPreloading || insightPrewarmed) return;
+    const handle = InteractionManager.runAfterInteractions(() => {
+      // Small extra delay so the chapter-swipe settle animation
+      // (~300ms) is fully past before we add Insight to the render.
+      const t = setTimeout(() => setInsightPrewarmed(true), 300);
+      // The InteractionManager.Handle API only exposes `cancel`; we
+      // can't return a setTimeout cleanup from here, so stash on the
+      // closure's outer scope via a sibling effect-return.
+      timeoutHandleRef.current = t;
+    });
+    return () => {
+      handle.cancel();
+      if (timeoutHandleRef.current) {
+        clearTimeout(timeoutHandleRef.current);
+        timeoutHandleRef.current = null;
+      }
+    };
+  }, [isPreloading, insightPrewarmed]);
 
   // Trigger staggered delayed render — only for the active page, not buffer pages,
   // and only while the user is actually in Explanations view.
   //
-  // Why gated on activeView: each TabContent (Summary, Byline) takes 500-700ms of
-  // JS-thread time to mount (full chapter ScrollView with verses). Pre-warming them
-  // while the user is on Bible view caused visible scroll hiccups exactly at the
-  // stage-3 / stage-4 timer firings (T+1.6s and T+2.1s after a chapter swipe). With
-  // this gate, the staged mounts only happen once the user actually switches to
-  // Insight — when they're not scrolling Bible content. The active Insight tab still
-  // mounts immediately on the switch; the staggered stages pre-warm the OTHER tabs
-  // so switching between Summary and Byline within Insight is instant.
+  // This still runs after a real activeView -> 'explanations' switch so
+  // the OTHER tab (byline if summary is active, or vice versa) gets
+  // pre-warmed in the background. The Insight container itself is now
+  // mounted via insightPrewarmed before the user ever switches, so the
+  // initial switch isn't blocked.
   useEffect(() => {
     if (isPreloading || activeView !== 'explanations') {
       setDelayedRenderStage(0);
@@ -419,6 +456,10 @@ export function ChapterPage({
   }, [isPreloading, activeView]);
 
   // Track explanation tab content heights for scroll syncing
+  // Stash for the Insight pre-warm setTimeout so the useEffect cleanup
+  // can clear it on unmount or when prewarm completes.
+  const timeoutHandleRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const tabContentHeightsRef = useRef<
     Record<string, { contentHeight: number; viewHeight: number }>
   >({});
@@ -898,9 +939,15 @@ export function ChapterPage({
 
   return (
     <View style={styles.container} collapsable={false}>
-      {/* Explanations View - Always render when user is in explanations view (even on buffer pages
-           during idle-deferred navigation). In bible view, only pre-render on active page after stagger delay. */}
-      {(activeView === 'explanations' || (!isPreloading && delayedRenderStage >= 1)) && (
+      {/* Explanations View — mount when:
+           1. User is on Insight view (always), OR
+           2. We've pre-warmed it after chapter settle (insightPrewarmed),
+              so the Bible -> Insight toggle is an instant style flip
+              with no JS-thread first-mount blocking, OR
+           3. Legacy staggered pre-render path for buffer pages. */}
+      {(activeView === 'explanations' ||
+        insightPrewarmed ||
+        (!isPreloading && delayedRenderStage >= 1)) && (
         <View
           style={[
             styles.container,

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -182,6 +182,23 @@ interface ChapterReaderProps {
   filteredHighlights?: Highlight[];
   /** Optional filtered auto-highlights (overrides context auto-highlights) */
   filteredAutoHighlights?: AutoHighlight[];
+  /**
+   * Progressive-load limit for byline verse sections. When set, only the
+   * first N parsed verse sections render. Parent can ramp this up over
+   * time (e.g. via setInterval) so the first paint is fast for long
+   * chapters (Psalm 119 = 176 verses) and the rest of the sections
+   * mount in the background. Undefined = render all sections (default
+   * behavior).
+   */
+  maxBylineSections?: number;
+  /**
+   * Same idea but for the Bible-view section list (chapter.sections).
+   * Long chapters like Psalm 119 have ~22 sections of 8 verses each;
+   * paragraph-mode rendering of all of them at once is heavy on first
+   * paint. Parent ramps this up after initial mount so the first
+   * couple sections render immediately and the rest stream in.
+   */
+  maxBibleSections?: number;
 }
 
 /**
@@ -276,6 +293,8 @@ export function ChapterReader({
   onOpenNotes,
   filteredHighlights,
   filteredAutoHighlights,
+  maxBylineSections,
+  maxBibleSections,
 }: ChapterReaderProps) {
   const { colors, mode } = useTheme();
   const specs = getHeaderSpecs(mode);
@@ -514,9 +533,15 @@ export function ChapterReader({
         </View>
       )}
 
-      {/* Render Bible verses (only in Bible view) */}
+      {/* Render Bible verses (only in Bible view). Sliced by
+          maxBibleSections so the parent can progressively reveal
+          sections — long chapters render the first couple immediately
+          and the rest mount in the background instead of all at once. */}
       {!explanationsOnly &&
-        chapter.sections.map((section) => (
+        (typeof maxBibleSections === 'number' && maxBibleSections < chapter.sections.length
+          ? chapter.sections.slice(0, Math.max(1, maxBibleSections))
+          : chapter.sections
+        ).map((section) => (
           <Fragment key={`section-${section.startVerse}-${section.subtitle || 'no-subtitle'}`}>
             {/* Section Subtitle */}
             {section.subtitle ? (
@@ -769,7 +794,15 @@ export function ChapterReader({
                   if (sections.length === 0) {
                     return <Markdown style={markdownStyles}>{contentWithoutTitle}</Markdown>;
                   }
-                  return sections.map((section, index) => (
+                  // Progressive reveal: parent caps via maxBylineSections so
+                  // long chapters (e.g. Psalm 119 with 176 verses) don't
+                  // parse every Markdown subtree on first paint. Sections
+                  // beyond the cap mount as the parent ramps the prop up.
+                  const visible =
+                    typeof maxBylineSections === 'number' && maxBylineSections < sections.length
+                      ? sections.slice(0, Math.max(1, maxBylineSections))
+                      : sections;
+                  return visible.map((section, index) => (
                     <View
                       key={`byline-section-${section.verseNumber}-${index}`}
                       ref={(node) => onByLineSectionRegister(section.verseNumber, node)}

--- a/components/bible/HamburgerMenu.tsx
+++ b/components/bible/HamburgerMenu.tsx
@@ -89,7 +89,6 @@ interface MenuItem {
     | 'bookmarks'
     | 'notes'
     | 'highlights'
-    | 'names-of-god'
     | 'settings'
     | 'share'
     | 'about'
@@ -101,7 +100,6 @@ const regularMenuItems: MenuItem[] = [
   { id: 'bookmarks', label: 'Bookmarks', icon: IconBookmarkFilled, action: 'bookmarks' },
   { id: 'notes', label: 'Notes', icon: IconDocument, action: 'notes' },
   { id: 'highlights', label: 'Highlights', icon: IconHighlight, action: 'highlights' },
-  { id: 'names-of-god', label: 'Names of God', icon: IconInfo, action: 'names-of-god' },
   { id: 'settings', label: 'Settings', icon: IconSettings, action: 'settings' },
   { id: 'share', label: 'Share VerseMate', icon: IconShare, action: 'share' },
   { id: 'about', label: 'About', icon: IconInfo, action: 'about' },
@@ -203,9 +201,6 @@ export function HamburgerMenu({ visible, onClose }: HamburgerMenuProps) {
       onClose();
       // biome-ignore lint/suspicious/noExplicitAny: Typed routes might be stale
       router.push('/highlights' as any);
-    } else if (item.action === 'names-of-god') {
-      onClose();
-      router.push('/names-of-god' as any);
     } else if (item.action === 'settings') {
       onClose();
       router.push('/settings' as never);

--- a/components/bible/SimpleChapterPager.tsx
+++ b/components/bible/SimpleChapterPager.tsx
@@ -149,9 +149,39 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
     // ViewPager fires `onPageSelected` for intermediate positions. Without
     // this guard, the very first reposition lands on position=0 (the prev
     // slot) and gets mistaken for a swipe — kicks navigateToChapter back
-    // to the previous chapter (e.g. dropdown → James 1 silently rewinds
-    // to Hebrews 13). See bug repro 2026-05-24.
+    // to the previous chapter.
+    //
+    // 2026-05-24 follow-up: clearing the guard on the FIRST event that
+    // matches the target index isn't enough. The native ViewPager keeps
+    // firing trailing `onPageSelected` events for ~50-200ms AFTER it
+    // settles on the target (often emitting position=0 or back-and-forth
+    // between adjacent positions). Those late events arrive with the
+    // guard already cleared and are treated as real swipes — the bug
+    // reproes as "every other dropdown navigation silently rewinds by
+    // one chapter". Fix: hold the guard open via a timer instead of
+    // clearing on first match.
     const programmaticTargetRef = useRef<number | null>(null);
+    const programmaticTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const armProgrammaticGuard = (targetIndex: number) => {
+      programmaticTargetRef.current = targetIndex;
+      if (programmaticTimerRef.current) clearTimeout(programmaticTimerRef.current);
+      // 400ms covers the worst-case trailing-event window observed in
+      // logs (~5 spurious events over ~250ms). Errs generous because
+      // a too-short window reproduces the rewind bug, while a too-long
+      // window only delays the user's next intentional swipe (no
+      // correctness impact — the dropdown navigation is already in
+      // flight by then).
+      programmaticTimerRef.current = setTimeout(() => {
+        programmaticTargetRef.current = null;
+        programmaticTimerRef.current = null;
+      }, 400);
+    };
+    useEffect(
+      () => () => {
+        if (programmaticTimerRef.current) clearTimeout(programmaticTimerRef.current);
+      },
+      []
+    );
 
     // Reset pager position to center after props change (parent navigated). Runs in
     // useLayoutEffect so the setPageWithoutAnimation lands in the same paint frame as
@@ -164,9 +194,11 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
       if (prevChapterKey.current === currentKey) return;
       prevChapterKey.current = currentKey;
       const targetIndex = canGoPrevious ? PAGE_CURRENT_MIDDLE : 0;
-      // Suppress pageSelected handling until the pager actually lands on
-      // the target index — see programmaticTargetRef.
-      programmaticTargetRef.current = targetIndex;
+      // Suppress pageSelected handling for the full reposition window —
+      // see armProgrammaticGuard. The guard auto-clears on a timer so
+      // the trailing onPageSelected events ViewPager emits after the
+      // seek finishes don't get treated as user swipes.
+      armProgrammaticGuard(targetIndex);
       pagerRef.current?.setPageWithoutAnimation(targetIndex);
     }, [bookId, chapterNumber, canGoPrevious]);
 
@@ -199,15 +231,13 @@ export const SimpleChapterPager = forwardRef<SimpleChapterPagerRef, SimpleChapte
     const handlePageSelected = (event: { nativeEvent: { position: number } }) => {
       const newPosition = event.nativeEvent.position;
 
-      // If a programmatic reposition is in flight, swallow page-selected
-      // events until we land on the target index. Without this, the
-      // intermediate position emitted during setPageWithoutAnimation
-      // (often position=0) gets treated as a user swipe and triggers
-      // a phantom navigateToChapter to the prev/next chapter.
+      // Swallow ALL page-selected events while a programmatic reposition
+      // is in flight (guard cleared by timer in armProgrammaticGuard).
+      // ViewPager fires both intermediate AND trailing events during
+      // the seek; clearing on first-match wasn't enough (caused phantom
+      // rewind to prev chapter). The user-swipe path doesn't arm the
+      // guard, so its events flow through normally.
       if (programmaticTargetRef.current !== null) {
-        if (newPosition === programmaticTargetRef.current) {
-          programmaticTargetRef.current = null;
-        }
         return;
       }
 

--- a/components/topics/SimpleTopicPager.tsx
+++ b/components/topics/SimpleTopicPager.tsx
@@ -6,7 +6,9 @@
  *
  * Architecture:
  * - 3-page window: [previous, current, next]
- * - Stable positional keys: ["page-prev", "page-current", "page-next"]
+ * - Topic-based keys: `topic-<uuid>` so the user's ScrollView instance
+ *   migrates between slots on swipe and keeps its scroll position
+ *   (the slot-based pattern teleports back to top — see `pages` memo below)
  * - Initial page is always index 1 (center/current)
  * - Props-driven repositioning via useEffect (no key-based remount)
  * - Matches SimpleChapterPager V3 pattern for consistent architecture
@@ -191,10 +193,20 @@ export function SimpleTopicPager({
    * No boundary pages needed for topics.
    */
   const pages = useMemo(() => {
-    // Handle case when topics not loaded or current topic not found
+    // Keys are topic-based, NOT slot-based ("page-prev/current/next").
+    // Why: after a swipe, React's pages-array shifts so the topic the
+    // user just swiped to ends up in a different slot (was at the right
+    // edge, now in the center). Slot-based keys would have React reuse
+    // the right-edge instance and mutate it to a different topic, then
+    // setPageWithoutAnimation moves the pager to a different instance
+    // with scroll=0 — that's the "teleport back to top" bug after
+    // swiping to a new topic and scrolling. Topic-based keys make React
+    // migrate the user's actual topic instance between slots, preserving
+    // its ScrollView/FlatList scroll position. Mirror of the fix on
+    // SimpleChapterPager.
     if (!sortedTopics || sortedTopics.length === 0 || currentIndex === -1) {
       return [
-        <View key="page-current" style={styles.page}>
+        <View key={`topic-${topicId}`} style={styles.page}>
           {renderTopicPage(topicId)}
         </View>,
       ];
@@ -203,7 +215,7 @@ export function SimpleTopicPager({
     // For a single topic, only render the current page
     if (sortedTopics.length === 1) {
       return [
-        <View key="page-current" style={styles.page}>
+        <View key={`topic-${topicId}`} style={styles.page}>
           {renderTopicPage(topicId)}
         </View>,
       ];
@@ -214,7 +226,7 @@ export function SimpleTopicPager({
     // Previous page (circular: always exists when >1 topics)
     if (prevTopicId) {
       result.push(
-        <View key="page-prev" style={styles.page}>
+        <View key={`topic-${prevTopicId}`} style={styles.page}>
           {renderTopicPage(prevTopicId)}
         </View>
       );
@@ -222,7 +234,7 @@ export function SimpleTopicPager({
 
     // Current page (always exists)
     result.push(
-      <View key="page-current" style={styles.page}>
+      <View key={`topic-${topicId}`} style={styles.page}>
         {renderTopicPage(topicId)}
       </View>
     );
@@ -230,7 +242,7 @@ export function SimpleTopicPager({
     // Next page (circular: always exists when >1 topics)
     if (nextTopicId) {
       result.push(
-        <View key="page-next" style={styles.page}>
+        <View key={`topic-${nextTopicId}`} style={styles.page}>
           {renderTopicPage(nextTopicId)}
         </View>
       );

--- a/components/topics/SimpleTopicPager.tsx
+++ b/components/topics/SimpleTopicPager.tsx
@@ -96,12 +96,22 @@ export function SimpleTopicPager({
   // Pending navigation target — set by onPageSelected, processed when pager reaches idle
   const pendingNavRef = useRef<string | null>(null);
 
+  // While a programmatic setPageWithoutAnimation is settling, the native
+  // ViewPager fires onPageSelected for intermediate positions. Without
+  // this guard, the first intermediate position (often PAGE_PREV=0) is
+  // mistaken for a user swipe and triggers onTopicChange back to the
+  // previous topic. Same bug + fix as SimpleChapterPager (a3d6df3).
+  const programmaticTargetRef = useRef<number | null>(null);
+
   // When props change (parent navigated), reset pager to the current page index
   // without remounting the entire component
   useEffect(() => {
     if (prevTopicIdRef.current === topicId) return;
     prevTopicIdRef.current = topicId;
     const targetIndex = !sortedTopics || sortedTopics.length <= 1 ? 0 : PAGE_CURRENT;
+    // Suppress pageSelected handling until the pager actually lands on
+    // the target index — see programmaticTargetRef.
+    programmaticTargetRef.current = targetIndex;
     pagerRef.current?.setPageWithoutAnimation(targetIndex);
   }, [topicId, sortedTopics]);
 
@@ -142,6 +152,18 @@ export function SimpleTopicPager({
    */
   const handlePageSelected = (event: { nativeEvent: { position: number } }) => {
     const newPosition = event.nativeEvent.position;
+
+    // If a programmatic reposition is in flight, swallow page-selected
+    // events until we land on the target index. Without this, the
+    // intermediate position emitted during setPageWithoutAnimation
+    // (often position=PAGE_PREV) gets treated as a user swipe and
+    // triggers a phantom onTopicChange to the prev/next topic.
+    if (programmaticTargetRef.current !== null) {
+      if (newPosition === programmaticTargetRef.current) {
+        programmaticTargetRef.current = null;
+      }
+      return;
+    }
 
     if (newPosition === PAGE_PREV && prevTopicId) {
       pendingNavRef.current = prevTopicId;

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -16,7 +16,8 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { t } from 'i18next';
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import type React from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
@@ -200,70 +201,92 @@ export function TopicExplanationsPanel({
   // Handle tab press with haptic feedback
   const handleTabPress = (tab: ContentTabType) => {
     if (tab !== activeTab) {
+      const t0 = performance.now();
+      console.log(`[TAB-PERF] topics tap ${activeTab}->${tab} @0ms`);
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       onTabChange(tab);
-      // Scroll to top when switching tabs
-      scrollViewRef.current?.scrollTo({ y: 0, animated: true });
+      console.log(
+        `[TAB-PERF] topics onTabChange returned +${(performance.now() - t0).toFixed(1)}ms`
+      );
+      // Defer the scroll so it doesn't compete with the tab switch
+      // for the current frame's JS budget.
+      requestAnimationFrame(() => {
+        scrollViewRef.current?.scrollTo({ y: 0, animated: false });
+      });
+      setTimeout(() => {
+        console.log(`[TAB-PERF] topics next-tick +${(performance.now() - t0).toFixed(1)}ms`);
+      }, 0);
     }
   };
 
-  // Tab indicator + tab pills use the URGENT `activeTab` so they snap
-  // instantly. Markdown body derivation below uses `deferredTab` — a
-  // copy that lags one render tick behind. React schedules the heavy
-  // Markdown re-mount at low priority, so the tab pill animation
-  // completes without being JS-thread-blocked. While the deferred
-  // body catches up, the user sees the previous tab's content — feels
-  // instant instead of staring at a frozen UI.
-  const deferredTab = useDeferredValue(activeTab);
-
-  // Get explanation content for the deferred tab (memoized so the
-  // Markdown body only re-renders when the underlying string actually
-  // changes — protects against parent re-renders that don't touch
-  // topic data).
-  const explanationContent = useMemo(() => {
-    if (!topicData?.explanation) return null;
-    let raw: string | null = null;
-    switch (deferredTab) {
-      case 'summary':
-        raw = topicData.explanation.summary ?? null;
-        break;
-      case 'byline':
-        raw = topicData.explanation.byline ?? null;
-        break;
-      case 'detailed':
-        raw = topicData.explanation.detailed ?? null;
-        break;
-    }
-    if (typeof raw !== 'string') return raw;
-    // Clean up byline content to remove redundant verse references,
-    // then strip the duplicate leading `# {topicName}` heading the
-    // header bar already shows.
-    const cleaned = deferredTab === 'byline' ? cleanupBylineReferences(raw) : raw;
+  // Pre-process all three tab contents up-front. We render ALL three
+  // Markdown trees at mount, then flip display: none between them on
+  // tab switch — same pattern Bible's BibleExplanationsPanel uses. The
+  // initial parse cost is 3x higher (one-time, on chapter open), but
+  // tab switching becomes a CSS flip with zero JS work, which is the
+  // only way to make the switch feel truly instant. useDeferredValue
+  // alone doesn't help here because the heavy Markdown parse still
+  // blocks the JS thread whenever it runs — it just runs at lower
+  // priority, not faster.
+  const cookContent = (raw: string | null | undefined, tab: ContentTabType): string | null => {
+    if (typeof raw !== 'string') return null;
+    const cleaned = tab === 'byline' ? cleanupBylineReferences(raw) : raw;
     return stripLeadingHeading(cleaned);
-  }, [topicData, deferredTab]);
+  };
 
-  const hasContent = explanationContent && typeof explanationContent === 'string';
+  const summaryContent = useMemo(
+    () => cookContent(topicData?.explanation?.summary, 'summary'),
+    [topicData?.explanation?.summary]
+  );
+  const bylineContent = useMemo(
+    () => cookContent(topicData?.explanation?.byline, 'byline'),
+    [topicData?.explanation?.byline]
+  );
+  const detailedContent = useMemo(
+    () => cookContent(topicData?.explanation?.detailed, 'detailed'),
+    [topicData?.explanation?.detailed]
+  );
 
-  // Memoize the rendered Markdown subtree so unrelated parent re-renders
-  // (scroll handlers, FAB visibility, header toggles) don't redo the
-  // expensive Markdown parse + layout. Only re-runs when content or
-  // styles actually change.
-  const renderedMarkdown = useMemo(() => {
-    if (!hasContent || typeof explanationContent !== 'string') return null;
-    return (
-      <View style={styles.explanationContainer}>
+  // Memoize each tab's rendered Markdown JSX so a tab switch doesn't
+  // force a re-render of the others. Content prop is stable per tab.
+  const summaryMarkdown = useMemo(
+    () =>
+      typeof summaryContent === 'string' ? (
         <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-          {explanationContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
+          {summaryContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
         </Markdown>
-      </View>
-    );
-  }, [
-    hasContent,
-    explanationContent,
-    markdownStyles,
-    dictionaryMarkdownRules,
-    styles.explanationContainer,
-  ]);
+      ) : null,
+    [summaryContent, markdownStyles, dictionaryMarkdownRules]
+  );
+  const bylineMarkdown = useMemo(
+    () =>
+      typeof bylineContent === 'string' ? (
+        <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+          {bylineContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
+        </Markdown>
+      ) : null,
+    [bylineContent, markdownStyles, dictionaryMarkdownRules]
+  );
+  const detailedMarkdown = useMemo(
+    () =>
+      typeof detailedContent === 'string' ? (
+        <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+          {detailedContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
+        </Markdown>
+      ) : null,
+    [detailedContent, markdownStyles, dictionaryMarkdownRules]
+  );
+
+  // For the empty-state copy + the "has content for active tab" check.
+  const activeContent =
+    activeTab === 'summary'
+      ? summaryContent
+      : activeTab === 'byline'
+        ? bylineContent
+        : activeTab === 'detailed'
+          ? detailedContent
+          : null;
+  const hasContent = typeof activeContent === 'string';
 
   // Custom share handler for topics
   const handleShare = async () => {
@@ -390,25 +413,39 @@ export function TopicExplanationsPanel({
         </View>
       </View>
 
-      {/* Content Area */}
-      <ScrollView
-        ref={scrollViewRef}
-        style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
-        showsVerticalScrollIndicator={true}
-        testID={`${testID}-scroll`}
-      >
-        {/* Explanation Content */}
-        {hasContent ? (
-          renderedMarkdown
-        ) : (
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>
-              No {activeTab} explanation available for this topic yet.
-            </Text>
-          </View>
-        )}
-      </ScrollView>
+      {/* Content Area — pre-mount all three tabs and flip display:none
+          between them on tab switch (Bible-panel pattern). Switching
+          is a CSS toggle, no Markdown re-parse. */}
+      {(
+        [
+          { id: 'summary' as const, content: summaryContent, markdown: summaryMarkdown },
+          { id: 'byline' as const, content: bylineContent, markdown: bylineMarkdown },
+          { id: 'detailed' as const, content: detailedContent, markdown: detailedMarkdown },
+        ] satisfies readonly {
+          id: ContentTabType;
+          content: string | null;
+          markdown: React.ReactNode;
+        }[]
+      ).map((tab) => (
+        <ScrollView
+          key={tab.id}
+          ref={tab.id === activeTab ? scrollViewRef : null}
+          style={[styles.scrollView, activeTab !== tab.id && { display: 'none' }]}
+          contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={true}
+          testID={`${testID}-scroll-${tab.id}`}
+        >
+          {tab.content ? (
+            <View style={styles.explanationContainer}>{tab.markdown}</View>
+          ) : (
+            <View style={styles.emptyContainer}>
+              <Text style={styles.emptyText}>
+                No {tab.id} explanation available for this topic yet.
+              </Text>
+            </View>
+          )}
+        </ScrollView>
+      ))}
 
       {/* Word Definition Tooltip — dictionary lookup on long-press */}
       {wordToDefine && (

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -16,7 +16,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { t } from 'i18next';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import { Animated, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
@@ -207,34 +207,63 @@ export function TopicExplanationsPanel({
     }
   };
 
-  // Get explanation content for active tab
-  const getExplanationContent = () => {
+  // Tab indicator + tab pills use the URGENT `activeTab` so they snap
+  // instantly. Markdown body derivation below uses `deferredTab` — a
+  // copy that lags one render tick behind. React schedules the heavy
+  // Markdown re-mount at low priority, so the tab pill animation
+  // completes without being JS-thread-blocked. While the deferred
+  // body catches up, the user sees the previous tab's content — feels
+  // instant instead of staring at a frozen UI.
+  const deferredTab = useDeferredValue(activeTab);
+
+  // Get explanation content for the deferred tab (memoized so the
+  // Markdown body only re-renders when the underlying string actually
+  // changes — protects against parent re-renders that don't touch
+  // topic data).
+  const explanationContent = useMemo(() => {
     if (!topicData?.explanation) return null;
-
-    switch (activeTab) {
+    let raw: string | null = null;
+    switch (deferredTab) {
       case 'summary':
-        return topicData.explanation.summary;
+        raw = topicData.explanation.summary ?? null;
+        break;
       case 'byline':
-        return topicData.explanation.byline;
+        raw = topicData.explanation.byline ?? null;
+        break;
       case 'detailed':
-        return topicData.explanation.detailed;
-      default:
-        return null;
+        raw = topicData.explanation.detailed ?? null;
+        break;
     }
-  };
+    if (typeof raw !== 'string') return raw;
+    // Clean up byline content to remove redundant verse references,
+    // then strip the duplicate leading `# {topicName}` heading the
+    // header bar already shows.
+    const cleaned = deferredTab === 'byline' ? cleanupBylineReferences(raw) : raw;
+    return stripLeadingHeading(cleaned);
+  }, [topicData, deferredTab]);
 
-  const rawExplanationContent = getExplanationContent();
-  // Clean up byline content to remove redundant verse references, then strip
-  // the duplicate leading `# {topicName}` heading the header bar already shows.
-  const cleanedExplanationContent =
-    activeTab === 'byline' && rawExplanationContent
-      ? cleanupBylineReferences(rawExplanationContent)
-      : rawExplanationContent;
-  const explanationContent =
-    typeof cleanedExplanationContent === 'string'
-      ? stripLeadingHeading(cleanedExplanationContent)
-      : cleanedExplanationContent;
   const hasContent = explanationContent && typeof explanationContent === 'string';
+
+  // Memoize the rendered Markdown subtree so unrelated parent re-renders
+  // (scroll handlers, FAB visibility, header toggles) don't redo the
+  // expensive Markdown parse + layout. Only re-runs when content or
+  // styles actually change.
+  const renderedMarkdown = useMemo(() => {
+    if (!hasContent || typeof explanationContent !== 'string') return null;
+    return (
+      <View style={styles.explanationContainer}>
+        <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+          {explanationContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
+        </Markdown>
+      </View>
+    );
+  }, [
+    hasContent,
+    explanationContent,
+    markdownStyles,
+    dictionaryMarkdownRules,
+    styles.explanationContainer,
+  ]);
 
   // Custom share handler for topics
   const handleShare = async () => {
@@ -371,11 +400,7 @@ export function TopicExplanationsPanel({
       >
         {/* Explanation Content */}
         {hasContent ? (
-          <View style={styles.explanationContainer}>
-            <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-              {explanationContent.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
-            </Markdown>
-          </View>
+          renderedMarkdown
         ) : (
           <View style={styles.emptyContainer}>
             <Text style={styles.emptyText}>

--- a/components/topics/TopicExplanationsPanel.tsx
+++ b/components/topics/TopicExplanationsPanel.tsx
@@ -23,6 +23,7 @@ import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
+import { SkeletonLoader } from '@/components/bible/SkeletonLoader';
 import { WordDefinitionTooltip } from '@/components/bible/WordDefinitionTooltip';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useToast } from '@/contexts/ToastContext';
@@ -104,6 +105,14 @@ export interface TopicExplanationsPanelProps {
   /** Callback when tab is changed */
   onTabChange: (tab: ContentTabType) => void;
 
+  /**
+   * True while a tab-switch transition is pending in the parent. Drives a
+   * skeleton overlay over the content area so the user sees immediate
+   * feedback even though React keeps the old tab visible while the new
+   * tree reconciles in the background.
+   */
+  isTabPending?: boolean;
+
   /** Callback when menu button is pressed */
   onMenuPress?: () => void;
 
@@ -121,6 +130,7 @@ export function TopicExplanationsPanel({
   topicName,
   activeTab,
   onTabChange,
+  isTabPending = false,
   onMenuPress,
   testID = 'topic-explanations-panel',
 }: TopicExplanationsPanelProps) {
@@ -198,24 +208,19 @@ export function TopicExplanationsPanel({
   // biome-ignore lint/suspicious/noExplicitAny: Hybrid online/offline data structure
   const topicData = rawTopicData as any;
 
-  // Handle tab press with haptic feedback
+  // Handle tab press with haptic feedback. The parent's onTabChange is
+  // expected to wrap setActiveTab in a useTransition so the heavy
+  // markdown re-render doesn't block the tap; isTabPending then drives
+  // the skeleton overlay below.
   const handleTabPress = (tab: ContentTabType) => {
     if (tab !== activeTab) {
-      const t0 = performance.now();
-      console.log(`[TAB-PERF] topics tap ${activeTab}->${tab} @0ms`);
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       onTabChange(tab);
-      console.log(
-        `[TAB-PERF] topics onTabChange returned +${(performance.now() - t0).toFixed(1)}ms`
-      );
       // Defer the scroll so it doesn't compete with the tab switch
       // for the current frame's JS budget.
       requestAnimationFrame(() => {
         scrollViewRef.current?.scrollTo({ y: 0, animated: false });
       });
-      setTimeout(() => {
-        console.log(`[TAB-PERF] topics next-tick +${(performance.now() - t0).toFixed(1)}ms`);
-      }, 0);
     }
   };
 
@@ -415,37 +420,53 @@ export function TopicExplanationsPanel({
 
       {/* Content Area — pre-mount all three tabs and flip display:none
           between them on tab switch (Bible-panel pattern). Switching
-          is a CSS toggle, no Markdown re-parse. */}
-      {(
-        [
-          { id: 'summary' as const, content: summaryContent, markdown: summaryMarkdown },
-          { id: 'byline' as const, content: bylineContent, markdown: bylineMarkdown },
-          { id: 'detailed' as const, content: detailedContent, markdown: detailedMarkdown },
-        ] satisfies readonly {
-          id: ContentTabType;
-          content: string | null;
-          markdown: React.ReactNode;
-        }[]
-      ).map((tab) => (
-        <ScrollView
-          key={tab.id}
-          ref={tab.id === activeTab ? scrollViewRef : null}
-          style={[styles.scrollView, activeTab !== tab.id && { display: 'none' }]}
-          contentContainerStyle={styles.scrollContent}
-          showsVerticalScrollIndicator={true}
-          testID={`${testID}-scroll-${tab.id}`}
-        >
-          {tab.content ? (
-            <View style={styles.explanationContainer}>{tab.markdown}</View>
-          ) : (
-            <View style={styles.emptyContainer}>
-              <Text style={styles.emptyText}>
-                No {tab.id} explanation available for this topic yet.
-              </Text>
-            </View>
-          )}
-        </ScrollView>
-      ))}
+          is a CSS toggle, no Markdown re-parse. Wrapped in a relative-
+          positioned View so the transition skeleton can absolute-cover
+          the tabs only (header + tab row stay visible). */}
+      <View style={styles.contentArea}>
+        {(
+          [
+            { id: 'summary' as const, content: summaryContent, markdown: summaryMarkdown },
+            { id: 'byline' as const, content: bylineContent, markdown: bylineMarkdown },
+            { id: 'detailed' as const, content: detailedContent, markdown: detailedMarkdown },
+          ] satisfies readonly {
+            id: ContentTabType;
+            content: string | null;
+            markdown: React.ReactNode;
+          }[]
+        ).map((tab) => (
+          <ScrollView
+            key={tab.id}
+            ref={tab.id === activeTab ? scrollViewRef : null}
+            style={[styles.scrollView, activeTab !== tab.id && { display: 'none' }]}
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={true}
+            testID={`${testID}-scroll-${tab.id}`}
+          >
+            {tab.content ? (
+              <View style={styles.explanationContainer}>{tab.markdown}</View>
+            ) : (
+              <View style={styles.emptyContainer}>
+                <Text style={styles.emptyText}>
+                  No {tab.id} explanation available for this topic yet.
+                </Text>
+              </View>
+            )}
+          </ScrollView>
+        ))}
+
+        {/* Transition skeleton overlay — shown while the parent's tab-switch
+            transition is reconciling. Covers the tab content area only. */}
+        {isTabPending && (
+          <View
+            style={styles.transitionSkeleton}
+            pointerEvents="none"
+            testID={`${testID}-tab-transition-skeleton`}
+          >
+            <SkeletonLoader />
+          </View>
+        )}
+      </View>
 
       {/* Word Definition Tooltip — dictionary lookup on long-press */}
       {wordToDefine && (
@@ -544,6 +565,18 @@ function createStyles(
     },
     scrollView: {
       flex: 1,
+    },
+    contentArea: {
+      flex: 1,
+      position: 'relative',
+    },
+    transitionSkeleton: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: colors.background,
     },
     scrollContent: {
       flexGrow: 1,

--- a/components/topics/TopicPage.tsx
+++ b/components/topics/TopicPage.tsx
@@ -19,9 +19,16 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { GestureResponderEvent, NativeScrollEvent, NativeSyntheticEvent } from 'react-native';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { FlatList, InteractionManager, ScrollView, StyleSheet, Text, View } from 'react-native';
 import type { RenderRules } from 'react-native-markdown-display';
 import Markdown from 'react-native-markdown-display';
+import Animated, {
+  Easing,
+  type SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
 import { BottomLogo } from '@/components/bible/BottomLogo';
 import { HighlightedText, type WordSelection } from '@/components/bible/HighlightedText';
 import { ShareButton } from '@/components/bible/ShareButton';
@@ -83,6 +90,51 @@ function cleanupBylineReferences(content: string): string {
 }
 
 /**
+ * Splits markdown into FlatList-friendly chunks. Prefers `## ` heading
+ * boundaries (semantically meaningful); if the content has no `## `
+ * headings, falls back to paragraph boundaries (`\n\n`). Returns a
+ * single chunk for content with neither, so callers can still feed it
+ * to a FlatList safely (it just renders one item with no virtualization
+ * benefit, which is the right behavior for short prose).
+ *
+ * Used to feed FlatList for the topic Insight tabs. Topics span many
+ * verses on byline (= many `##` sections), and detailed often has
+ * subsection headings — both benefit hugely from virtualization.
+ * Summary is usually short prose, so it falls back to paragraphs.
+ */
+function splitMarkdownForVirtualization(markdown: string): { key: string; body: string }[] {
+  if (!markdown) return [];
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const hasHeadings = /^## /m.test(normalized);
+  let parts: string[];
+  if (hasHeadings) {
+    // Split at `## ` boundaries, keeping the heading with its body.
+    const lines = normalized.split('\n');
+    const buf: string[] = [];
+    parts = [];
+    const flush = () => {
+      const body = buf.join('\n').trim();
+      if (body.length > 0) parts.push(body);
+      buf.length = 0;
+    };
+    for (const line of lines) {
+      if (line.startsWith('## ') && buf.length > 0) flush();
+      buf.push(line);
+    }
+    flush();
+  } else {
+    // No headings — split at blank lines (paragraph boundaries). Safe
+    // because paragraphs are independent markdown blocks. Lists,
+    // blockquotes, and code blocks stay within a single paragraph.
+    parts = normalized
+      .split(/\n{2,}/)
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+  }
+  return parts.map((body, idx) => ({ key: `section-${idx}`, body }));
+}
+
+/**
  * Preprocess Bible references text to format verse numbers as Unicode superscripts
  */
 function formatVerseNumbers(text: string): string {
@@ -115,6 +167,19 @@ export interface TopicPageProps {
   activeTab: ContentTabType;
   /** Current view mode (bible or explanations) */
   activeView: 'bible' | 'explanations';
+  /**
+   * Shared visual progress (0 = Bible, 1 = Insight) driven by parent.
+   * Optional so isolated callers can omit; falls back to a local
+   * sharedValue mirroring activeView. Matches the Bible ChapterPage
+   * pattern.
+   */
+  toggleProgress?: SharedValue<number>;
+  /**
+   * Shared visual key (active tab) for inner tab switching. Drives each
+   * tab's wrapper maxHeight + opacity on the UI thread so the swap is
+   * instant. Optional with activeTab-mirroring fallback.
+   */
+  activeTabProgress?: SharedValue<ContentTabType>;
   /** Whether to reset scroll to top on topic change (default: true) */
   shouldResetScroll?: boolean;
   /** Whether this page is being preloaded (skips heavy AI content) */
@@ -155,6 +220,8 @@ export function TopicPage({
   topicId,
   activeTab,
   activeView,
+  toggleProgress,
+  activeTabProgress,
   shouldResetScroll = true,
   isPreloading = false,
   onScroll,
@@ -163,7 +230,11 @@ export function TopicPage({
   onVersePress,
 }: TopicPageProps) {
   const { colors } = useTheme();
-  const { styles, markdownStyles } = createStyles(colors);
+  // Memoise the StyleSheet objects so they're stable across renders. The
+  // raw `createStyles(colors)` call returns fresh objects every time,
+  // which breaks any Markdown component's prop-equality check downstream
+  // and forces it to re-parse the entire markdown string on every render.
+  const { styles, markdownStyles } = useMemo(() => createStyles(colors), [colors]);
   const { showToast } = useToast();
 
   // TODO: Implement Bible version selection in Settings page
@@ -219,36 +290,72 @@ export function TopicPage({
   const touchStartTime = useRef(0);
   const touchStartY = useRef(0);
 
-  // Staggered rendering state to prevent UI freeze (waterfall loading)
-  // 0: Initial (only active view)
-  // 1: Mount Explanations container
-  // 2: Mount Summary tab (if hidden)
-  // 3: Mount Byline tab (if hidden)
-  // 4: Mount Detailed tab (if hidden)
-  const [delayedRenderStage, setDelayedRenderStage] = useState(0);
+  // Pre-warmed flag mirrors Bible's ChapterPage pattern: fires as soon
+  // as the initial interaction settles (~16ms after mount) so the
+  // Insight subtree mounts before the user first taps Bible/Insight.
+  // Sticky once true; resets when topicId shifts so each new active
+  // topic gets its own prewarm.
+  const [insightPrewarmed, setInsightPrewarmed] = useState(false);
 
-  // Trigger staggered delayed render — only for the active page, not buffer pages
+  // Visit-based lazy mount for the inner tabs (summary/byline/detailed).
+  // Only the currently-active tab mounts on initial topic render; other
+  // tabs mount when the user actually taps them. Once a tab is visited
+  // it stays mounted — subsequent switches are instant via sharedValue
+  // opacity flip. Resets on topicId change.
+  //
+  // Replaces the previous staggered-timer mount that auto-mounted every
+  // tab within 2.1s of topic settle. That timer blocked the JS thread
+  // parsing markdown for tabs the user wasn't even looking at, which
+  // was the cause of the 3-5s "load" lag after swiping to a new topic
+  // while on the byline tab (even though byline itself is now
+  // virtualized).
+  const [visitedTabs, setVisitedTabs] = useState<Set<ContentTabType>>(() => new Set([activeTab]));
+
+  // Reset visitedTabs on topicId change so each new topic starts with
+  // only the currently-active tab mounted (others stay lazy). DON'T
+  // reset insightPrewarmed — once true, keep it sticky. The data inside
+  // (markdown memos) refreshes via useTopicById + bylineSections deps,
+  // so unmount/remount is unnecessary and causes a flicker on every
+  // topic swipe ("byline loads, flickers, loads again").
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on topicId change
   useEffect(() => {
-    if (isPreloading) {
-      setDelayedRenderStage(0);
-      return;
-    }
-    const t1 = setTimeout(() => setDelayedRenderStage(1), 600);
-    const t2 = setTimeout(() => setDelayedRenderStage(2), 1100);
-    const t3 = setTimeout(() => setDelayedRenderStage(3), 1600);
-    const t4 = setTimeout(() => setDelayedRenderStage(4), 2100);
+    setVisitedTabs(new Set([activeTab]));
+  }, [topicId]);
 
+  // Add the active tab to the visited set whenever it changes.
+  useEffect(() => {
+    setVisitedTabs((prev) => {
+      if (prev.has(activeTab)) return prev;
+      const next = new Set(prev);
+      next.add(activeTab);
+      return next;
+    });
+  }, [activeTab]);
+
+  // Prewarm fires for buffer pages too — not gated on isPreloading.
+  // Each instance mounts its Insight subtree (with only the active
+  // tab's content per visitedTabs) so the next swipe lands on a page
+  // that already has content rendered, no blank-frame gap. Cost is
+  // small because each buffer only parses one tab's markdown (and
+  // byline is virtualized to ~3 sections).
+  useEffect(() => {
+    if (insightPrewarmed) return;
+    const handle = InteractionManager.runAfterInteractions(() => {
+      setInsightPrewarmed(true);
+    });
     return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
-      clearTimeout(t3);
-      clearTimeout(t4);
+      handle.cancel();
     };
-  }, [isPreloading]);
+  }, [insightPrewarmed]);
 
-  // Reset scroll state when topic changes
+  // Reset scroll state when topic changes. Separate refs per inner tab
+  // matches Bible's pattern and keeps each tab's scroll position
+  // independent across switches.
   const bibleScrollRef = useRef<ScrollView>(null);
-  const explanationsScrollRef = useRef<ScrollView>(null);
+  // All three Insight tabs are FlatLists now — use scrollToOffset.
+  const summaryScrollRef = useRef<FlatList<{ key: string; body: string }>>(null);
+  const bylineScrollRef = useRef<FlatList<{ key: string; body: string }>>(null);
+  const detailedScrollRef = useRef<FlatList<{ key: string; body: string }>>(null);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: topicId and shouldResetScroll are required to trigger scroll reset
   useEffect(() => {
@@ -257,7 +364,9 @@ export function TopicPage({
     // ONLY if shouldResetScroll is true (skipped during seamless pager snaps)
     if (shouldResetScroll) {
       bibleScrollRef.current?.scrollTo({ y: 0, animated: false });
-      explanationsScrollRef.current?.scrollTo({ y: 0, animated: false });
+      summaryScrollRef.current?.scrollToOffset({ offset: 0, animated: false });
+      bylineScrollRef.current?.scrollToOffset({ offset: 0, animated: false });
+      detailedScrollRef.current?.scrollToOffset({ offset: 0, animated: false });
     }
 
     // Reset internal scroll tracking
@@ -352,6 +461,105 @@ export function TopicPage({
       ? topic.description
       : null;
 
+  // UI-thread driven opacities — flip the visible content the same frame
+  // as the tap, without waiting for the activeView prop reconciliation.
+  // Falls back to a local sharedValue mirroring activeView when no parent
+  // sharedValue is provided (tests, isolated callers).
+  const localToggleProgress = useSharedValue(activeView === 'bible' ? 0 : 1);
+  useEffect(() => {
+    if (toggleProgress) return;
+    localToggleProgress.value = withTiming(activeView === 'bible' ? 0 : 1, {
+      duration: 180,
+      easing: Easing.out(Easing.cubic),
+    });
+  }, [activeView, localToggleProgress, toggleProgress]);
+  const effectiveProgress = toggleProgress ?? localToggleProgress;
+  const insightContainerStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: effectiveProgress.value,
+      zIndex: effectiveProgress.value > 0.5 ? 1 : 0,
+    };
+  });
+  const bibleContainerStyle = useAnimatedStyle(() => {
+    'worklet';
+    return {
+      opacity: 1 - effectiveProgress.value,
+      zIndex: effectiveProgress.value > 0.5 ? 0 : 1,
+    };
+  });
+
+  // Pre-process + memoise each tab's rendered markdown JSX. Without this,
+  // every tab tap triggers TopicPage to re-render with the same content,
+  // and react-native-markdown-display re-parses ALL three trees from
+  // scratch (the inline `.replace()` calls produce fresh string refs each
+  // render, and the markdown component can't tell it's the same input).
+  // Logs showed 3-5s of JS-thread blocking per tap before this memo.
+  // All three Insight tabs feed FlatLists so virtualization can keep
+  // the first-tap parse small. Splitter prefers `## ` headings;
+  // falls back to paragraph boundaries when there are none (typical
+  // for summary).
+  const summarySections = useMemo<{ key: string; body: string }[]>(() => {
+    const raw = displayTopicData?.explanation?.summary;
+    if (typeof raw !== 'string' || !raw) return [];
+    const processed = raw.replace(/#{1,6}\s*Summary\s*\n/gi, '\n');
+    return splitMarkdownForVirtualization(processed);
+  }, [displayTopicData?.explanation?.summary]);
+
+  const bylineSections = useMemo<{ key: string; body: string }[]>(() => {
+    const raw = displayTopicData?.explanation?.byline;
+    if (typeof raw !== 'string' || !raw) return [];
+    const processed = cleanupBylineReferences(raw).replace(/#{1,6}\s*Summary\s*\n/gi, '\n');
+    return splitMarkdownForVirtualization(processed);
+  }, [displayTopicData?.explanation?.byline]);
+
+  const detailedSections = useMemo<{ key: string; body: string }[]>(() => {
+    const raw = displayTopicData?.explanation?.detailed;
+    if (typeof raw !== 'string' || !raw) return [];
+    const processed = raw.replace(/#{1,6}\s*Summary\s*\n/gi, '\n');
+    return splitMarkdownForVirtualization(processed);
+  }, [displayTopicData?.explanation?.detailed]);
+
+  // One render function shared across all three tabs — same Markdown
+  // component, same rules, same styles per section.
+  const renderMarkdownSection = useCallback(
+    ({ item }: { item: { key: string; body: string } }) => (
+      <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
+        {item.body}
+      </Markdown>
+    ),
+    [markdownStyles, dictionaryMarkdownRules]
+  );
+  const sectionKeyExtractor = useCallback((item: { key: string; body: string }) => item.key, []);
+
+  // Inner-tab visibility — driven by activeTabProgress. Each tab is now
+  // its own absolute-positioned ScrollView (Bible pattern); only opacity
+  // and zIndex flip on the UI thread, no layout reflow. The previous
+  // maxHeight-collapse approach inside a shared ScrollView forced Yoga
+  // to re-measure the entire markdown subtree on every tab switch and
+  // was the root cause of the sloppy/teleport animations.
+  const localActiveTabProgress = useSharedValue<ContentTabType>(activeTab);
+  useEffect(() => {
+    if (activeTabProgress) return;
+    localActiveTabProgress.value = activeTab;
+  }, [activeTab, localActiveTabProgress, activeTabProgress]);
+  const effectiveTabProgress = activeTabProgress ?? localActiveTabProgress;
+  const summaryTabAnimStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'summary';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+  const bylineTabAnimStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'byline';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+  const detailedTabAnimStyle = useAnimatedStyle(() => {
+    'worklet';
+    const match = effectiveTabProgress.value === 'detailed';
+    return { opacity: match ? 1 : 0, zIndex: match ? 1 : 0 };
+  });
+
   // Loading state - show skeleton ONLY on initial mount when no data exists
   if (isTopicLoading && !displayTopicData) {
     return (
@@ -386,21 +594,12 @@ export function TopicPage({
 
   return (
     <View style={styles.container} testID={`topic-page-${topicId}`}>
-      {/* Bible References View */}
-      <ScrollView
-        ref={bibleScrollRef}
-        style={[
-          styles.container,
-          activeView !== 'bible' && {
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            opacity: 0,
-            zIndex: -1,
-          },
-        ]}
+      {/* Bible References View — opacity flipped by toggleProgress on
+          the UI thread. Always absolute-fill so it overlaps the Insight
+          container at the same bounds; opacity decides which is visible. */}
+      <Animated.ScrollView
+        ref={bibleScrollRef as React.Ref<Animated.ScrollView>}
+        style={[styles.container, styles.absoluteFill, bibleContainerStyle]}
         contentContainerStyle={styles.contentContainer}
         showsVerticalScrollIndicator={true}
         testID={`topic-page-scroll-${topicId}-bible`}
@@ -481,56 +680,52 @@ export function TopicPage({
           </>
         )}
         <BottomLogo />
-      </ScrollView>
+      </Animated.ScrollView>
 
-      {/* Explanations View - Always render when user is in explanations view (even on buffer pages
-           during idle-deferred navigation). In bible view, only pre-render on active page after stagger delay. */}
-      {(activeView === 'explanations' || (!isPreloading && delayedRenderStage >= 1)) && (
-        <ScrollView
-          ref={explanationsScrollRef}
-          style={[
-            styles.container,
-            activeView !== 'explanations' && {
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              opacity: 0,
-              zIndex: -1,
-            },
-          ]}
-          contentContainerStyle={styles.contentContainer}
-          showsVerticalScrollIndicator={true}
-          testID={`topic-page-scroll-${topicId}-explanations`}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-          onTouchStart={handleTouchStart}
-          onTouchEnd={handleTouchEnd}
+      {/* Explanations View — opacity flipped by toggleProgress on the UI
+          thread. Always absolute-fill, overlapping Bible at the same
+          bounds. Mount gated on insightPrewarmed OR the legacy stage
+          tick — both only fire on the ACTIVE page (isPreloading=false),
+          so buffer pages skip the heavy markdown parse entirely.
+          Previously the `activeView === 'explanations'` condition
+          forced buffer pages to render the Insight subtree on every
+          swipe, producing 3+ second render blocks. */}
+      {/* Insight view — matches Bible ChapterPage's absolute-overlap
+          pattern. Each inner tab gets its own ScrollView, absolute-
+          positioned and overlapping at the same bounds. Switching tabs
+          is pure opacity flip on the UI thread via activeTabProgress —
+          no layout reflow (which was the source of the sloppy/teleport
+          animations under the previous maxHeight-collapse design). */}
+      {insightPrewarmed && (
+        <Animated.View
+          style={[styles.container, styles.absoluteFill, insightContainerStyle]}
           pointerEvents={activeView === 'explanations' ? 'auto' : 'none'}
         >
-          {/* Topic Title */}
-          <Text style={styles.topicTitle} accessibilityRole="header">
-            {topic?.name}
-          </Text>
-
-          {/* Topic Description */}
-          {topicDescription ? (
-            <Text style={styles.topicDescription}>{topicDescription}</Text>
-          ) : null}
-
-          {/* Render active explanation type */}
-          {/* Summary explanation */}
-          {(activeTab === 'summary' || delayedRenderStage >= 2) && (
-            <View
-              style={[styles.explanationContainer, activeTab !== 'summary' && { display: 'none' }]}
+          {visitedTabs.has('summary') && (
+            <Animated.View
+              style={[styles.absoluteFill, summaryTabAnimStyle]}
               testID="topic-explanation-summary"
+              pointerEvents={activeTab === 'summary' ? 'auto' : 'none'}
             >
-              {displayTopicData?.explanation?.summary &&
-              typeof displayTopicData.explanation.summary === 'string' ? (
-                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-                  {displayTopicData.explanation.summary.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
-                </Markdown>
+              {summarySections.length > 0 ? (
+                <FlatList
+                  ref={summaryScrollRef}
+                  style={styles.container}
+                  contentContainerStyle={styles.contentContainer}
+                  data={summarySections}
+                  keyExtractor={sectionKeyExtractor}
+                  renderItem={renderMarkdownSection}
+                  showsVerticalScrollIndicator={true}
+                  testID={`topic-page-scroll-${topicId}-summary`}
+                  onScroll={activeTab === 'summary' ? handleScroll : undefined}
+                  scrollEventThrottle={16}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                  initialNumToRender={3}
+                  maxToRenderPerBatch={2}
+                  windowSize={5}
+                  removeClippedSubviews
+                />
               ) : (
                 <View style={styles.emptyContainer}>
                   <Text style={styles.emptyText}>
@@ -538,23 +733,39 @@ export function TopicPage({
                   </Text>
                 </View>
               )}
-            </View>
+            </Animated.View>
           )}
 
-          {/* Byline explanation */}
-          {(activeTab === 'byline' || delayedRenderStage >= 3) && (
-            <View
-              style={[styles.explanationContainer, activeTab !== 'byline' && { display: 'none' }]}
+          {visitedTabs.has('byline') && (
+            <Animated.View
+              style={[styles.absoluteFill, bylineTabAnimStyle]}
               testID="topic-explanation-byline"
+              pointerEvents={activeTab === 'byline' ? 'auto' : 'none'}
             >
-              {displayTopicData?.explanation?.byline &&
-              typeof displayTopicData.explanation.byline === 'string' ? (
-                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-                  {cleanupBylineReferences(displayTopicData.explanation.byline).replace(
-                    /#{1,6}\s*Summary\s*\n/gi,
-                    '\n'
-                  )}
-                </Markdown>
+              {bylineSections.length > 0 ? (
+                <FlatList
+                  ref={bylineScrollRef}
+                  style={styles.container}
+                  contentContainerStyle={styles.contentContainer}
+                  data={bylineSections}
+                  keyExtractor={sectionKeyExtractor}
+                  renderItem={renderMarkdownSection}
+                  showsVerticalScrollIndicator={true}
+                  testID={`topic-page-scroll-${topicId}-byline`}
+                  onScroll={activeTab === 'byline' ? handleScroll : undefined}
+                  scrollEventThrottle={16}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                  // Render only enough sections to fill the screen on first
+                  // mount; load more as the user scrolls. Topics with 30+
+                  // verses used to block ~3-5s on first byline tap; now it
+                  // renders the first ~3 sections instantly and streams
+                  // the rest in during scroll.
+                  initialNumToRender={3}
+                  maxToRenderPerBatch={2}
+                  windowSize={5}
+                  removeClippedSubviews
+                />
               ) : (
                 <View style={styles.emptyContainer}>
                   <Text style={styles.emptyText}>
@@ -562,20 +773,34 @@ export function TopicPage({
                   </Text>
                 </View>
               )}
-            </View>
+            </Animated.View>
           )}
 
-          {/* Detailed explanation */}
-          {(activeTab === 'detailed' || delayedRenderStage >= 4) && (
-            <View
-              style={[styles.explanationContainer, activeTab !== 'detailed' && { display: 'none' }]}
+          {visitedTabs.has('detailed') && (
+            <Animated.View
+              style={[styles.absoluteFill, detailedTabAnimStyle]}
               testID="topic-explanation-detailed"
+              pointerEvents={activeTab === 'detailed' ? 'auto' : 'none'}
             >
-              {displayTopicData?.explanation?.detailed &&
-              typeof displayTopicData.explanation.detailed === 'string' ? (
-                <Markdown style={markdownStyles} rules={dictionaryMarkdownRules}>
-                  {displayTopicData.explanation.detailed.replace(/#{1,6}\s*Summary\s*\n/gi, '\n')}
-                </Markdown>
+              {detailedSections.length > 0 ? (
+                <FlatList
+                  ref={detailedScrollRef}
+                  style={styles.container}
+                  contentContainerStyle={styles.contentContainer}
+                  data={detailedSections}
+                  keyExtractor={sectionKeyExtractor}
+                  renderItem={renderMarkdownSection}
+                  showsVerticalScrollIndicator={true}
+                  testID={`topic-page-scroll-${topicId}-detailed`}
+                  onScroll={activeTab === 'detailed' ? handleScroll : undefined}
+                  scrollEventThrottle={16}
+                  onTouchStart={handleTouchStart}
+                  onTouchEnd={handleTouchEnd}
+                  initialNumToRender={3}
+                  maxToRenderPerBatch={2}
+                  windowSize={5}
+                  removeClippedSubviews
+                />
               ) : (
                 <View style={styles.emptyContainer}>
                   <Text style={styles.emptyText}>
@@ -583,9 +808,9 @@ export function TopicPage({
                   </Text>
                 </View>
               )}
-            </View>
+            </Animated.View>
           )}
-        </ScrollView>
+        </Animated.View>
       )}
 
       {/* Word Definition Tooltip — dictionary lookup on long-press */}
@@ -613,6 +838,13 @@ const createStyles = (colors: ReturnType<typeof getColors>) => {
     container: {
       flex: 1,
       backgroundColor: colors.background,
+    },
+    absoluteFill: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
     },
     contentContainer: {
       flexGrow: 1,

--- a/hooks/bible/use-bookmarks.ts
+++ b/hooks/bible/use-bookmarks.ts
@@ -264,13 +264,34 @@ export function useBookmarks(): UseBookmarksResult {
       console.error('Failed to add bookmark:', error);
       showToast('Failed to add bookmark. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (data, variables) => {
       // Track analytics: BOOKMARK_ADDED event
       if (variables.body) {
         analytics.track(AnalyticsEvent.BOOKMARK_ADDED, {
           bookId: variables.body.book_id,
           chapterNumber: variables.body.chapter_number,
         });
+      }
+
+      // Same fix shape as notes (5cae71d) / highlights (b9fd76b) — when
+      // online + isUserDataSynced the UI reads from local SQLite, not
+      // from bookmarksQueryKey. The online path above only hits the
+      // server; without mirroring the new bookmark into local SQLite,
+      // invalidating local-bookmarks-offline-fallback re-reads the
+      // unchanged local DB and the add appears as a no-op.
+      const serverFav = (data as { favorite?: Bookmark })?.favorite;
+      if (isOnline && serverFav && variables.body) {
+        try {
+          await addLocalBookmark({
+            favorite_id: serverFav.favorite_id,
+            book_id: serverFav.book_id,
+            chapter_number: serverFav.chapter_number,
+            created_at: new Date().toISOString(),
+            insight_type: serverFav.insight_type || undefined,
+          });
+        } catch (e) {
+          console.warn('[bookmarks] local mirror after add failed:', e);
+        }
       }
 
       // Refetch to get accurate server data (with correct favorite_id and book_name)
@@ -345,13 +366,28 @@ export function useBookmarks(): UseBookmarksResult {
       console.error('Failed to remove bookmark:', error);
       showToast('Failed to remove bookmark. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       // Track analytics: BOOKMARK_REMOVED event
       if (variables.query) {
         analytics.track(AnalyticsEvent.BOOKMARK_REMOVED, {
           bookId: Number(variables.query.book_id),
           chapterNumber: Number(variables.query.chapter_number),
         });
+      }
+
+      // Mirror the deletion into local SQLite — see addMutation's
+      // onSuccess for the rationale (online + synced UI reads from
+      // local DB; online path otherwise leaves stale rows).
+      if (isOnline && variables.query) {
+        try {
+          await deleteLocalBookmarkByChapter(
+            Number(variables.query.book_id),
+            Number(variables.query.chapter_number),
+            variables.query.insight_type || undefined
+          );
+        } catch (e) {
+          console.warn('[bookmarks] local mirror after delete failed:', e);
+        }
       }
 
       // Refetch to sync with server

--- a/hooks/bible/use-notes.ts
+++ b/hooks/bible/use-notes.ts
@@ -361,12 +361,28 @@ export function useNotes(): UseNotesResult {
       console.error('Failed to update note:', error);
       showToast('Failed to update note. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       // Track analytics: NOTE_EDITED event (never track note content)
       if (variables.body) {
         analytics.track(AnalyticsEvent.NOTE_EDITED, {
           noteId: variables.body.note_id,
         });
+      }
+
+      // When isUserDataSynced=true the UI reads from local SQLite, not
+      // from the remote notesQueryKey cache the optimistic update wrote
+      // to. The online mutation path above only hits the server — the
+      // local DB never received the new content. Invalidating the
+      // local-fallback query re-runs getLocalAllNotes() which returns
+      // STALE data, so the edit appears to be silently discarded.
+      // Mirror the server-confirmed update into local SQLite first,
+      // then invalidate. Same shape as the highlight fix (b9fd76b).
+      if (isOnline && variables.body) {
+        try {
+          await updateLocalNote(variables.body.note_id, variables.body.content);
+        } catch (e) {
+          console.warn('[notes] local mirror after edit failed:', e);
+        }
       }
 
       // Refetch to sync with server
@@ -420,12 +436,23 @@ export function useNotes(): UseNotesResult {
       console.error('Failed to delete note:', error);
       showToast('Failed to delete note. Please try again.');
     },
-    onSuccess: (_data, variables) => {
+    onSuccess: async (_data, variables) => {
       // Track analytics: NOTE_DELETED event
       if (variables.query) {
         analytics.track(AnalyticsEvent.NOTE_DELETED, {
           noteId: variables.query.note_id,
         });
+      }
+
+      // Mirror the deletion into local SQLite — see updateMutation's
+      // onSuccess for the rationale (isUserDataSynced UI reads from
+      // local DB; online path otherwise leaves stale rows).
+      if (isOnline && variables.query) {
+        try {
+          await deleteLocalNote(variables.query.note_id);
+        } catch (e) {
+          console.warn('[notes] local mirror after delete failed:', e);
+        }
       }
 
       // Refetch to sync with server


### PR DESCRIPTION
Andy 2026-05-24 round of issues — three fixes, one open question.

## #1 Notes edit doesn't save
**Same root cause as the highlights bug in `b9fd76b`** — PR #268 changed the UI to read from local SQLite when `isUserDataSynced=true`, but the online mutation paths in `hooks/bible/use-notes.ts` only hit the server + updated the (now-disabled) remote query cache. The local-fallback invalidate re-reads the unchanged local DB and the edit appears to be silently discarded.

Fix: in `updateMutation.onSuccess`, after server success, also call `updateLocalNote(noteId, content)` before invalidating local-fallback. Same shape for `deleteMutation.onSuccess` calling `deleteLocalNote`. Add path was already correct (PR ~218 explicitly mirrored).

## #2 Remove Names of God from hamburger
Added by PR #330 (the agent who built the Names of God feature). Pulled the menu item, the union type entry, and the router-push branch from `HamburgerMenu.tsx`.

## #3 Insight tab blank on first switch from Bible
**Race in TanStack Query enable transition.** `useBibleSummary`/`useBibleByLine` have `enabled: activeTab === '...'`. When you switch Bible→Insight, `enabled` flips false→true. But TanStack Query schedules the actual fetch in an effect that runs AFTER render. On that first synchronous render:
- `data = undefined`
- `fetchStatus = 'idle'` still
- `isLoading = isPending && isFetching = true && false = false`

Render condition was `tab.loading ? <Skeleton/> : tab.data ? <Content/> : null` — both false → **nothing renders → blank tab**. On the next tick the fetch starts, `isLoading` flips true, skeleton appears, then content. But on first activation visible.

Fix: include `isPending` in the skeleton gate. `isPending` is true the moment the query exists without data, regardless of fetch state — closes the one-frame window. Matches Andy's repro of "blank typically on app startup."

## #4 Dictionary on the Insight tab — open question
Not part of this PR. PR #312 (`verse-mate-agent` on 2026-05-16, VER-72) deliberately added `WordDefinitionTooltip` to both the Insight and Topics screens. It's the same long-press → system-dictionary popup as the Bible side. Andy/Sebastian to decide: keep, remove, or extend to include lexicon (Strong's) lookups when a word in the commentary matches an underlined word in the verse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)