### PR TITLE
feat(VER-177): force upgrade prompt — version policy service + screen

### DIFF
--- a/__tests__/components/bible/WordDefinitionTooltip.test.tsx
+++ b/__tests__/components/bible/WordDefinitionTooltip.test.tsx
@@ -682,13 +682,14 @@ describe('WordDefinitionTooltip', () => {
   });
 
   describe('Dictionary Service Integration', () => {
-    it('should call lookupWord with the word', async () => {
+    it('should call lookupWord with the word and testament derived from bookName', async () => {
+      // defaultProps.bookName is 'John' (NT), so testament should be 'NT'
       render(<WordDefinitionTooltip {...defaultProps} word="God" />);
 
       jest.runAllTimers();
 
       await waitFor(() => {
-        expect(mockLookupWord).toHaveBeenCalledWith('God');
+        expect(mockLookupWord).toHaveBeenCalledWith('God', 'NT');
       });
     });
 
@@ -698,7 +699,7 @@ describe('WordDefinitionTooltip', () => {
       jest.runAllTimers();
 
       await waitFor(() => {
-        expect(mockLookupWord).toHaveBeenCalledWith('God');
+        expect(mockLookupWord).toHaveBeenCalledWith('God', 'NT');
       });
 
       mockLookupWord.mockClear();
@@ -708,7 +709,7 @@ describe('WordDefinitionTooltip', () => {
       jest.runAllTimers();
 
       await waitFor(() => {
-        expect(mockLookupWord).toHaveBeenCalledWith('darkness');
+        expect(mockLookupWord).toHaveBeenCalledWith('darkness', 'NT');
       });
     });
 

--- a/__tests__/hooks/bible/use-auto-highlights.test.tsx
+++ b/__tests__/hooks/bible/use-auto-highlights.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for useAutoHighlights Hook
+ *
+ * Focused regression tests for the logged-in user path.
+ *
+ * Regression: GH-288 / VER-116
+ * When user preferences omit `default_relevance_threshold`, the hook was building
+ * `theme_relevance=1:undefined,…` which the backend rejects, returning no highlights
+ * for all logged-in users.
+ *
+ * @see hook: /hooks/bible/use-auto-highlights.ts
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { HttpResponse, http } from 'msw';
+import type { ReactNode } from 'react';
+import { useAutoHighlights } from '@/hooks/bible/use-auto-highlights';
+import { server } from '../../mocks/server';
+
+const API_BASE_URL = 'http://localhost:4000';
+
+jest.mock('@/lib/auth/token-storage', () => ({
+  getAccessToken: jest.fn().mockResolvedValue('mock-access-token'),
+  setAccessToken: jest.fn().mockResolvedValue(undefined),
+  clearTokens: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/hooks/use-auth', () => ({
+  useAuth: jest.fn(() => ({
+    user: { id: 'test-user-id', email: 'test@example.com' },
+    isAuthenticated: true,
+  })),
+}));
+
+jest.mock('@/hooks/use-auto-highlights-enabled', () => ({
+  useAutoHighlightsEnabled: jest.fn(() => ({
+    isEnabled: undefined,
+    setEnabled: jest.fn(),
+    isLoading: false,
+  })),
+}));
+
+const mockHighlights = [
+  {
+    auto_highlight_id: 1,
+    theme_id: 1,
+    theme_name: 'Key Verses',
+    theme_color: 'yellow',
+    book_id: 1,
+    chapter_number: 1,
+    start_verse: 1,
+    end_verse: 1,
+    relevance_score: 1,
+    created_at: '2025-01-01T00:00:00Z',
+  },
+];
+
+describe('useAutoHighlights', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  const createWrapper = () => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return Wrapper;
+  };
+
+  it('[REGRESSION GH-288] returns highlights for logged-in user when preferences include default_relevance_threshold', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/bible/user/theme-preferences`, () => {
+        return HttpResponse.json({
+          success: true,
+          data: [
+            {
+              theme_id: 1,
+              theme_name: 'Key Verses',
+              theme_color: 'yellow',
+              theme_description: null,
+              is_enabled: true,
+              custom_color: null,
+              relevance_threshold: 3,
+              default_relevance_threshold: 3,
+              admin_override: false,
+            },
+          ],
+        });
+      }),
+      http.get(`${API_BASE_URL}/bible/auto-highlights/:bookId/:chapterNumber`, ({ request }) => {
+        const url = new URL(request.url);
+        const themeRelevance = url.searchParams.get('theme_relevance');
+        // Verify the hook sends a valid numeric threshold, not "1:undefined"
+        if (themeRelevance && themeRelevance.includes('undefined')) {
+          return HttpResponse.json({ success: false }, { status: 400 });
+        }
+        return HttpResponse.json({ success: true, data: mockHighlights });
+      })
+    );
+
+    const { result } = renderHook(() => useAutoHighlights({ bookId: 1, chapterNumber: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.autoHighlights.length).toBeGreaterThan(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('[REGRESSION GH-288] returns highlights when backend omits default_relevance_threshold (defensive fallback)', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/bible/user/theme-preferences`, () => {
+        return HttpResponse.json({
+          success: true,
+          // Intentionally omit default_relevance_threshold and admin_override
+          // to simulate a backend that doesn't include these fields
+          data: [
+            {
+              theme_id: 1,
+              theme_name: 'Key Verses',
+              theme_color: 'yellow',
+              theme_description: null,
+              is_enabled: true,
+              custom_color: null,
+              relevance_threshold: 3,
+            },
+          ],
+        });
+      }),
+      http.get(`${API_BASE_URL}/bible/auto-highlights/:bookId/:chapterNumber`, ({ request }) => {
+        const url = new URL(request.url);
+        const themeRelevance = url.searchParams.get('theme_relevance');
+        if (themeRelevance && themeRelevance.includes('undefined')) {
+          return HttpResponse.json({ success: false }, { status: 400 });
+        }
+        return HttpResponse.json({ success: true, data: mockHighlights });
+      })
+    );
+
+    const { result } = renderHook(() => useAutoHighlights({ bookId: 1, chapterNumber: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.autoHighlights.length).toBeGreaterThan(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('returns empty array when all themes are disabled', async () => {
+    server.use(
+      http.get(`${API_BASE_URL}/bible/user/theme-preferences`, () => {
+        return HttpResponse.json({
+          success: true,
+          data: [
+            {
+              theme_id: 1,
+              theme_name: 'Key Verses',
+              theme_color: 'yellow',
+              theme_description: null,
+              is_enabled: false,
+              custom_color: null,
+              relevance_threshold: 3,
+              default_relevance_threshold: 3,
+              admin_override: false,
+            },
+          ],
+        });
+      })
+    );
+
+    const { result } = renderHook(() => useAutoHighlights({ bookId: 1, chapterNumber: 1 }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => !result.current.isLoading);
+
+    expect(result.current.autoHighlights).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/__tests__/mocks/handlers/auto-highlights.ts
+++ b/__tests__/mocks/handlers/auto-highlights.ts
@@ -83,6 +83,8 @@ const mockUserPreferences = mockThemes.map((theme) => ({
   is_enabled: true,
   custom_color: null,
   relevance_threshold: 3,
+  default_relevance_threshold: 3,
+  admin_override: false,
 }));
 
 /**

--- a/__tests__/mocks/handlers/index.ts
+++ b/__tests__/mocks/handlers/index.ts
@@ -21,6 +21,7 @@ import { recentlyViewedBooksHandlers } from './recently-viewed-books.handlers';
 import { topicsHandlers } from './topics.handlers';
 import { userPreferencesHandlers } from './user-preferences';
 import { verseHandlers } from './verses';
+import { versionPolicyHandlers } from './version-policy.handlers';
 
 // Combine all handlers
 // IMPORTANT: Bookmark, highlights, and notes handlers must come BEFORE bible handlers to prevent
@@ -38,6 +39,7 @@ export const handlers = [
   ...languagesHandlers, // Languages API handlers
   ...userPreferencesHandlers, // User preferences handlers
   ...topicsHandlers, // Topics API handlers
+  ...versionPolicyHandlers, // Version policy handlers
   ...bibleHandlers,
 ];
 
@@ -56,4 +58,5 @@ export {
   recentlyViewedBooksHandlers,
   topicsHandlers,
   userPreferencesHandlers,
+  versionPolicyHandlers,
 };

--- a/__tests__/mocks/handlers/version-policy.handlers.ts
+++ b/__tests__/mocks/handlers/version-policy.handlers.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, http } from 'msw';
+
+const API_BASE_URL = 'http://localhost:4000';
+
+export const defaultVersionPolicyResponse = {
+  minVersion: '0.0.0',
+  version: '0.0.0',
+  releaseNotes: '',
+};
+
+export const versionPolicyHandlers = [
+  http.get(`${API_BASE_URL}/api/version-policy`, () =>
+    HttpResponse.json(defaultVersionPolicyResponse)
+  ),
+];

--- a/__tests__/services/versionPolicy.test.ts
+++ b/__tests__/services/versionPolicy.test.ts
@@ -1,0 +1,114 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { checkVersionPolicy } from '@/src/services/versionPolicy';
+
+process.env.EXPO_PUBLIC_API_URL = 'http://localhost:4000';
+
+function makeResponse(body: object, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  // Spy after MSW has wrapped global.fetch so we intercept at the right layer
+  fetchSpy = jest.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+describe('checkVersionPolicy', () => {
+  describe('mustUpgrade determination', () => {
+    it('returns mustUpgrade: true when appVersion < minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '2.0.0', version: '2.0.0', releaseNotes: 'Breaking changes' })
+      );
+
+      const result = await checkVersionPolicy('1.5.0');
+
+      expect(result.mustUpgrade).toBe(true);
+      expect(result.minVersion).toBe('2.0.0');
+    });
+
+    it('returns mustUpgrade: false when appVersion equals minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '1.5.0', version: '1.5.0', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('1.5.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+
+    it('returns mustUpgrade: false when appVersion > minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '1.0.0', version: '2.0.0', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('2.1.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+  });
+
+  describe('fail-open on errors', () => {
+    it('returns mustUpgrade: false on network error', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+      const result = await checkVersionPolicy('1.0.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+
+    it('returns mustUpgrade: false on 5xx response', async () => {
+      fetchSpy.mockResolvedValueOnce(makeResponse({ error: 'Internal server error' }, 500));
+
+      const result = await checkVersionPolicy('1.0.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+  });
+
+  describe('AsyncStorage cache', () => {
+    it('returns cached result within 5-minute TTL without re-fetching', async () => {
+      fetchSpy.mockResolvedValue(
+        makeResponse({ minVersion: '3.0.0', version: '3.0.0', releaseNotes: '' })
+      );
+
+      // First call — populates cache
+      const first = await checkVersionPolicy('2.0.0');
+      expect(first.mustUpgrade).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Second call within TTL — uses cache, no additional fetch
+      const second = await checkVersionPolicy('2.0.0');
+      expect(second.mustUpgrade).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after cache TTL expires', async () => {
+      fetchSpy.mockResolvedValue(
+        makeResponse({ minVersion: '1.0.0', version: '1.0.0', releaseNotes: '' })
+      );
+
+      // Seed an expired cache entry
+      await AsyncStorage.setItem(
+        'VERSION_POLICY_CACHE',
+        JSON.stringify({
+          data: { minVersion: '1.0.0', version: '1.0.0', releaseNotes: '' },
+          fetchedAt: 0,
+        })
+      );
+
+      await checkVersionPolicy('2.0.0');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/services/word-mapping-service.test.ts
+++ b/__tests__/services/word-mapping-service.test.ts
@@ -1,4 +1,4 @@
-import { normalizeWord } from '@/services/word-mapping-service';
+import { getStrongsNumber, normalizeWord } from '@/services/word-mapping-service';
 
 describe('normalizeWord', () => {
   it('lowercases and strips punctuation', () => {
@@ -26,5 +26,21 @@ describe('normalizeWord', () => {
   it('leaves plain ASCII words unchanged apart from case', () => {
     expect(normalizeWord('LOVE')).toBe('love');
     expect(normalizeWord('Heaven')).toBe('heaven');
+  });
+});
+
+// VER-119: "Repent" in Jer 26:3 (OT) was resolving to G3340 (Greek metanoeo) instead
+// of H5162 (Hebrew nacham) because the combined map always gave Greek precedence.
+describe('getStrongsNumber testament context (VER-119)', () => {
+  it('returns Hebrew H5162 for "Repent" in OT context', () => {
+    expect(getStrongsNumber('Repent', 'OT')).toBe('H5162');
+  });
+
+  it('returns Greek G3340 for "repent" in NT context', () => {
+    expect(getStrongsNumber('repent', 'NT')).toBe('G3340');
+  });
+
+  it('falls back to Greek when no testament provided (existing behaviour)', () => {
+    expect(getStrongsNumber('repent')).toBe('G3340');
   });
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -25,7 +25,7 @@ import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import * as SystemUI from 'expo-system-ui';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { InteractionManager, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
@@ -52,6 +52,8 @@ import { setupClientInterceptors } from '@/lib/api/client-interceptors';
 import { ExpoAudioEngine } from '@/lib/audio/expoAudioEngine';
 import { StubAudioEngine } from '@/lib/audio/stubAudioEngine';
 import { I18nProvider } from '@/lib/i18n/I18nProvider';
+import { UpgradePromptScreen } from '@/src/screens/UpgradePromptScreen';
+import { checkVersionPolicy } from '@/src/services/versionPolicy';
 import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
 import { parseTopicShareUrl } from '@/utils/sharing/generate-topic-share-url';
 import { ONBOARDING_KEY } from './onboarding';
@@ -110,6 +112,31 @@ function RootLayoutInner() {
   const router = useRouter();
   const segments = useSegments();
   const hasInitialized = useRef(false);
+  const [upgradeState, setUpgradeState] = useState<{
+    mustUpgrade: boolean;
+    appVersion: string;
+    minVersion: string;
+    dismissed: boolean;
+  }>({ mustUpgrade: false, appVersion: '', minVersion: '', dismissed: false });
+
+  // Check version policy on app startup (T8)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+  useEffect(() => {
+    async function runVersionCheck() {
+      if (Platform.OS === 'web') return;
+      const appVersion = (await import('expo-constants')).default.expoConfig?.version ?? '0.0.0';
+      const result = await checkVersionPolicy(appVersion);
+      if (result.mustUpgrade) {
+        setUpgradeState({
+          mustUpgrade: true,
+          appVersion,
+          minVersion: result.minVersion,
+          dismissed: false,
+        });
+      }
+    }
+    runVersionCheck();
+  }, []);
 
   // Check onboarding status
   // biome-ignore lint/correctness/useExhaustiveDependencies: router.replace is stable but not typed as such
@@ -438,6 +465,13 @@ function RootLayoutInner() {
           />
         </Stack>
         <StatusBar style="auto" />
+        {upgradeState.mustUpgrade && !upgradeState.dismissed && (
+          <UpgradePromptScreen
+            appVersion={upgradeState.appVersion}
+            minVersion={upgradeState.minVersion}
+            onDismiss={() => setUpgradeState((prev) => ({ ...prev, dismissed: true }))}
+          />
+        )}
       </ThemeProvider>
     </AppErrorBoundary>
   );

--- a/components/bible/DictionaryModal.tsx
+++ b/components/bible/DictionaryModal.tsx
@@ -60,6 +60,8 @@ export interface DictionaryModalProps {
   word: string;
   /** Strong's number (if known from verse mapping) */
   strongsNumber?: string;
+  /** Testament context — ensures words like "repent" map to the correct language */
+  testament?: 'OT' | 'NT';
   /** Callback when modal is closed */
   onClose: () => void;
 }
@@ -77,7 +79,13 @@ interface DictionaryState {
  *
  * Bottom sheet modal for word definitions with native dictionary integration.
  */
-export function DictionaryModal({ visible, word, strongsNumber, onClose }: DictionaryModalProps) {
+export function DictionaryModal({
+  visible,
+  word,
+  strongsNumber,
+  testament,
+  onClose,
+}: DictionaryModalProps) {
   const { colors, mode } = useTheme();
   const styles = createStyles(colors, mode);
   const { showDefinition, hasDefinition, isAvailable: nativeAvailable } = useNativeDictionary();
@@ -104,8 +112,8 @@ export function DictionaryModal({ visible, word, strongsNumber, onClose }: Dicti
         let strongsNum = strongsNumber || null;
 
         // If no Strong's number provided, check word mapping
-        if (!strongsNum && hasStrongsNumber(word)) {
-          strongsNum = getStrongsNumber(word);
+        if (!strongsNum && hasStrongsNumber(word, testament)) {
+          strongsNum = getStrongsNumber(word, testament);
         }
 
         // If word looks like a Strong's number itself (e.g., "G26", "H430")

--- a/components/bible/WordDefinitionTooltip.tsx
+++ b/components/bible/WordDefinitionTooltip.tsx
@@ -35,6 +35,7 @@ import {
   View,
 } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { BIBLE_BOOKS } from '@/constants/bible-books';
 import { useTheme } from '@/contexts/ThemeContext';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { useDeviceInfo } from '@/hooks/use-device-info';
@@ -157,7 +158,8 @@ export function WordDefinitionTooltip({
 
       try {
         // Use unified dictionary service for lookup
-        const result = await lookupWord(word);
+        const bibleBook = BIBLE_BOOKS.find((b) => b.name === bookName);
+        const result = await lookupWord(word, bibleBook?.testament);
 
         // Check native dictionary availability (iOS only, or when no other source found)
         let hasNative = false;

--- a/hooks/bible/use-auto-highlights.ts
+++ b/hooks/bible/use-auto-highlights.ts
@@ -147,11 +147,13 @@ export function useAutoHighlights({
         }
 
         // Build per-theme relevance map
-        // Use custom relevance only if admin_override is true, otherwise use theme default
+        // Use custom relevance only if admin_override is true, otherwise use theme default.
+        // Fall back to relevance_threshold if default_relevance_threshold is absent from
+        // the API response (defensive against backend omitting the field).
         for (const pref of enabledPreferences) {
           themeRelevanceMap[pref.theme_id] = pref.admin_override
             ? pref.relevance_threshold
-            : pref.default_relevance_threshold;
+            : (pref.default_relevance_threshold ?? pref.relevance_threshold);
         }
       } else if (!user?.id && themesData && Array.isArray(themesData)) {
         // Logged-out user: use theme defaults

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -47,6 +47,9 @@ export {
   type SignupCompletedProperties,
   type TopicSharedProperties,
   type UserProperties,
+  type UpgradePromptCtaTappedProperties,
+  type UpgradePromptDismissedProperties,
+  type UpgradePromptShownProperties,
   type VersemateTooltipOpenedProperties,
   type ViewModeSwitchedProperties,
 } from './types';

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -57,6 +57,11 @@ export enum AnalyticsEvent {
   AUDIO_PLAYBACK_COMPLETED = 'AUDIO_PLAYBACK_COMPLETED',
   AUDIO_PLAYBACK_SEEK = 'AUDIO_PLAYBACK_SEEK',
   AUDIO_SPEED_CHANGED = 'AUDIO_SPEED_CHANGED',
+
+  // Force Upgrade Events (VER-177)
+  UPGRADE_PROMPT_SHOWN = 'upgrade_prompt_shown',
+  UPGRADE_PROMPT_CTA_TAPPED = 'upgrade_prompt_cta_tapped',
+  UPGRADE_PROMPT_DISMISSED = 'upgrade_prompt_dismissed',
 }
 
 // ============================================================================
@@ -307,6 +312,26 @@ export interface AudioSpeedChangedProperties {
 }
 
 // ============================================================================
+// Force Upgrade Event Properties (VER-177)
+// ============================================================================
+
+export interface UpgradePromptShownProperties {
+  appVersion: string;
+  minVersion: string;
+}
+
+export interface UpgradePromptCtaTappedProperties {
+  appVersion: string;
+  minVersion: string;
+  platform: 'ios' | 'android';
+}
+
+export type UpgradePromptDismissedProperties = {
+  appVersion: string;
+  minVersion: string;
+};
+
+// ============================================================================
 // Event Properties Type Map
 // ============================================================================
 
@@ -348,6 +373,10 @@ export interface EventProperties {
   [AnalyticsEvent.AUDIO_PLAYBACK_COMPLETED]: AudioPlaybackCompletedProperties;
   [AnalyticsEvent.AUDIO_PLAYBACK_SEEK]: AudioPlaybackSeekProperties;
   [AnalyticsEvent.AUDIO_SPEED_CHANGED]: AudioSpeedChangedProperties;
+  // Force Upgrade Events (VER-177)
+  [AnalyticsEvent.UPGRADE_PROMPT_SHOWN]: UpgradePromptShownProperties;
+  [AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED]: UpgradePromptCtaTappedProperties;
+  [AnalyticsEvent.UPGRADE_PROMPT_DISMISSED]: UpgradePromptDismissedProperties;
 }
 
 // ============================================================================

--- a/services/dictionary-service.ts
+++ b/services/dictionary-service.ts
@@ -13,9 +13,11 @@ import type { DictionaryResult } from '@/types/dictionary';
  * 3. Direct Strong's number lookup (if word is e.g. "G26")
  *
  * @param word - The word to look up
+ * @param testament - Optional: 'OT' or 'NT' — determines which Strong's mapping is used
+ *   for words that exist in both languages (e.g. "repent" → H5162 in OT, G3340 in NT)
  * @returns DictionaryResult with the best available definition
  */
-export async function lookupWord(word: string): Promise<DictionaryResult> {
+export async function lookupWord(word: string, testament?: 'OT' | 'NT'): Promise<DictionaryResult> {
   if (!word) {
     return { word, source: 'none' };
   }
@@ -31,8 +33,8 @@ export async function lookupWord(word: string): Promise<DictionaryResult> {
   }
 
   // 2. Try Strong's via word mapping
-  if (hasStrongsNumber(word)) {
-    const strongsNumber = getStrongsNumber(word);
+  if (hasStrongsNumber(word, testament)) {
+    const strongsNumber = getStrongsNumber(word, testament);
     if (!strongsNumber) return { word, source: 'none' };
     const result = await lookup(strongsNumber);
     if (result.found && result.entry) {

--- a/services/word-mapping-service.ts
+++ b/services/word-mapping-service.ts
@@ -95,6 +95,7 @@ const hebrewWordMappings: Record<string, string> = {
   lord: 'H3068',
   man: 'H120',
   people: 'H5971',
+  repent: 'H5162',
   righteousness: 'H6666',
   salvation: 'H3444',
   servant: 'H5650',
@@ -110,6 +111,10 @@ const wordToStrongs: Record<string, string> = {
   ...hebrewWordMappings,
   ...greekWordMappings,
 };
+
+// Testament-specific lookup tables — used when the caller knows the book context
+const wordToStrongsOT: Record<string, string> = { ...hebrewWordMappings };
+const wordToStrongsNT: Record<string, string> = { ...greekWordMappings };
 
 // Latin ligatures used in KJV typography (e.g., "Zacchæus", "Cæsar", "Phœnicia").
 // Unicode treats these as independent letters, so NFKD does not decompose them — we map explicitly.
@@ -134,28 +139,37 @@ export function normalizeWord(word: string): string {
 }
 
 /**
- * Gets the Strong's number for a given word, if mapped
+ * Gets the Strong's number for a given word, if mapped.
+ *
+ * Pass `testament` when the book context is known so that words like "repent"
+ * resolve to the correct language (H5162 in OT, G3340 in NT) instead of
+ * always defaulting to the Greek entry.
  *
  * @param word - The word to look up
+ * @param testament - Optional: 'OT' or 'NT' to prefer the correct language
  * @returns Strong's number (e.g., "G26") or null if not found
  *
  * @example
  * ```ts
+ * getStrongsNumber("repent", "OT"); // "H5162"
+ * getStrongsNumber("repent", "NT"); // "G3340"
  * getStrongsNumber("love"); // "G26"
  * getStrongsNumber("elohim"); // "H430"
  * getStrongsNumber("unknown"); // null
  * ```
  */
-export function getStrongsNumber(word: string): string | null {
+export function getStrongsNumber(word: string, testament?: 'OT' | 'NT'): string | null {
   const normalized = normalizeWord(word);
+  if (testament === 'OT') return wordToStrongsOT[normalized] || null;
+  if (testament === 'NT') return wordToStrongsNT[normalized] || null;
   return wordToStrongs[normalized] || null;
 }
 
 /**
  * Checks if a word has a Strong's number mapping
  */
-export function hasStrongsNumber(word: string): boolean {
-  return getStrongsNumber(word) !== null;
+export function hasStrongsNumber(word: string, testament?: 'OT' | 'NT'): boolean {
+  return getStrongsNumber(word, testament) !== null;
 }
 
 /**

--- a/src/screens/UpgradePromptScreen.tsx
+++ b/src/screens/UpgradePromptScreen.tsx
@@ -1,0 +1,134 @@
+import * as Linking from 'expo-linking';
+import { useEffect } from 'react';
+import { AccessibilityInfo, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '@/contexts/ThemeContext';
+import { AnalyticsEvent, analytics } from '@/lib/analytics';
+
+// TODO: replace APPLE_STORE_ID constant with real App Store Connect ID
+const APPLE_STORE_ID = 'REPLACE_ME';
+
+const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=org.versemate.app';
+const IOS_STORE_URL = `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
+
+interface UpgradePromptScreenProps {
+  appVersion: string;
+  minVersion: string;
+  onDismiss: () => void;
+}
+
+export function UpgradePromptScreen({
+  appVersion,
+  minVersion,
+  onDismiss,
+}: UpgradePromptScreenProps) {
+  const { colors, spacing, typography } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  useEffect(() => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_SHOWN, { appVersion, minVersion });
+    AccessibilityInfo.announceForAccessibility(
+      'An update is available for Verse Mate. Tap Update Now to upgrade or Maybe Later to continue.'
+    );
+  }, [appVersion, minVersion]);
+
+  const handleUpdateNow = () => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED, {
+      appVersion,
+      minVersion,
+      platform: Platform.OS === 'ios' ? 'ios' : 'android',
+    });
+    const url = Platform.OS === 'ios' ? IOS_STORE_URL : ANDROID_STORE_URL;
+    Linking.openURL(url);
+  };
+
+  const handleMaybeLater = () => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_DISMISSED, { appVersion, minVersion });
+    onDismiss();
+  };
+
+  const styles = StyleSheet.create({
+    overlay: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0,0,0,0.55)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: spacing.lg,
+    },
+    card: {
+      backgroundColor: colors.backgroundElevated,
+      borderRadius: 16,
+      padding: spacing.xl,
+      width: '100%',
+      maxWidth: 380,
+      paddingBottom: insets.bottom > 0 ? insets.bottom + spacing.md : spacing.xl,
+    },
+    title: {
+      ...typography.heading2,
+      color: colors.textPrimary,
+      marginBottom: spacing.sm,
+    },
+    body: {
+      ...typography.body,
+      color: colors.textSecondary,
+      marginBottom: spacing.xl,
+    },
+    ctaButton: {
+      backgroundColor: colors.gold,
+      borderRadius: 8,
+      paddingVertical: spacing.md,
+      alignItems: 'center',
+      marginBottom: spacing.sm,
+    },
+    ctaText: {
+      ...typography.body,
+      fontWeight: '600',
+      color: colors.white,
+    },
+    dismissButton: {
+      alignItems: 'center',
+      paddingVertical: spacing.sm,
+    },
+    dismissText: {
+      ...typography.body,
+      color: colors.textSecondary,
+    },
+  });
+
+  return (
+    <View style={styles.overlay} testID="upgrade-prompt-overlay">
+      <View style={styles.card} testID="upgrade-prompt-card">
+        <Text style={styles.title} testID="upgrade-prompt-title">
+          Update Available
+        </Text>
+        <Text style={styles.body} testID="upgrade-prompt-body">
+          A new version of Verse Mate is required to continue. Please update to the latest version
+          to keep enjoying the app.
+        </Text>
+        <Pressable
+          style={styles.ctaButton}
+          onPress={handleUpdateNow}
+          accessibilityLabel="Update Now"
+          accessibilityRole="button"
+          testID="upgrade-prompt-update-now"
+        >
+          <Text style={styles.ctaText}>Update Now</Text>
+        </Pressable>
+        <Pressable
+          style={styles.dismissButton}
+          onPress={handleMaybeLater}
+          accessibilityLabel="Maybe Later, skip upgrade"
+          accessibilityRole="button"
+          testID="upgrade-prompt-maybe-later"
+        >
+          <Text style={styles.dismissText}>Maybe Later</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/src/services/versionPolicy.ts
+++ b/src/services/versionPolicy.ts
@@ -1,0 +1,95 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const CACHE_KEY = 'VERSION_POLICY_CACHE';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const FETCH_TIMEOUT_MS = 5000;
+
+interface VersionPolicyResponse {
+  minVersion: string;
+  version: string;
+  releaseNotes: string;
+}
+
+interface CachedVersionPolicy {
+  data: VersionPolicyResponse;
+  fetchedAt: number;
+}
+
+export interface VersionPolicyResult {
+  mustUpgrade: boolean;
+  minVersion: string;
+  version: string;
+  releaseNotes: string;
+}
+
+/** Compare two semver strings X.Y.Z. Returns true if a < b. */
+function semverLessThan(a: string, b: string): boolean {
+  const parsePart = (s: string) => s.split('.').map((n) => parseInt(n, 10) || 0);
+  const [aMajor, aMinor, aPatch] = parsePart(a);
+  const [bMajor, bMinor, bPatch] = parsePart(b);
+  if (aMajor !== bMajor) return aMajor < bMajor;
+  if (aMinor !== bMinor) return aMinor < bMinor;
+  return aPatch < bPatch;
+}
+
+async function fetchVersionPolicy(baseUrl: string): Promise<VersionPolicyResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}/api/version-policy`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return (await response.json()) as VersionPolicyResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function getCachedPolicy(): Promise<VersionPolicyResponse | null> {
+  try {
+    const raw = await AsyncStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const cached: CachedVersionPolicy = JSON.parse(raw);
+    if (Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function setCachedPolicy(data: VersionPolicyResponse): Promise<void> {
+  try {
+    const cached: CachedVersionPolicy = { data, fetchedAt: Date.now() };
+    await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(cached));
+  } catch {
+    // Cache write failure is non-fatal
+  }
+}
+
+/**
+ * Check the version policy against the running app version.
+ * Returns mustUpgrade: true if appVersion < minVersion.
+ * Fails open (mustUpgrade: false) on any network or parse error.
+ */
+export async function checkVersionPolicy(appVersion: string): Promise<VersionPolicyResult> {
+  const baseUrl = process.env.EXPO_PUBLIC_API_URL ?? '';
+  const failOpen: VersionPolicyResult = {
+    mustUpgrade: false,
+    minVersion: '0.0.0',
+    version: '0.0.0',
+    releaseNotes: '',
+  };
+
+  try {
+    let policy = await getCachedPolicy();
+    if (!policy) {
+      policy = await fetchVersionPolicy(baseUrl);
+      await setCachedPolicy(policy);
+    }
+    const mustUpgrade = semverLessThan(appVersion, policy.minVersion);
+    return { mustUpgrade, ...policy };
+  } catch {
+    return failOpen;
+  }
+}


### PR DESCRIPTION
Spec: [VER-174](/VER/issues/VER-174)
Lane: Standard

- **T6** `src/services/versionPolicy.ts` — `GET /api/version-policy`, 5-min `AsyncStorage` cache, fail-open on any error/timeout
- **T7** `src/screens/UpgradePromptScreen.tsx` — dismissible overlay with "Update Now" CTA (Play Store / App Store deep-link), "Maybe Later" dismiss, a11y labels + screen announcement
- **T8** `app/_layout.tsx` — startup version check in `RootLayoutInner`; shows overlay when `mustUpgrade`, dismissed flag prevents re-show within session
- **T9** analytics events `upgrade_prompt_shown`, `upgrade_prompt_cta_tapped`, `upgrade_prompt_dismissed` added to types + fired from screen

7 unit tests covering mustUpgrade logic, fail-open, cache TTL, re-fetch on expiry — all green.