### PR TITLE
feat(onboarding): feature tour with full + "What's New" modes

### DIFF
--- a/.maestro/regression/swipe-debug-flow.yaml
+++ b/.maestro/regression/swipe-debug-flow.yaml
@@ -25,9 +25,9 @@ env:
 # is reached via the home → Bible → Genesis → chapter 1 path.
 - runFlow:
     when:
-      visible: 'Get Started'
+      visible: 'Start reading'
     commands:
-      - tapOn: 'Get Started'
+      - tapOn: 'Start reading'
 
 # Open the chapter selector and ensure we're on Genesis 1
 - runFlow:

--- a/__tests__/components/onboarding/OnboardingPreviews.test.tsx
+++ b/__tests__/components/onboarding/OnboardingPreviews.test.tsx
@@ -44,18 +44,18 @@ describe('Onboarding previews', () => {
     expect(render(<TopicsPreview />).getByText('Prophecies')).toBeTruthy();
   });
 
-  it('LexiconPreview renders the Greek definition card', () => {
+  it('LexiconPreview renders the Hebrew definition card', () => {
     const { getByText } = render(<LexiconPreview />);
-    expect(getByText('G2316')).toBeTruthy();
-    expect(getByText('θεός')).toBeTruthy();
+    expect(getByText('yom')).toBeTruthy();
+    expect(getByText('day')).toBeTruthy();
   });
 
-  it('InductivePreview renders the 9-step list', () => {
-    expect(render(<InductivePreview />).getByText('9 inductive steps')).toBeTruthy();
+  it('InductivePreview renders the observation steps', () => {
+    expect(render(<InductivePreview />).getByText('Begin with prayer')).toBeTruthy();
   });
 
-  it('VisualsPreview renders the video card', () => {
-    expect(render(<VisualsPreview />).getByText('Book Overview')).toBeTruthy();
+  it('VisualsPreview renders the visuals tab', () => {
+    expect(render(<VisualsPreview />).getByText('Visuals for Genesis 1')).toBeTruthy();
   });
 
   it('LanguagesPreview renders language chips', () => {

--- a/__tests__/components/onboarding/OnboardingPreviews.test.tsx
+++ b/__tests__/components/onboarding/OnboardingPreviews.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Smoke tests for the onboarding feature previews + slide template.
+ *
+ * These render the leaf components in isolation (theme is auto-mocked globally)
+ * to guard against runtime crashes — e.g. a missing theme token or a bad SVG
+ * prop — without needing the PagerView / router / reanimated stack.
+ */
+
+import { render } from '@testing-library/react-native';
+import {
+  InductivePreview,
+  LanguagesPreview,
+  LevelsPreview,
+  LexiconPreview,
+  SharePreview,
+  TopicsPreview,
+  VerseInsightPreview,
+  VisualsPreview,
+  WelcomePreview,
+} from '@/components/onboarding/OnboardingPreviews';
+import { OnboardingSlide } from '@/components/onboarding/OnboardingSlide';
+
+describe('OnboardingSlide', () => {
+  it('renders eyebrow, title, and body', () => {
+    const { getByText } = render(
+      <OnboardingSlide eyebrow="ORIGINAL LANGUAGES" title="Greek & Hebrew" body="A description.">
+        {null}
+      </OnboardingSlide>
+    );
+    expect(getByText('ORIGINAL LANGUAGES')).toBeTruthy();
+    expect(getByText('Greek & Hebrew')).toBeTruthy();
+    expect(getByText('A description.')).toBeTruthy();
+  });
+});
+
+describe('Onboarding previews', () => {
+  it('WelcomePreview renders the reader mock', () => {
+    expect(render(<WelcomePreview />).getByText('Genesis 1')).toBeTruthy();
+  });
+
+  it('VerseInsightPreview renders the insight card', () => {
+    expect(render(<VerseInsightPreview />).getByText('Verse Insight')).toBeTruthy();
+  });
+
+  it('LevelsPreview renders the explanation levels', () => {
+    expect(render(<LevelsPreview />).getByText('By Line')).toBeTruthy();
+  });
+
+  it('TopicsPreview renders topic rows', () => {
+    expect(render(<TopicsPreview />).getByText('Prophecies')).toBeTruthy();
+  });
+
+  it('SharePreview renders share actions', () => {
+    expect(render(<SharePreview />).getByText('Share')).toBeTruthy();
+  });
+
+  it('LexiconPreview renders the Greek definition card', () => {
+    const { getByText } = render(<LexiconPreview />);
+    expect(getByText('G2316')).toBeTruthy();
+    expect(getByText('θεός')).toBeTruthy();
+  });
+
+  it('InductivePreview renders the 9-step list', () => {
+    expect(render(<InductivePreview />).getByText('9 inductive steps')).toBeTruthy();
+  });
+
+  it('VisualsPreview renders the video card', () => {
+    expect(render(<VisualsPreview />).getByText('Book Overview')).toBeTruthy();
+  });
+
+  it('LanguagesPreview renders language chips', () => {
+    expect(render(<LanguagesPreview />).getByText('English')).toBeTruthy();
+  });
+});

--- a/__tests__/components/onboarding/OnboardingPreviews.test.tsx
+++ b/__tests__/components/onboarding/OnboardingPreviews.test.tsx
@@ -12,11 +12,9 @@ import {
   LanguagesPreview,
   LevelsPreview,
   LexiconPreview,
-  SharePreview,
   TopicsPreview,
   VerseInsightPreview,
   VisualsPreview,
-  WelcomePreview,
 } from '@/components/onboarding/OnboardingPreviews';
 import { OnboardingSlide } from '@/components/onboarding/OnboardingSlide';
 
@@ -34,10 +32,6 @@ describe('OnboardingSlide', () => {
 });
 
 describe('Onboarding previews', () => {
-  it('WelcomePreview renders the reader mock', () => {
-    expect(render(<WelcomePreview />).getByText('Genesis 1')).toBeTruthy();
-  });
-
   it('VerseInsightPreview renders the insight card', () => {
     expect(render(<VerseInsightPreview />).getByText('Verse Insight')).toBeTruthy();
   });
@@ -48,10 +42,6 @@ describe('Onboarding previews', () => {
 
   it('TopicsPreview renders topic rows', () => {
     expect(render(<TopicsPreview />).getByText('Prophecies')).toBeTruthy();
-  });
-
-  it('SharePreview renders share actions', () => {
-    expect(render(<SharePreview />).getByText('Share')).toBeTruthy();
   });
 
   it('LexiconPreview renders the Greek definition card', () => {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -57,7 +57,7 @@ import { UpgradePromptScreen } from '@/src/screens/UpgradePromptScreen';
 import { checkVersionPolicy } from '@/src/services/versionPolicy';
 import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
 import { parseTopicShareUrl } from '@/utils/sharing/generate-topic-share-url';
-import { ONBOARDING_KEY } from './onboarding';
+import { ONBOARDING_KEY, WHATS_NEW_KEY, WHATS_NEW_VERSION } from './onboarding';
 
 // Keep the splash screen visible while we fetch last read position
 SplashScreen.preventAutoHideAsync();
@@ -153,7 +153,14 @@ function RootLayoutInner() {
       try {
         const hasSeenOnboarding = await AsyncStorage.getItem(ONBOARDING_KEY);
         if (hasSeenOnboarding !== 'true') {
+          // New user / first run: show the full feature tour.
           router.replace('/onboarding');
+          return;
+        }
+        // Existing user who just updated: show only the new feature cards once.
+        const seenWhatsNew = await AsyncStorage.getItem(WHATS_NEW_KEY);
+        if (seenWhatsNew !== WHATS_NEW_VERSION) {
+          router.replace({ pathname: '/onboarding', params: { mode: 'whatsnew' } });
         }
       } catch (error) {
         console.error('Error checking onboarding status:', error);

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -19,11 +19,9 @@ import {
   LanguagesPreview,
   LevelsPreview,
   LexiconPreview,
-  SharePreview,
   TopicsPreview,
   VerseInsightPreview,
   VisualsPreview,
-  WelcomePreview,
 } from '@/components/onboarding/OnboardingPreviews';
 import { OnboardingSlide } from '@/components/onboarding/OnboardingSlide';
 import { useTheme } from '@/contexts/ThemeContext';
@@ -49,13 +47,6 @@ type Slide = {
 // the very end.
 const slides: Slide[] = [
   {
-    key: 'welcome',
-    eyebrow: 'WELCOME TO VERSEMATE',
-    title: 'The Bible was meant to be understood',
-    body: 'Not just read. VerseMate opens Scripture with clear, faithful explanations — right alongside the text.',
-    Preview: WelcomePreview,
-  },
-  {
     key: 'verse-insight',
     eyebrow: 'ANY BOOK, ANY VERSE',
     title: 'Tap any verse for deeper insight',
@@ -75,13 +66,6 @@ const slides: Slide[] = [
     title: 'Explore the bigger story',
     body: 'Follow themes, prophecies, and events across the whole of Scripture by topic.',
     Preview: TopicsPreview,
-  },
-  {
-    key: 'share',
-    eyebrow: 'MAKE IT PERSONAL',
-    title: 'Make it personal, share it forward',
-    body: 'Save highlights and share Scripture and insights with the people you love.',
-    Preview: SharePreview,
   },
   {
     key: 'lexicon',

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import { type ComponentType, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -33,6 +33,13 @@ import { colors as palette } from '@/theme/tokens';
 export const ONBOARDING_KEY = 'HAS_SEEN_ONBOARDING';
 /** Web-parity flag (mirrors verse-mate-web's `versemate-onboarding-seen`). */
 export const FEATURE_ONBOARDING_KEY = 'versemate-onboarding-seen';
+/** Tracks the latest "What's New" feature set an existing user has seen. */
+export const WHATS_NEW_KEY = 'versemate-whatsnew-seen';
+/** Bump this id whenever new feature cards are added, so existing users see them once. */
+export const WHATS_NEW_VERSION = 'greek-hebrew-inductive-visuals';
+
+/** Slide keys surfaced in "What's New" mode (the new features for existing users). */
+const WHATS_NEW_KEYS = ['lexicon', 'inductive', 'visuals'];
 
 type Slide = {
   key: string;
@@ -134,8 +141,14 @@ export default function OnboardingScreen() {
   const insets = useSafeAreaInsets();
   const { isTablet } = useDeviceInfo();
 
+  // `?mode=whatsnew` (existing users after an app update) shows only the new
+  // feature cards; the default flow shows everything (new users / first run).
+  const params = useLocalSearchParams<{ mode?: string }>();
+  const isWhatsNew = params.mode === 'whatsnew';
+  const activeSlides = isWhatsNew ? slides.filter((s) => WHATS_NEW_KEYS.includes(s.key)) : slides;
+
   const scrollOffset = useSharedValue(0);
-  const isLastPage = currentPage === slides.length - 1;
+  const isLastPage = currentPage === activeSlides.length - 1;
   const backgroundColor = mode === 'dark' ? colors.background : palette.light.bookBackground;
 
   useEffect(() => {
@@ -151,7 +164,7 @@ export default function OnboardingScreen() {
   };
 
   const handleNext = async () => {
-    if (currentPage < slides.length - 1) {
+    if (currentPage < activeSlides.length - 1) {
       pagerRef.current?.setPage(currentPage + 1);
     } else {
       await completeOnboarding('completed');
@@ -171,6 +184,7 @@ export default function OnboardingScreen() {
       await AsyncStorage.multiSet([
         [ONBOARDING_KEY, 'true'],
         [FEATURE_ONBOARDING_KEY, 'true'],
+        [WHATS_NEW_KEY, WHATS_NEW_VERSION],
       ]);
 
       // biome-ignore lint/suspicious/noExplicitAny: router.replace accepts specific strings but we pass a generic string
@@ -189,6 +203,13 @@ export default function OnboardingScreen() {
   return (
     <View style={[styles.container, { backgroundColor }]}>
       <StatusBar style={mode === 'dark' ? 'light' : 'dark'} />
+      {isWhatsNew && (
+        <View style={[styles.whatsNewHeader, { paddingTop: insets.top + 10 }]} pointerEvents="none">
+          <Text style={[styles.whatsNewText, { color: colors.gold }]}>
+            {t('onboarding.whats_new')}
+          </Text>
+        </View>
+      )}
       <PagerView
         style={styles.pagerView}
         initialPage={0}
@@ -196,7 +217,7 @@ export default function OnboardingScreen() {
         onPageSelected={(e) => setCurrentPage(e.nativeEvent.position)}
         onPageScroll={onPageScroll}
       >
-        {slides.map((slide) => (
+        {activeSlides.map((slide) => (
           <View
             key={slide.key}
             style={[styles.page, { paddingTop: insets.top + 16, paddingBottom: 188 }]}
@@ -215,7 +236,7 @@ export default function OnboardingScreen() {
 
       <View style={[styles.controls, { paddingBottom: insets.bottom + 24 }]}>
         <View style={styles.pagination}>
-          {slides.map((slide, index) => (
+          {activeSlides.map((slide, index) => (
             <PaginationDot
               key={slide.key}
               index={index}
@@ -234,11 +255,13 @@ export default function OnboardingScreen() {
             >
               <Text style={styles.primaryButtonText}>{t('onboarding.start_reading')}</Text>
             </Pressable>
-            <Pressable onPress={handleLogin} style={styles.loginButton} testID="onboarding-login">
-              <Text style={[styles.loginText, { color: colors.textSecondary }]}>
-                {t('onboarding.login')}
-              </Text>
-            </Pressable>
+            {!isWhatsNew && (
+              <Pressable onPress={handleLogin} style={styles.loginButton} testID="onboarding-login">
+                <Text style={[styles.loginText, { color: colors.textSecondary }]}>
+                  {t('onboarding.login')}
+                </Text>
+              </Pressable>
+            )}
           </View>
         ) : (
           <View style={styles.navRow}>
@@ -269,6 +292,20 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  whatsNewHeader: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 2,
+  },
+  whatsNewText: {
+    fontSize: 13,
+    fontWeight: '700',
+    letterSpacing: 1.5,
+    textTransform: 'uppercase',
   },
   pagerView: {
     flex: 1,

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,9 +1,8 @@
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Image } from 'expo-image';
 import { useRouter } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
-import { useEffect, useRef, useState } from 'react';
+import { type ComponentType, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
@@ -15,44 +14,113 @@ import Animated, {
 } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import PagerView from '@/components/common/PagerView';
+import {
+  InductivePreview,
+  LanguagesPreview,
+  LevelsPreview,
+  LexiconPreview,
+  SharePreview,
+  TopicsPreview,
+  VerseInsightPreview,
+  VisualsPreview,
+  WelcomePreview,
+} from '@/components/onboarding/OnboardingPreviews';
+import { OnboardingSlide } from '@/components/onboarding/OnboardingSlide';
+import { useTheme } from '@/contexts/ThemeContext';
 import { useDeviceInfo } from '@/hooks/use-device-info';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
+import { colors as palette } from '@/theme/tokens';
 
-const phoneSlides = [
-  require('../assets/images/onboarding/slide1.jpg'),
-  require('../assets/images/onboarding/slide2.jpg'),
-  require('../assets/images/onboarding/slide3.jpg'),
-  require('../assets/images/onboarding/slide4.jpg'),
-  require('../assets/images/onboarding/slide5.jpg'),
-  require('../assets/images/onboarding/slide6.jpg'),
-];
-
-const tabletSlides = [
-  require('../assets/images/onboarding/slide1-tablet.jpg'),
-  require('../assets/images/onboarding/slide2-tablet.jpg'),
-  require('../assets/images/onboarding/slide3-tablet.jpg'),
-  require('../assets/images/onboarding/slide4-tablet.jpg'),
-  require('../assets/images/onboarding/slide5-tablet.jpg'),
-  require('../assets/images/onboarding/slide6-tablet.jpg'),
-];
-
-const tabletLandscapeSlides = [
-  require('../assets/images/onboarding/slide1-tablet-landscape.jpg'),
-  require('../assets/images/onboarding/slide2-tablet-landscape.jpg'),
-  require('../assets/images/onboarding/slide3-tablet-landscape.jpg'),
-  require('../assets/images/onboarding/slide4-tablet-landscape.jpg'),
-  require('../assets/images/onboarding/slide5-tablet-landscape.jpg'),
-  require('../assets/images/onboarding/slide6-tablet-landscape.jpg'),
-];
-
+/** Gates the first-run redirect in app/_layout.tsx. */
 export const ONBOARDING_KEY = 'HAS_SEEN_ONBOARDING';
+/** Web-parity flag (mirrors verse-mate-web's `versemate-onboarding-seen`). */
+export const FEATURE_ONBOARDING_KEY = 'versemate-onboarding-seen';
+
+type Slide = {
+  key: string;
+  eyebrow: string;
+  title: string;
+  body: string;
+  Preview: ComponentType;
+};
+
+// Order per product: the five original welcome screens, then the three new
+// feature-tour screens, with the original "Multiple Languages" screen moved to
+// the very end.
+const slides: Slide[] = [
+  {
+    key: 'welcome',
+    eyebrow: 'WELCOME TO VERSEMATE',
+    title: 'The Bible was meant to be understood',
+    body: 'Not just read. VerseMate opens Scripture with clear, faithful explanations — right alongside the text.',
+    Preview: WelcomePreview,
+  },
+  {
+    key: 'verse-insight',
+    eyebrow: 'ANY BOOK, ANY VERSE',
+    title: 'Tap any verse for deeper insight',
+    body: 'Open any verse to reveal analysis, context, and meaning — the whole Bible, a tap away.',
+    Preview: VerseInsightPreview,
+  },
+  {
+    key: 'levels',
+    eyebrow: 'EXPLANATION LEVELS',
+    title: 'Understand Scripture at every level',
+    body: 'Choose how deep you want to go — a quick summary, line-by-line, or in-depth analysis.',
+    Preview: LevelsPreview,
+  },
+  {
+    key: 'topics',
+    eyebrow: 'TOPICS & THEMES',
+    title: 'Explore the bigger story',
+    body: 'Follow themes, prophecies, and events across the whole of Scripture by topic.',
+    Preview: TopicsPreview,
+  },
+  {
+    key: 'share',
+    eyebrow: 'MAKE IT PERSONAL',
+    title: 'Make it personal, share it forward',
+    body: 'Save highlights and share Scripture and insights with the people you love.',
+    Preview: SharePreview,
+  },
+  {
+    key: 'lexicon',
+    eyebrow: 'ORIGINAL LANGUAGES',
+    title: 'Greek & Hebrew, one tap away',
+    body: "Tap any highlighted word to reveal its original-language definition — Strong's number, pronunciation, semantic range, and related words. Read Scripture in the language it was written.",
+    Preview: LexiconPreview,
+  },
+  {
+    key: 'inductive',
+    eyebrow: 'GUIDED STUDY',
+    title: 'The inductive method, step by step',
+    body: 'Work through the proven 9-step Precept method: observe what the text says, interpret what it means, then apply it. Each chapter unfolds as guided, collapsible steps.',
+    Preview: InductivePreview,
+  },
+  {
+    key: 'visuals',
+    eyebrow: 'VISUAL LEARNING',
+    title: 'See the whole book at a glance',
+    body: 'Watch animated overviews and explore hand-drawn visual summaries for every book — from BibleProject, Insight for Living, and VerseMate originals. Tap any image to zoom in.',
+    Preview: VisualsPreview,
+  },
+  {
+    key: 'languages',
+    eyebrow: 'FOR EVERYONE',
+    title: 'Multiple languages. Always free.',
+    body: 'VerseMate is free worldwide and available in multiple languages — so anyone, anywhere can understand the Word.',
+    Preview: LanguagesPreview,
+  },
+];
 
 const PaginationDot = ({
   index,
   scrollOffset,
+  color,
 }: {
   index: number;
   scrollOffset: SharedValue<number>;
+  color: string;
 }) => {
   const animatedStyle = useAnimatedStyle(() => {
     const width = interpolate(
@@ -61,37 +129,31 @@ const PaginationDot = ({
       [8, 20, 8],
       Extrapolation.CLAMP
     );
-
     const opacity = interpolate(
       scrollOffset.value,
       [index - 1, index, index + 1],
-      [0.4, 1, 0.4],
+      [0.3, 1, 0.3],
       Extrapolation.CLAMP
     );
-
-    return {
-      width,
-      opacity,
-    };
+    return { width, opacity };
   });
 
-  return <Animated.View style={[styles.dot, animatedStyle]} />;
+  return <Animated.View style={[styles.dot, { backgroundColor: color }, animatedStyle]} />;
 };
 
 export default function OnboardingScreen() {
   const { t } = useTranslation();
   const router = useRouter();
+  const { colors, mode } = useTheme();
   const pagerRef = useRef<PagerView>(null);
   const [currentPage, setCurrentPage] = useState(0);
   const insets = useSafeAreaInsets();
+  const { isTablet } = useDeviceInfo();
 
-  const { isTablet, isLandscape } = useDeviceInfo();
-  const slides = isTablet ? (isLandscape ? tabletLandscapeSlides : tabletSlides) : phoneSlides;
-
-  // Shared value to track scroll position (0 to slides.length - 1)
   const scrollOffset = useSharedValue(0);
+  const isLastPage = currentPage === slides.length - 1;
+  const backgroundColor = mode === 'dark' ? colors.background : palette.light.bookBackground;
 
-  // Track onboarding start
   useEffect(() => {
     analytics.track(AnalyticsEvent.ONBOARDING_STARTED, {
       deviceType: isTablet ? 'tablet' : 'phone',
@@ -117,20 +179,21 @@ export default function OnboardingScreen() {
     targetPath = '/bible/1/1'
   ) => {
     try {
-      // Track completion
       analytics.track(AnalyticsEvent.ONBOARDING_COMPLETED, {
         method,
         finalSlideIndex: currentPage,
       });
 
-      // Still save to permanent storage
-      await AsyncStorage.setItem(ONBOARDING_KEY, 'true');
+      await AsyncStorage.multiSet([
+        [ONBOARDING_KEY, 'true'],
+        [FEATURE_ONBOARDING_KEY, 'true'],
+      ]);
 
-      // biome-ignore lint/suspicious/noExplicitAny: router.replace accepts specific strings but we are passing a generic string
+      // biome-ignore lint/suspicious/noExplicitAny: router.replace accepts specific strings but we pass a generic string
       router.replace(targetPath as any);
     } catch (error) {
       console.error('Failed to save onboarding status', error);
-      // biome-ignore lint/suspicious/noExplicitAny: router.replace accepts specific strings but we are passing a generic string
+      // biome-ignore lint/suspicious/noExplicitAny: router.replace accepts specific strings but we pass a generic string
       router.replace(targetPath as any);
     }
   };
@@ -140,8 +203,8 @@ export default function OnboardingScreen() {
   };
 
   return (
-    <View style={[styles.container, { paddingTop: insets.top }]}>
-      <StatusBar style="light" />
+    <View style={[styles.container, { backgroundColor }]}>
+      <StatusBar style={mode === 'dark' ? 'light' : 'dark'} />
       <PagerView
         style={styles.pagerView}
         initialPage={0}
@@ -149,54 +212,71 @@ export default function OnboardingScreen() {
         onPageSelected={(e) => setCurrentPage(e.nativeEvent.position)}
         onPageScroll={onPageScroll}
       >
-        {slides.map((slide, index) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: slides array is static and never reordered
-          <View key={index} style={styles.slide}>
-            {/* Main Image */}
-            <Image source={slide} style={styles.image} contentFit="cover" transition={200} />
+        {slides.map((slide) => (
+          <View
+            key={slide.key}
+            style={[styles.page, { paddingTop: insets.top + 16, paddingBottom: 188 }]}
+          >
+            <OnboardingSlide
+              eyebrow={slide.eyebrow}
+              title={slide.title}
+              body={slide.body}
+              testID={`onboarding-slide-${slide.key}`}
+            >
+              <slide.Preview />
+            </OnboardingSlide>
           </View>
         ))}
       </PagerView>
 
-      {/* Overlay Controls */}
-      <View style={[styles.controlsContainer, { paddingBottom: insets.bottom + 20 }]}>
-        {/* Pagination Dots */}
+      <View style={[styles.controls, { paddingBottom: insets.bottom + 24 }]}>
         <View style={styles.pagination}>
-          {slides.map((_, index) => (
+          {slides.map((slide, index) => (
             <PaginationDot
-              // biome-ignore lint/suspicious/noArrayIndexKey: slides array is static and never reordered
-              key={index}
+              key={slide.key}
               index={index}
               scrollOffset={scrollOffset}
+              color={colors.gold}
             />
           ))}
         </View>
 
-        {/* Buttons */}
-        <View style={styles.buttonContainer}>
-          {currentPage < slides.length - 1 ? (
-            <>
-              <Pressable onPress={() => completeOnboarding('skipped')} style={styles.skipButton}>
-                <Text style={styles.skipText}>{t('onboarding.skip')}</Text>
-              </Pressable>
-              <Pressable onPress={handleNext} style={styles.nextButton}>
-                <Ionicons name="arrow-forward" size={24} color="#000" />
-              </Pressable>
-            </>
-          ) : (
-            <View style={styles.finalButtonsRow}>
-              <Pressable
-                onPress={() => completeOnboarding('completed')}
-                style={styles.getStartedButton}
-              >
-                <Text style={styles.getStartedText}>{t('onboarding.get_started')}</Text>
-              </Pressable>
-              <Pressable onPress={handleLogin} style={styles.loginButton}>
-                <Text style={styles.loginText}>{t('onboarding.login')}</Text>
-              </Pressable>
-            </View>
-          )}
-        </View>
+        {isLastPage ? (
+          <View style={styles.finalButtons}>
+            <Pressable
+              onPress={() => completeOnboarding('completed')}
+              style={[styles.primaryButton, { backgroundColor: colors.gold }]}
+              testID="onboarding-start"
+            >
+              <Text style={styles.primaryButtonText}>{t('onboarding.start_reading')}</Text>
+            </Pressable>
+            <Pressable onPress={handleLogin} style={styles.loginButton} testID="onboarding-login">
+              <Text style={[styles.loginText, { color: colors.textSecondary }]}>
+                {t('onboarding.login')}
+              </Text>
+            </Pressable>
+          </View>
+        ) : (
+          <View style={styles.navRow}>
+            <Pressable
+              onPress={() => completeOnboarding('skipped')}
+              style={styles.skipButton}
+              testID="onboarding-skip"
+            >
+              <Text style={[styles.skipText, { color: colors.textSecondary }]}>
+                {t('onboarding.skip')}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={handleNext}
+              style={[styles.nextButton, { backgroundColor: colors.gold }]}
+              testID="onboarding-next"
+            >
+              <Text style={styles.nextText}>{t('onboarding.next')}</Text>
+              <Ionicons name="arrow-forward" size={18} color="#1a1a1a" />
+            </Pressable>
+          </View>
+        )}
       </View>
     </View>
   );
@@ -205,91 +285,86 @@ export default function OnboardingScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#000',
   },
   pagerView: {
     flex: 1,
   },
-  slide: {
+  page: {
     flex: 1,
+    paddingHorizontal: 8,
   },
-  image: {
-    flex: 1,
-    width: '100%',
-    height: '100%',
-  },
-  controlsContainer: {
+  controls: {
     position: 'absolute',
     bottom: 0,
     left: 0,
     right: 0,
-    paddingHorizontal: 20,
+    paddingHorizontal: 24,
     alignItems: 'center',
   },
   pagination: {
     flexDirection: 'row',
-    marginBottom: 20,
+    marginBottom: 24,
   },
   dot: {
     height: 8,
     borderRadius: 4,
-    backgroundColor: '#fff',
     marginHorizontal: 4,
   },
-  buttonContainer: {
+  navRow: {
     flexDirection: 'row',
     justifyContent: 'space-between',
-    width: '100%',
     alignItems: 'center',
-    height: 50,
-  },
-  finalButtonsRow: {
-    flexDirection: 'row',
     width: '100%',
-    gap: 12,
+    maxWidth: 460,
   },
   skipButton: {
-    padding: 10,
+    paddingVertical: 12,
+    paddingHorizontal: 8,
   },
   skipText: {
-    color: '#fff',
     fontSize: 16,
     fontWeight: '600',
   },
   nextButton: {
-    width: 50,
-    height: 50,
-    borderRadius: 25,
-    backgroundColor: '#fff',
-    justifyContent: 'center',
+    flexDirection: 'row',
     alignItems: 'center',
+    gap: 8,
+    paddingVertical: 12,
+    paddingHorizontal: 24,
+    borderRadius: 999,
+    minHeight: 48,
   },
-  getStartedButton: {
-    backgroundColor: '#fff',
-    flex: 2,
-    height: 50,
-    borderRadius: 25,
-    justifyContent: 'center',
+  nextText: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#1a1a1a',
+  },
+  finalButtons: {
+    width: '100%',
+    maxWidth: 460,
     alignItems: 'center',
+    gap: 8,
   },
-  getStartedText: {
-    color: '#000',
+  primaryButton: {
+    width: '100%',
+    minHeight: 52,
+    borderRadius: 999,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  primaryButtonText: {
     fontSize: 18,
-    fontWeight: 'bold',
+    fontWeight: '700',
+    color: '#1a1a1a',
   },
   loginButton: {
-    backgroundColor: 'rgba(255, 255, 255, 0.2)',
-    flex: 1,
-    height: 50,
-    borderRadius: 25,
-    justifyContent: 'center',
+    minHeight: 44,
     alignItems: 'center',
-    borderWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.3)',
+    justifyContent: 'center',
+    paddingHorizontal: 16,
   },
   loginText: {
-    color: '#fff',
-    fontSize: 16,
+    fontSize: 15,
     fontWeight: '600',
   },
 });

--- a/components/onboarding/OnboardingPreviews.tsx
+++ b/components/onboarding/OnboardingPreviews.tsx
@@ -1,0 +1,652 @@
+/**
+ * Onboarding feature previews
+ *
+ * Lightweight, theme-reactive recreations of each feature shown in the
+ * onboarding flow. They are built from the app's own theme tokens (gold accent,
+ * elevated surfaces, serif headings) rather than baked screenshots, so the whole
+ * tour shares one look and responds to light/dark mode.
+ *
+ * The Visuals preview uses a neutral hand-drawn placeholder on purpose — the
+ * real screen shows licensed thumbnails (BibleProject etc.) which are not ours
+ * to ship in onboarding art.
+ */
+
+import { Ionicons } from '@expo/vector-icons';
+import type { ComponentProps, ReactNode } from 'react';
+import { StyleSheet, Text, type TextStyle, View, type ViewStyle } from 'react-native';
+import Svg, { Circle, Line, Path } from 'react-native-svg';
+import { useTheme } from '@/contexts/ThemeContext';
+import { SERIF_FONT } from './OnboardingSlide';
+
+type IoniconName = ComponentProps<typeof Ionicons>['name'];
+
+/** Fixed dark ink for text/icons sitting on the gold accent (same in both themes). */
+const ON_GOLD = '#1a1a1a';
+
+const CARD_MAX_WIDTH = 340;
+
+function withAlpha(hex: string, alpha: number): string {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.substring(0, 2), 16);
+  const g = parseInt(h.substring(2, 4), 16);
+  const b = parseInt(h.substring(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+// ============================================================================
+// Shared primitives
+// ============================================================================
+
+function PreviewCard({ children, style }: { children: ReactNode; style?: ViewStyle }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={[
+        {
+          width: '100%',
+          maxWidth: CARD_MAX_WIDTH,
+          backgroundColor: colors.backgroundElevated,
+          borderRadius: 20,
+          borderWidth: StyleSheet.hairlineWidth,
+          borderColor: colors.border,
+          padding: 18,
+          shadowColor: colors.shadow,
+          shadowOffset: { width: 0, height: 8 },
+          shadowOpacity: 1,
+          shadowRadius: 16,
+          elevation: 6,
+        },
+        style,
+      ]}
+    >
+      {children}
+    </View>
+  );
+}
+
+function Pill({ label, active = false }: { label: string; active?: boolean }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        paddingVertical: 6,
+        paddingHorizontal: 14,
+        borderRadius: 999,
+        backgroundColor: active ? colors.gold : 'transparent',
+        borderWidth: active ? 0 : StyleSheet.hairlineWidth,
+        borderColor: colors.border,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 12,
+          fontWeight: '600',
+          color: active ? ON_GOLD : colors.textSecondary,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function Chip({ label, tone = 'neutral' }: { label: string; tone?: 'neutral' | 'gold' }) {
+  const { colors } = useTheme();
+  const gold = tone === 'gold';
+  return (
+    <View
+      style={{
+        paddingVertical: 4,
+        paddingHorizontal: 10,
+        borderRadius: 999,
+        backgroundColor: gold ? withAlpha(colors.gold, 0.18) : colors.backgroundSecondary,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: gold ? colors.gold : colors.border,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 12,
+          fontWeight: '500',
+          color: gold ? colors.gold : colors.textSecondary,
+        }}
+      >
+        {label}
+      </Text>
+    </View>
+  );
+}
+
+function MiniActionButton({ icon, label }: { icon: IoniconName; label: string }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        flex: 1,
+        flexDirection: 'row',
+        gap: 6,
+        alignItems: 'center',
+        justifyContent: 'center',
+        paddingVertical: 8,
+        borderRadius: 10,
+        borderWidth: StyleSheet.hairlineWidth,
+        borderColor: colors.border,
+        backgroundColor: colors.backgroundSecondary,
+      }}
+    >
+      <Ionicons name={icon} size={14} color={colors.textSecondary} />
+      <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary }}>{label}</Text>
+    </View>
+  );
+}
+
+/** Neutral hand-drawn landscape — a deliberate placeholder for licensed art. */
+function SketchPlaceholder({ height }: { height: number }) {
+  const { colors } = useTheme();
+  const stroke = colors.textTertiary;
+  return (
+    <View style={{ height, backgroundColor: colors.backgroundSecondary }}>
+      <Svg width="100%" height="100%" viewBox="0 0 200 120" preserveAspectRatio="none">
+        <Circle cx="152" cy="34" r="15" stroke={stroke} strokeWidth={2} fill="none" />
+        <Path
+          d="M0 90 Q 40 58 80 84 T 160 78 T 200 90"
+          stroke={stroke}
+          strokeWidth={2}
+          fill="none"
+        />
+        <Path d="M0 104 Q 50 80 110 100 T 200 104" stroke={stroke} strokeWidth={2} fill="none" />
+        <Line x1="18" y1="118" x2="74" y2="94" stroke={stroke} strokeWidth={2} />
+      </Svg>
+    </View>
+  );
+}
+
+// ============================================================================
+// 1 — Welcome (highlighted verses)
+// ============================================================================
+
+function VerseLine({
+  text,
+  highlight,
+  muted,
+}: {
+  text: string;
+  highlight?: string;
+  muted?: boolean;
+}) {
+  const { colors } = useTheme();
+  const base: TextStyle = {
+    fontSize: 13,
+    lineHeight: 20,
+    marginBottom: 6,
+    color: muted ? colors.textTertiary : colors.textPrimary,
+  };
+  return (
+    <Text style={highlight ? [base, { backgroundColor: highlight, borderRadius: 4 }] : base}>
+      {text}
+    </Text>
+  );
+}
+
+export function WelcomePreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <Text style={{ fontSize: 14, fontWeight: '700', color: colors.textPrimary }}>Genesis 1</Text>
+      <Text
+        style={{
+          fontSize: 10,
+          color: colors.textTertiary,
+          textTransform: 'uppercase',
+          letterSpacing: 1,
+          marginTop: 2,
+          marginBottom: 12,
+        }}
+      >
+        The Creation
+      </Text>
+      <VerseLine
+        text="In the beginning God created the heavens and the earth."
+        highlight="rgba(176,80,70,0.28)"
+      />
+      <VerseLine
+        text="The earth was formless and void, and darkness was over the surface of the deep."
+        muted
+      />
+      <VerseLine
+        text="Then God said, “Let there be light”; and there was light."
+        highlight="rgba(58,120,180,0.30)"
+      />
+      <VerseLine
+        text="God called the light day, and the darkness He called night."
+        highlight={withAlpha(colors.gold, 0.32)}
+      />
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 2 — Verse Insight
+// ============================================================================
+
+export function VerseInsightPreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <Text
+        style={{
+          textAlign: 'center',
+          color: colors.gold,
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 1,
+          textTransform: 'uppercase',
+          marginBottom: 10,
+        }}
+      >
+        Verse Insight
+      </Text>
+      <Text style={{ fontSize: 14, fontWeight: '700', color: colors.textPrimary }}>
+        Genesis 1:1
+      </Text>
+      <Text
+        style={{
+          fontSize: 13,
+          fontStyle: 'italic',
+          color: colors.textSecondary,
+          marginTop: 4,
+          marginBottom: 12,
+        }}
+      >
+        “In the beginning God created the heavens and the earth.”
+      </Text>
+      <View
+        style={{
+          height: StyleSheet.hairlineWidth,
+          backgroundColor: colors.divider,
+          marginBottom: 12,
+        }}
+      />
+      <Text style={{ fontSize: 11, fontWeight: '700', color: colors.textPrimary, marginBottom: 6 }}>
+        Analysis
+      </Text>
+      <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary, marginBottom: 14 }}>
+        God is the uncaused origin of everything — time, space, and matter begin here, created by
+        His word.
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <MiniActionButton icon="copy-outline" label="Copy" />
+        <MiniActionButton icon="share-outline" label="Share" />
+      </View>
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 3 — Levels (Summary / By Line / Detailed)
+// ============================================================================
+
+export function LevelsPreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'center', marginBottom: 14 }}>
+        <Pill label="Summary" />
+        <Pill label="By Line" active />
+        <Pill label="Detailed" />
+      </View>
+      <View
+        style={{
+          borderLeftWidth: 3,
+          borderLeftColor: colors.gold,
+          paddingLeft: 10,
+          marginBottom: 10,
+        }}
+      >
+        <Text style={{ fontSize: 12, color: colors.textPrimary }}>
+          In the beginning God created the heavens and the earth.
+        </Text>
+      </View>
+      <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary }}>
+        In Hebrew, <Text style={{ fontWeight: '700', color: colors.textPrimary }}>bara</Text> means
+        God creates by His own power — bringing something from nothing.
+      </Text>
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 4 — Topics
+// ============================================================================
+
+function TopicRow({ title, sub }: { title: string; sub: string }) {
+  const { colors } = useTheme();
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 8 }}>
+      <View style={{ flex: 1 }}>
+        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.textPrimary }}>{title}</Text>
+        <Text style={{ fontSize: 11, color: colors.textTertiary }} numberOfLines={1}>
+          {sub}
+        </Text>
+      </View>
+      <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
+    </View>
+  );
+}
+
+export function TopicsPreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <View style={{ flexDirection: 'row', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
+        <Pill label="Events" />
+        <Pill label="Prophecies" active />
+        <Pill label="Themes" />
+      </View>
+      <TopicRow title="The Seed of the Woman" sub="God foretells the serpent's defeat." />
+      <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: colors.divider }} />
+      <TopicRow title="Blessing to All Nations" sub="All nations blessed through Abraham." />
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 5 — Share
+// ============================================================================
+
+export function SharePreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <Text style={{ fontSize: 13, fontWeight: '700', color: colors.textPrimary }}>
+        Genesis 1:1
+      </Text>
+      <Text
+        style={{
+          fontSize: 13,
+          fontStyle: 'italic',
+          color: colors.textSecondary,
+          marginTop: 4,
+          marginBottom: 14,
+        }}
+      >
+        “In the beginning God created the heavens and the earth.”
+      </Text>
+      <View style={{ flexDirection: 'row', gap: 8 }}>
+        <MiniActionButton icon="copy-outline" label="Copy" />
+        <MiniActionButton icon="share-social-outline" label="Share" />
+        <MiniActionButton icon="bookmark-outline" label="Save" />
+      </View>
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 6 — Greek & Hebrew lexicon definition (NEW)
+// ============================================================================
+
+export function LexiconPreview() {
+  const { colors } = useTheme();
+  return (
+    <View style={{ width: '100%', maxWidth: CARD_MAX_WIDTH, alignItems: 'center' }}>
+      <Text
+        style={{
+          position: 'absolute',
+          top: -8,
+          left: 6,
+          right: 6,
+          fontSize: 13,
+          lineHeight: 22,
+          color: colors.textPrimary,
+          opacity: 0.07,
+        }}
+      >
+        In the beginning was the Word, and the Word was with God, and the Word was God. He was in
+        the beginning with God.
+      </Text>
+      <PreviewCard>
+        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 }}>
+          <View
+            style={{
+              backgroundColor: colors.gold,
+              borderRadius: 6,
+              paddingHorizontal: 8,
+              paddingVertical: 3,
+            }}
+          >
+            <Text style={{ fontSize: 11, fontWeight: '700', color: ON_GOLD }}>G2316</Text>
+          </View>
+          <Text style={{ fontSize: 11, color: colors.textTertiary }}>Strong’s · noun</Text>
+        </View>
+        <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 8 }}>
+          <Text style={{ fontFamily: SERIF_FONT, fontSize: 28, color: colors.textPrimary }}>
+            θεός
+          </Text>
+          <Text style={{ fontSize: 13, fontStyle: 'italic', color: colors.textSecondary }}>
+            the·os
+          </Text>
+        </View>
+        <Text
+          style={{
+            fontSize: 12,
+            lineHeight: 18,
+            color: colors.textSecondary,
+            marginTop: 6,
+            marginBottom: 14,
+          }}
+        >
+          God; the supreme Divinity; the one true God.
+        </Text>
+        <Text
+          style={{
+            fontSize: 10,
+            fontWeight: '700',
+            letterSpacing: 1,
+            textTransform: 'uppercase',
+            color: colors.textTertiary,
+            marginBottom: 8,
+          }}
+        >
+          Related words
+        </Text>
+        <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap' }}>
+          <Chip label="θεότης" />
+          <Chip label="θεῖος" />
+          <Chip label="divine" tone="gold" />
+        </View>
+      </PreviewCard>
+    </View>
+  );
+}
+
+// ============================================================================
+// 7 — Inductive study method (NEW)
+// ============================================================================
+
+function InductiveStep({ n, label, open = false }: { n: number; label: string; open?: boolean }) {
+  const { colors } = useTheme();
+  return (
+    <View style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 7 }}>
+      <View
+        style={{
+          width: 22,
+          height: 22,
+          borderRadius: 11,
+          backgroundColor: open ? colors.gold : colors.backgroundSecondary,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginRight: 10,
+          borderWidth: open ? 0 : StyleSheet.hairlineWidth,
+          borderColor: colors.border,
+        }}
+      >
+        <Text
+          style={{ fontSize: 11, fontWeight: '700', color: open ? ON_GOLD : colors.textSecondary }}
+        >
+          {n}
+        </Text>
+      </View>
+      <Text
+        style={{
+          flex: 1,
+          fontSize: 13,
+          fontWeight: open ? '600' : '400',
+          color: open ? colors.textPrimary : colors.textSecondary,
+        }}
+      >
+        {label}
+      </Text>
+      <Ionicons
+        name={open ? 'chevron-down' : 'chevron-forward'}
+        size={15}
+        color={colors.textTertiary}
+      />
+    </View>
+  );
+}
+
+export function InductivePreview() {
+  const { colors } = useTheme();
+  return (
+    <PreviewCard>
+      <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'center', marginBottom: 12 }}>
+        <Pill label="Observe" active />
+        <Pill label="Interpret" />
+        <Pill label="Apply" />
+      </View>
+      <Text
+        style={{
+          fontSize: 11,
+          fontWeight: '700',
+          letterSpacing: 0.5,
+          color: colors.textTertiary,
+          textTransform: 'uppercase',
+          marginBottom: 2,
+        }}
+      >
+        9 inductive steps
+      </Text>
+      <InductiveStep n={1} label="Observe what the text says" open />
+      <InductiveStep n={2} label="Ask who, what, when, where" />
+      <InductiveStep n={3} label="Interpret what it means" />
+      <InductiveStep n={4} label="Apply it to your life" />
+      <Text style={{ fontSize: 11, color: colors.textTertiary, marginTop: 4, marginLeft: 32 }}>
+        + 5 more steps
+      </Text>
+    </PreviewCard>
+  );
+}
+
+// ============================================================================
+// 8 — Visuals (NEW)
+// ============================================================================
+
+export function VisualsPreview() {
+  const { colors } = useTheme();
+  const cardFrame: ViewStyle = {
+    borderRadius: 16,
+    overflow: 'hidden',
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: colors.border,
+    backgroundColor: colors.backgroundElevated,
+  };
+  return (
+    <View style={{ width: '100%', maxWidth: CARD_MAX_WIDTH, gap: 12 }}>
+      <View style={cardFrame}>
+        <View>
+          <SketchPlaceholder height={128} />
+          <View
+            style={[
+              StyleSheet.absoluteFillObject,
+              { alignItems: 'center', justifyContent: 'center' },
+            ]}
+          >
+            <View
+              style={{
+                width: 48,
+                height: 48,
+                borderRadius: 24,
+                backgroundColor: colors.gold,
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <Ionicons name="play" size={22} color={ON_GOLD} style={{ marginLeft: 2 }} />
+            </View>
+          </View>
+        </View>
+        <View
+          style={{
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: 10,
+          }}
+        >
+          <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textPrimary }}>
+            Book Overview
+          </Text>
+          <View
+            style={{
+              backgroundColor: colors.backgroundSecondary,
+              paddingHorizontal: 8,
+              paddingVertical: 2,
+              borderRadius: 6,
+            }}
+          >
+            <Text style={{ fontSize: 10, letterSpacing: 1, color: colors.textTertiary }}>
+              VIDEO
+            </Text>
+          </View>
+        </View>
+      </View>
+
+      <View style={cardFrame}>
+        <View>
+          <SketchPlaceholder height={84} />
+          <View
+            style={{
+              position: 'absolute',
+              top: 8,
+              right: 8,
+              width: 26,
+              height: 26,
+              borderRadius: 13,
+              backgroundColor: colors.backgroundOverlay,
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Ionicons name="scan-outline" size={14} color={colors.textPrimary} />
+          </View>
+        </View>
+        <View style={{ padding: 10 }}>
+          <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textPrimary }}>
+            Visual summary
+          </Text>
+        </View>
+      </View>
+    </View>
+  );
+}
+
+// ============================================================================
+// 9 — Multiple languages (relocated to the end)
+// ============================================================================
+
+export function LanguagesPreview() {
+  const { colors } = useTheme();
+  return (
+    <View style={{ width: '100%', maxWidth: CARD_MAX_WIDTH, alignItems: 'center', gap: 20 }}>
+      <Ionicons name="globe-outline" size={92} color={colors.gold} />
+      <View style={{ flexDirection: 'row', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Chip label="English" />
+        <Chip label="Español" />
+        <Chip label="Français" />
+        <Chip label="Português" />
+        <Chip label="Deutsch" />
+        <Chip label="Always free" tone="gold" />
+      </View>
+    </View>
+  );
+}

--- a/components/onboarding/OnboardingPreviews.tsx
+++ b/components/onboarding/OnboardingPreviews.tsx
@@ -13,7 +13,7 @@
 
 import { Ionicons } from '@expo/vector-icons';
 import type { ComponentProps, ReactNode } from 'react';
-import { StyleSheet, Text, type TextStyle, View, type ViewStyle } from 'react-native';
+import { StyleSheet, Text, View, type ViewStyle } from 'react-native';
 import Svg, { Circle, Line, Path } from 'react-native-svg';
 import { useTheme } from '@/contexts/ThemeContext';
 import { SERIF_FONT } from './OnboardingSlide';
@@ -162,71 +162,7 @@ function SketchPlaceholder({ height }: { height: number }) {
 }
 
 // ============================================================================
-// 1 — Welcome (highlighted verses)
-// ============================================================================
-
-function VerseLine({
-  text,
-  highlight,
-  muted,
-}: {
-  text: string;
-  highlight?: string;
-  muted?: boolean;
-}) {
-  const { colors } = useTheme();
-  const base: TextStyle = {
-    fontSize: 13,
-    lineHeight: 20,
-    marginBottom: 6,
-    color: muted ? colors.textTertiary : colors.textPrimary,
-  };
-  return (
-    <Text style={highlight ? [base, { backgroundColor: highlight, borderRadius: 4 }] : base}>
-      {text}
-    </Text>
-  );
-}
-
-export function WelcomePreview() {
-  const { colors } = useTheme();
-  return (
-    <PreviewCard>
-      <Text style={{ fontSize: 14, fontWeight: '700', color: colors.textPrimary }}>Genesis 1</Text>
-      <Text
-        style={{
-          fontSize: 10,
-          color: colors.textTertiary,
-          textTransform: 'uppercase',
-          letterSpacing: 1,
-          marginTop: 2,
-          marginBottom: 12,
-        }}
-      >
-        The Creation
-      </Text>
-      <VerseLine
-        text="In the beginning God created the heavens and the earth."
-        highlight="rgba(176,80,70,0.28)"
-      />
-      <VerseLine
-        text="The earth was formless and void, and darkness was over the surface of the deep."
-        muted
-      />
-      <VerseLine
-        text="Then God said, “Let there be light”; and there was light."
-        highlight="rgba(58,120,180,0.30)"
-      />
-      <VerseLine
-        text="God called the light day, and the darkness He called night."
-        highlight={withAlpha(colors.gold, 0.32)}
-      />
-    </PreviewCard>
-  );
-}
-
-// ============================================================================
-// 2 — Verse Insight
+// 1 — Verse Insight
 // ============================================================================
 
 export function VerseInsightPreview() {
@@ -283,7 +219,7 @@ export function VerseInsightPreview() {
 }
 
 // ============================================================================
-// 3 — Levels (Summary / By Line / Detailed)
+// 2 — Levels (Summary / By Line / Detailed)
 // ============================================================================
 
 export function LevelsPreview() {
@@ -316,7 +252,7 @@ export function LevelsPreview() {
 }
 
 // ============================================================================
-// 4 — Topics
+// 3 — Topics
 // ============================================================================
 
 function TopicRow({ title, sub }: { title: string; sub: string }) {
@@ -351,38 +287,7 @@ export function TopicsPreview() {
 }
 
 // ============================================================================
-// 5 — Share
-// ============================================================================
-
-export function SharePreview() {
-  const { colors } = useTheme();
-  return (
-    <PreviewCard>
-      <Text style={{ fontSize: 13, fontWeight: '700', color: colors.textPrimary }}>
-        Genesis 1:1
-      </Text>
-      <Text
-        style={{
-          fontSize: 13,
-          fontStyle: 'italic',
-          color: colors.textSecondary,
-          marginTop: 4,
-          marginBottom: 14,
-        }}
-      >
-        “In the beginning God created the heavens and the earth.”
-      </Text>
-      <View style={{ flexDirection: 'row', gap: 8 }}>
-        <MiniActionButton icon="copy-outline" label="Copy" />
-        <MiniActionButton icon="share-social-outline" label="Share" />
-        <MiniActionButton icon="bookmark-outline" label="Save" />
-      </View>
-    </PreviewCard>
-  );
-}
-
-// ============================================================================
-// 6 — Greek & Hebrew lexicon definition (NEW)
+// 4 — Greek & Hebrew lexicon definition (NEW)
 // ============================================================================
 
 export function LexiconPreview() {
@@ -460,7 +365,7 @@ export function LexiconPreview() {
 }
 
 // ============================================================================
-// 7 — Inductive study method (NEW)
+// 5 — Inductive study method (NEW)
 // ============================================================================
 
 function InductiveStep({ n, label, open = false }: { n: number; label: string; open?: boolean }) {
@@ -538,7 +443,7 @@ export function InductivePreview() {
 }
 
 // ============================================================================
-// 8 — Visuals (NEW)
+// 6 — Visuals (NEW)
 // ============================================================================
 
 export function VisualsPreview() {
@@ -631,7 +536,7 @@ export function VisualsPreview() {
 }
 
 // ============================================================================
-// 9 — Multiple languages (relocated to the end)
+// 7 — Multiple languages (last screen)
 // ============================================================================
 
 export function LanguagesPreview() {

--- a/components/onboarding/OnboardingPreviews.tsx
+++ b/components/onboarding/OnboardingPreviews.tsx
@@ -1,14 +1,16 @@
 /**
  * Onboarding feature previews
  *
- * Lightweight, theme-reactive recreations of each feature shown in the
- * onboarding flow. They are built from the app's own theme tokens (gold accent,
- * elevated surfaces, serif headings) rather than baked screenshots, so the whole
- * tour shares one look and responds to light/dark mode.
+ * Theme-reactive recreations of each real in-app screen shown in the onboarding
+ * flow, built from the app's own theme tokens (gold accent, elevated surfaces,
+ * serif headings) rather than baked screenshots — so the tour responds to
+ * light/dark mode and stays visually consistent.
  *
- * The Visuals preview uses a neutral hand-drawn placeholder on purpose — the
- * real screen shows licensed thumbnails (BibleProject etc.) which are not ours
- * to ship in onboarding art.
+ * Layouts mirror the real product UI (Verse Insight sheet, the Insight level
+ * tabs, the Topics browser, the Hebrew/Greek lexicon card, the inductive
+ * observation steps, and the Visuals tab). The Visuals thumbnail uses a neutral
+ * hand-drawn placeholder on purpose — the real screen shows licensed BibleProject
+ * art which is not ours to ship in onboarding.
  */
 
 import { Ionicons } from '@expo/vector-icons';
@@ -49,7 +51,7 @@ function PreviewCard({ children, style }: { children: ReactNode; style?: ViewSty
           borderRadius: 20,
           borderWidth: StyleSheet.hairlineWidth,
           borderColor: colors.border,
-          padding: 18,
+          padding: 16,
           shadowColor: colors.shadow,
           shadowOffset: { width: 0, height: 8 },
           shadowOpacity: 1,
@@ -64,13 +66,21 @@ function PreviewCard({ children, style }: { children: ReactNode; style?: ViewSty
   );
 }
 
-function Pill({ label, active = false }: { label: string; active?: boolean }) {
+function Pill({
+  label,
+  active = false,
+  small = false,
+}: {
+  label: string;
+  active?: boolean;
+  small?: boolean;
+}) {
   const { colors } = useTheme();
   return (
     <View
       style={{
-        paddingVertical: 6,
-        paddingHorizontal: 14,
+        paddingVertical: small ? 5 : 6,
+        paddingHorizontal: small ? 10 : 14,
         borderRadius: 999,
         backgroundColor: active ? colors.gold : 'transparent',
         borderWidth: active ? 0 : StyleSheet.hairlineWidth,
@@ -79,7 +89,7 @@ function Pill({ label, active = false }: { label: string; active?: boolean }) {
     >
       <Text
         style={{
-          fontSize: 12,
+          fontSize: small ? 11 : 12,
           fontWeight: '600',
           color: active ? ON_GOLD : colors.textSecondary,
         }}
@@ -134,8 +144,79 @@ function MiniActionButton({ icon, label }: { icon: IoniconName; label: string })
         backgroundColor: colors.backgroundSecondary,
       }}
     >
-      <Ionicons name={icon} size={14} color={colors.textSecondary} />
-      <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textSecondary }}>{label}</Text>
+      <Ionicons name={icon} size={13} color={colors.textSecondary} />
+      <Text style={{ fontSize: 11, fontWeight: '600', color: colors.textSecondary }}>{label}</Text>
+    </View>
+  );
+}
+
+/** Gold uppercase section label, matching the in-app eyebrow style. */
+function SectionLabel({ children }: { children: string }) {
+  const { colors } = useTheme();
+  return (
+    <Text
+      style={{
+        fontSize: 10,
+        fontWeight: '700',
+        letterSpacing: 1,
+        color: colors.gold,
+        textTransform: 'uppercase',
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+
+function Divider({ my = 10 }: { my?: number }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        height: StyleSheet.hairlineWidth,
+        backgroundColor: colors.divider,
+        marginVertical: my,
+      }}
+    />
+  );
+}
+
+/** The four Insight level tabs (Summary · By Line · Study · Visuals). */
+function InsightTabs({ active }: { active: 'Summary' | 'By Line' | 'Study' | 'Visuals' }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        flexDirection: 'row',
+        justifyContent: 'center',
+        gap: 4,
+        backgroundColor: colors.backgroundSecondary,
+        borderRadius: 999,
+        padding: 4,
+        alignSelf: 'center',
+      }}
+    >
+      {(['Summary', 'By Line', 'Study', 'Visuals'] as const).map((t) => (
+        <Pill key={t} label={t} active={t === active} small />
+      ))}
+    </View>
+  );
+}
+
+function RoundIcon({ icon, size = 26 }: { icon: IoniconName; size?: number }) {
+  const { colors } = useTheme();
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: size / 2,
+        backgroundColor: colors.backgroundSecondary,
+        alignItems: 'center',
+        justifyContent: 'center',
+      }}
+    >
+      <Ionicons name={icon} size={size * 0.55} color={colors.textSecondary} />
     </View>
   );
 }
@@ -162,91 +243,149 @@ function SketchPlaceholder({ height }: { height: number }) {
 }
 
 // ============================================================================
-// 1 — Verse Insight
+// 1 — Verse Insight (bottom sheet)
 // ============================================================================
 
 export function VerseInsightPreview() {
   const { colors } = useTheme();
   return (
     <PreviewCard>
+      <View
+        style={{
+          width: 36,
+          height: 4,
+          borderRadius: 2,
+          backgroundColor: colors.border,
+          alignSelf: 'center',
+          marginBottom: 12,
+        }}
+      />
       <Text
         style={{
           textAlign: 'center',
           color: colors.gold,
-          fontSize: 11,
+          fontSize: 13,
           fontWeight: '700',
-          letterSpacing: 1,
-          textTransform: 'uppercase',
-          marginBottom: 10,
+          marginBottom: 8,
         }}
       >
         Verse Insight
       </Text>
-      <Text style={{ fontSize: 14, fontWeight: '700', color: colors.textPrimary }}>
-        Genesis 1:1
-      </Text>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: 8,
+        }}
+      >
+        <RoundIcon icon="chevron-back" />
+        <Text style={{ fontSize: 15, fontWeight: '700', color: colors.textPrimary }}>
+          Genesis 1:4
+        </Text>
+        <RoundIcon icon="chevron-forward" />
+      </View>
       <Text
         style={{
-          fontSize: 13,
+          fontSize: 12,
           fontStyle: 'italic',
           color: colors.textSecondary,
-          marginTop: 4,
+          textAlign: 'center',
           marginBottom: 12,
         }}
       >
-        “In the beginning God created the heavens and the earth.”
+        “God saw that the light was good; and God separated the light from the darkness.”
       </Text>
       <View
         style={{
-          height: StyleSheet.hairlineWidth,
-          backgroundColor: colors.divider,
+          backgroundColor: colors.backgroundSecondary,
+          borderRadius: 12,
+          padding: 12,
           marginBottom: 12,
         }}
-      />
-      <Text style={{ fontSize: 11, fontWeight: '700', color: colors.textPrimary, marginBottom: 6 }}>
-        Analysis
-      </Text>
-      <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary, marginBottom: 14 }}>
-        God is the uncaused origin of everything — time, space, and matter begin here, created by
-        His word.
-      </Text>
-      <View style={{ flexDirection: 'row', gap: 8 }}>
+      >
+        <Text
+          style={{ fontSize: 12, fontWeight: '700', color: colors.textPrimary, marginBottom: 6 }}
+        >
+          Summary
+        </Text>
+        <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary }}>
+          God looks at the light and calls it good, then separates light from darkness — showing
+          that creation’s order is good and right.
+        </Text>
+        <Divider my={10} />
+        <SectionLabel>Cross references</SectionLabel>
+        <View style={{ flexDirection: 'row', marginTop: 6 }}>
+          <Chip label="Genesis 1:4" />
+        </View>
+      </View>
+      <View style={{ flexDirection: 'row', gap: 8, marginBottom: 12 }}>
         <MiniActionButton icon="copy-outline" label="Copy" />
         <MiniActionButton icon="share-outline" label="Share" />
+        <MiniActionButton icon="bookmark-outline" label="Save" />
+      </View>
+      <View
+        style={{
+          backgroundColor: colors.gold,
+          borderRadius: 12,
+          paddingVertical: 11,
+          alignItems: 'center',
+        }}
+      >
+        <Text style={{ fontSize: 14, fontWeight: '700', color: ON_GOLD }}>Close</Text>
       </View>
     </PreviewCard>
   );
 }
 
 // ============================================================================
-// 2 — Levels (Summary / By Line / Detailed)
+// 2 — Explanation levels (By Line)
 // ============================================================================
 
 export function LevelsPreview() {
   const { colors } = useTheme();
   return (
     <PreviewCard>
-      <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'center', marginBottom: 14 }}>
-        <Pill label="Summary" />
-        <Pill label="By Line" active />
-        <Pill label="Detailed" />
-      </View>
+      <InsightTabs active="By Line" />
+      <Text style={{ fontSize: 13, fontWeight: '700', color: colors.textPrimary, marginTop: 14 }}>
+        Genesis 1:1
+      </Text>
       <View
         style={{
           borderLeftWidth: 3,
           borderLeftColor: colors.gold,
           paddingLeft: 10,
+          marginTop: 6,
           marginBottom: 10,
         }}
       >
-        <Text style={{ fontSize: 12, color: colors.textPrimary }}>
+        <Text style={{ fontSize: 12, fontStyle: 'italic', color: colors.textSecondary }}>
           In the beginning God created the heavens and the earth.
         </Text>
       </View>
-      <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary }}>
-        In Hebrew, <Text style={{ fontWeight: '700', color: colors.textPrimary }}>bara</Text> means
-        God creates by His own power — bringing something from nothing.
+      <Text style={{ fontSize: 11, fontWeight: '700', color: colors.textPrimary, marginBottom: 4 }}>
+        Summary
       </Text>
+      <Text style={{ fontSize: 12, lineHeight: 18, color: colors.textSecondary, marginBottom: 10 }}>
+        In Hebrew, <Text style={{ fontWeight: '700', color: colors.textPrimary }}>bara</Text> means
+        God creates by His own power. The subject is{' '}
+        <Text style={{ fontWeight: '700', color: colors.textPrimary }}>Elohim</Text>, the mighty
+        personal God.
+      </Text>
+      <Divider my={0} />
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingTop: 10,
+        }}
+      >
+        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.textPrimary }}>
+          Genesis 1:2
+        </Text>
+        <Ionicons name="chevron-down" size={16} color={colors.textTertiary} />
+      </View>
     </PreviewCard>
   );
 }
@@ -255,16 +394,18 @@ export function LevelsPreview() {
 // 3 — Topics
 // ============================================================================
 
-function TopicRow({ title, sub }: { title: string; sub: string }) {
+function TopicRow({ title }: { title: string }) {
   const { colors } = useTheme();
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 8 }}>
-      <View style={{ flex: 1 }}>
-        <Text style={{ fontSize: 13, fontWeight: '600', color: colors.textPrimary }}>{title}</Text>
-        <Text style={{ fontSize: 11, color: colors.textTertiary }} numberOfLines={1}>
-          {sub}
-        </Text>
-      </View>
+    <View
+      style={{
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        paddingVertical: 9,
+      }}
+    >
+      <Text style={{ fontSize: 13, color: colors.textPrimary }}>{title}</Text>
       <Ionicons name="chevron-forward" size={16} color={colors.textTertiary} />
     </View>
   );
@@ -274,20 +415,81 @@ export function TopicsPreview() {
   const { colors } = useTheme();
   return (
     <PreviewCard>
-      <View style={{ flexDirection: 'row', gap: 6, marginBottom: 6, flexWrap: 'wrap' }}>
-        <Pill label="Events" />
-        <Pill label="Prophecies" active />
-        <Pill label="Themes" />
+      <View
+        style={{
+          flexDirection: 'row',
+          backgroundColor: colors.backgroundSecondary,
+          borderRadius: 999,
+          padding: 4,
+          marginBottom: 10,
+        }}
+      >
+        {(['Old Testament', 'New Testament', 'Topics'] as const).map((t) => {
+          const active = t === 'Topics';
+          return (
+            <View
+              key={t}
+              style={{
+                flex: 1,
+                paddingVertical: 6,
+                borderRadius: 999,
+                alignItems: 'center',
+                backgroundColor: active ? colors.gold : 'transparent',
+              }}
+            >
+              <Text
+                style={{
+                  fontSize: 10,
+                  fontWeight: '600',
+                  color: active ? ON_GOLD : colors.textSecondary,
+                }}
+              >
+                {t}
+              </Text>
+            </View>
+          );
+        })}
       </View>
-      <TopicRow title="The Seed of the Woman" sub="God foretells the serpent's defeat." />
-      <View style={{ height: StyleSheet.hairlineWidth, backgroundColor: colors.divider }} />
-      <TopicRow title="Blessing to All Nations" sub="All nations blessed through Abraham." />
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: 6,
+          marginBottom: 10,
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+        }}
+      >
+        <Pill label="Events" active small />
+        <Pill label="Prophecies" small />
+        <Pill label="Parables" small />
+        <Pill label="Themes" small />
+      </View>
+      <View
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: 8,
+          backgroundColor: colors.backgroundSecondary,
+          borderRadius: 999,
+          paddingVertical: 8,
+          paddingHorizontal: 12,
+          marginBottom: 6,
+        }}
+      >
+        <Ionicons name="search" size={14} color={colors.textTertiary} />
+        <Text style={{ fontSize: 12, color: colors.textTertiary }}>Search…</Text>
+      </View>
+      <TopicRow title="The Creation of the World" />
+      <Divider my={0} />
+      <TopicRow title="The Fall of Man" />
+      <Divider my={0} />
+      <TopicRow title="The Great Flood" />
     </PreviewCard>
   );
 }
 
 // ============================================================================
-// 4 — Greek & Hebrew lexicon definition (NEW)
+// 4 — Greek & Hebrew lexicon definition
 // ============================================================================
 
 export function LexiconPreview() {
@@ -297,7 +499,7 @@ export function LexiconPreview() {
       <Text
         style={{
           position: 'absolute',
-          top: -8,
+          top: -10,
           left: 6,
           right: 6,
           fontSize: 13,
@@ -306,58 +508,40 @@ export function LexiconPreview() {
           opacity: 0.07,
         }}
       >
-        In the beginning was the Word, and the Word was with God, and the Word was God. He was in
-        the beginning with God.
+        Consider it all joy when you encounter various trials, knowing that the testing of your
+        faith produces endurance.
       </Text>
       <PreviewCard>
-        <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 10 }}>
-          <View
-            style={{
-              backgroundColor: colors.gold,
-              borderRadius: 6,
-              paddingHorizontal: 8,
-              paddingVertical: 3,
-            }}
-          >
-            <Text style={{ fontSize: 11, fontWeight: '700', color: ON_GOLD }}>G2316</Text>
-          </View>
-          <Text style={{ fontSize: 11, color: colors.textTertiary }}>Strong’s · noun</Text>
-        </View>
-        <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 8 }}>
-          <Text style={{ fontFamily: SERIF_FONT, fontSize: 28, color: colors.textPrimary }}>
-            θεός
+        <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 10 }}>
+          <Text style={{ fontFamily: SERIF_FONT, fontSize: 26, color: colors.textPrimary }}>
+            יוֹם
           </Text>
-          <Text style={{ fontSize: 13, fontStyle: 'italic', color: colors.textSecondary }}>
-            the·os
-          </Text>
+          <Text style={{ fontSize: 16, fontWeight: '600', color: colors.gold }}>yom</Text>
         </View>
-        <Text
-          style={{
-            fontSize: 12,
-            lineHeight: 18,
-            color: colors.textSecondary,
-            marginTop: 6,
-            marginBottom: 14,
-          }}
-        >
-          God; the supreme Divinity; the one true God.
+        <Text style={{ fontSize: 11, color: colors.textTertiary, marginTop: 4 }}>
+          Noun (masc.) · H3117 · 2037× in OT
         </Text>
-        <Text
-          style={{
-            fontSize: 10,
-            fontWeight: '700',
-            letterSpacing: 1,
-            textTransform: 'uppercase',
-            color: colors.textTertiary,
-            marginBottom: 8,
-          }}
-        >
-          Related words
+        <Divider my={12} />
+        <SectionLabel>Basic sense</SectionLabel>
+        <Text style={{ fontSize: 13, color: colors.textPrimary, marginTop: 4 }}>day</Text>
+        <Divider my={12} />
+        <SectionLabel>Semantic range</SectionLabel>
+        <Text style={{ fontSize: 12, lineHeight: 17, color: colors.textSecondary, marginTop: 4 }}>
+          • a 24-hour period marked by evening and morning
         </Text>
-        <View style={{ flexDirection: 'row', gap: 6, flexWrap: 'wrap' }}>
-          <Chip label="θεότης" />
-          <Chip label="θεῖος" />
-          <Chip label="divine" tone="gold" />
+        <Text style={{ fontSize: 12, lineHeight: 17, color: colors.textSecondary }}>
+          • daylight hours; the light portion of a day
+        </Text>
+        <Divider my={12} />
+        <SectionLabel>Related</SectionLabel>
+        <View style={{ flexDirection: 'row', alignItems: 'baseline', gap: 8, marginTop: 6 }}>
+          <Text style={{ fontFamily: SERIF_FONT, fontSize: 14, color: colors.textPrimary }}>
+            יוֹמָם
+          </Text>
+          <Text style={{ fontSize: 12, fontWeight: '600', color: colors.gold }}>yomam</Text>
+          <Text style={{ fontSize: 11, color: colors.textTertiary, flex: 1 }}>
+            by day; during the day
+          </Text>
         </View>
       </PreviewCard>
     </View>
@@ -365,47 +549,39 @@ export function LexiconPreview() {
 }
 
 // ============================================================================
-// 5 — Inductive study method (NEW)
+// 5 — Inductive study method (Observation)
 // ============================================================================
 
-function InductiveStep({ n, label, open = false }: { n: number; label: string; open?: boolean }) {
+function ObservationStep({ n, title, note }: { n: number; title: string; note: string }) {
   const { colors } = useTheme();
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', paddingVertical: 7 }}>
+    <View style={{ flexDirection: 'row', paddingVertical: 8 }}>
       <View
         style={{
           width: 22,
           height: 22,
           borderRadius: 11,
-          backgroundColor: open ? colors.gold : colors.backgroundSecondary,
+          backgroundColor: colors.gold,
           alignItems: 'center',
           justifyContent: 'center',
           marginRight: 10,
-          borderWidth: open ? 0 : StyleSheet.hairlineWidth,
-          borderColor: colors.border,
         }}
       >
-        <Text
-          style={{ fontSize: 11, fontWeight: '700', color: open ? ON_GOLD : colors.textSecondary }}
+        <Text style={{ fontSize: 11, fontWeight: '700', color: ON_GOLD }}>{n}</Text>
+      </View>
+      <View style={{ flex: 1 }}>
+        <View
+          style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}
         >
-          {n}
+          <Text style={{ fontSize: 13, fontWeight: '600', color: colors.textPrimary }}>
+            {title}
+          </Text>
+          <Ionicons name="chevron-down" size={15} color={colors.textTertiary} />
+        </View>
+        <Text style={{ fontSize: 11, lineHeight: 16, color: colors.textTertiary, marginTop: 2 }}>
+          {note}
         </Text>
       </View>
-      <Text
-        style={{
-          flex: 1,
-          fontSize: 13,
-          fontWeight: open ? '600' : '400',
-          color: open ? colors.textPrimary : colors.textSecondary,
-        }}
-      >
-        {label}
-      </Text>
-      <Ionicons
-        name={open ? 'chevron-down' : 'chevron-forward'}
-        size={15}
-        color={colors.textTertiary}
-      />
     </View>
   );
 }
@@ -414,36 +590,44 @@ export function InductivePreview() {
   const { colors } = useTheme();
   return (
     <PreviewCard>
-      <View style={{ flexDirection: 'row', gap: 8, justifyContent: 'center', marginBottom: 12 }}>
-        <Pill label="Observe" active />
-        <Pill label="Interpret" />
-        <Pill label="Apply" />
+      <InsightTabs active="Study" />
+      <View style={{ marginTop: 12, marginBottom: 4 }}>
+        <SectionLabel>Observation — 9 inductive steps</SectionLabel>
       </View>
-      <Text
+      <View
         style={{
-          fontSize: 11,
-          fontWeight: '700',
-          letterSpacing: 0.5,
-          color: colors.textTertiary,
-          textTransform: 'uppercase',
-          marginBottom: 2,
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          paddingBottom: 4,
         }}
       >
-        9 inductive steps
-      </Text>
-      <InductiveStep n={1} label="Observe what the text says" open />
-      <InductiveStep n={2} label="Ask who, what, when, where" />
-      <InductiveStep n={3} label="Interpret what it means" />
-      <InductiveStep n={4} label="Apply it to your life" />
-      <Text style={{ fontSize: 11, color: colors.textTertiary, marginTop: 4, marginLeft: 32 }}>
-        + 5 more steps
-      </Text>
+        <Text style={{ fontSize: 13, fontWeight: '700', color: colors.textPrimary }}>
+          About the nine observation steps
+        </Text>
+        <Ionicons name="chevron-down" size={15} color={colors.textTertiary} />
+      </View>
+      <ObservationStep
+        n={1}
+        title="Begin with prayer"
+        note="Apart from the Holy Spirit’s illumination this is just a method."
+      />
+      <ObservationStep
+        n={2}
+        title="Ask the 5 W’s and an H"
+        note="Setting the table — author, audience, occasion."
+      />
+      <ObservationStep
+        n={3}
+        title="Mark key words and phrases"
+        note="Repeated words carry the author’s purpose."
+      />
     </PreviewCard>
   );
 }
 
 // ============================================================================
-// 6 — Visuals (NEW)
+// 6 — Visuals
 // ============================================================================
 
 export function VisualsPreview() {
@@ -456,10 +640,20 @@ export function VisualsPreview() {
     backgroundColor: colors.backgroundElevated,
   };
   return (
-    <View style={{ width: '100%', maxWidth: CARD_MAX_WIDTH, gap: 12 }}>
+    <View style={{ width: '100%', maxWidth: CARD_MAX_WIDTH, gap: 10 }}>
+      <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+        <Text style={{ fontSize: 13, fontWeight: '700', color: colors.textPrimary }}>
+          Visuals for Genesis 1
+        </Text>
+        <View style={{ flexDirection: 'row', gap: 12 }}>
+          <Ionicons name="copy-outline" size={15} color={colors.textTertiary} />
+          <Ionicons name="share-outline" size={15} color={colors.textTertiary} />
+        </View>
+      </View>
+
       <View style={cardFrame}>
         <View>
-          <SketchPlaceholder height={128} />
+          <SketchPlaceholder height={132} />
           <View
             style={[
               StyleSheet.absoluteFillObject,
@@ -479,28 +673,24 @@ export function VisualsPreview() {
               <Ionicons name="play" size={22} color={ON_GOLD} style={{ marginLeft: 2 }} />
             </View>
           </View>
-        </View>
-        <View
-          style={{
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: 10,
-          }}
-        >
-          <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textPrimary }}>
-            Book Overview
-          </Text>
           <View
             style={{
-              backgroundColor: colors.backgroundSecondary,
-              paddingHorizontal: 8,
-              paddingVertical: 2,
-              borderRadius: 6,
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              bottom: 0,
+              padding: 10,
+              backgroundColor: 'rgba(0,0,0,0.5)',
             }}
           >
-            <Text style={{ fontSize: 10, letterSpacing: 1, color: colors.textTertiary }}>
-              VIDEO
+            <Text style={{ fontSize: 13, fontWeight: '700', color: '#ffffff' }}>
+              Genesis 1–11 — Overview
+            </Text>
+            <Text style={{ fontSize: 10, color: 'rgba(255,255,255,0.85)' }}>
+              BibleProject overview · animated explainer
+            </Text>
+            <Text style={{ fontSize: 9, color: 'rgba(255,255,255,0.7)', marginTop: 2 }}>
+              BibleProject · CC BY-SA 4.0
             </Text>
           </View>
         </View>
@@ -508,7 +698,7 @@ export function VisualsPreview() {
 
       <View style={cardFrame}>
         <View>
-          <SketchPlaceholder height={84} />
+          <SketchPlaceholder height={78} />
           <View
             style={{
               position: 'absolute',
@@ -524,11 +714,6 @@ export function VisualsPreview() {
           >
             <Ionicons name="scan-outline" size={14} color={colors.textPrimary} />
           </View>
-        </View>
-        <View style={{ padding: 10 }}>
-          <Text style={{ fontSize: 12, fontWeight: '600', color: colors.textPrimary }}>
-            Visual summary
-          </Text>
         </View>
       </View>
     </View>

--- a/components/onboarding/OnboardingSlide.tsx
+++ b/components/onboarding/OnboardingSlide.tsx
@@ -1,0 +1,90 @@
+/**
+ * OnboardingSlide
+ *
+ * Shared layout for every onboarding screen: a feature preview on top, then an
+ * eyebrow label, a serif title, and a description. Theme-reactive (light/dark)
+ * via the app's ThemeContext. Used by both the original welcome screens and the
+ * new feature-tour screens so the whole flow shares one look and feel.
+ */
+
+import type { ReactNode } from 'react';
+import { Platform, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+
+/**
+ * Cross-platform serif stack for onboarding titles. React Native has no
+ * `serif` alias on iOS, so we name a bundled system serif per platform.
+ */
+export const SERIF_FONT = Platform.select({
+  ios: 'Georgia',
+  android: 'serif',
+  default: 'Georgia',
+});
+
+interface OnboardingSlideProps {
+  eyebrow: string;
+  title: string;
+  body: string;
+  /** Feature preview rendered above the text block. */
+  children: ReactNode;
+  testID?: string;
+}
+
+export function OnboardingSlide({ eyebrow, title, body, children, testID }: OnboardingSlideProps) {
+  const { colors } = useTheme();
+
+  return (
+    <View style={styles.container} testID={testID}>
+      <View style={styles.previewWrap}>{children}</View>
+
+      <View style={styles.textBlock}>
+        <Text style={[styles.eyebrow, { color: colors.gold }]}>{eyebrow}</Text>
+        <Text style={[styles.title, { color: colors.textPrimary }]}>{title}</Text>
+        <Text style={[styles.body, { color: colors.textSecondary }]}>{body}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    width: '100%',
+    maxWidth: 520,
+    alignSelf: 'center',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 24,
+    gap: 32,
+  },
+  previewWrap: {
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  textBlock: {
+    width: '100%',
+    alignItems: 'center',
+    gap: 12,
+  },
+  eyebrow: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 1.6,
+    textTransform: 'uppercase',
+    textAlign: 'center',
+  },
+  title: {
+    fontFamily: SERIF_FONT,
+    fontSize: 30,
+    fontWeight: '700',
+    lineHeight: 38,
+    textAlign: 'center',
+  },
+  body: {
+    fontSize: 16,
+    lineHeight: 24,
+    textAlign: 'center',
+    maxWidth: 420,
+  },
+});

--- a/locales/de.json
+++ b/locales/de.json
@@ -43,7 +43,8 @@
     "skip": "Überspringen",
     "next": "Weiter",
     "get_started": "Loslegen",
-    "login": "Anmelden"
+    "login": "Anmelden",
+    "start_reading": "Lesen beginnen"
   },
 
   "settings": {

--- a/locales/de.json
+++ b/locales/de.json
@@ -44,7 +44,8 @@
     "next": "Weiter",
     "get_started": "Loslegen",
     "login": "Anmelden",
-    "start_reading": "Lesen beginnen"
+    "start_reading": "Lesen beginnen",
+    "whats_new": "Neuigkeiten"
   },
 
   "settings": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -43,7 +43,8 @@
     "skip": "Skip",
     "next": "Next",
     "get_started": "Get Started",
-    "login": "Log In"
+    "login": "Log In",
+    "start_reading": "Start reading"
   },
 
   "settings": {

--- a/locales/en.json
+++ b/locales/en.json
@@ -44,7 +44,8 @@
     "next": "Next",
     "get_started": "Get Started",
     "login": "Log In",
-    "start_reading": "Start reading"
+    "start_reading": "Start reading",
+    "whats_new": "What's New"
   },
 
   "settings": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -44,7 +44,8 @@
     "next": "Siguiente",
     "get_started": "Comenzar",
     "login": "Iniciar sesión",
-    "start_reading": "Empezar a leer"
+    "start_reading": "Empezar a leer",
+    "whats_new": "Novedades"
   },
 
   "settings": {

--- a/locales/es.json
+++ b/locales/es.json
@@ -43,7 +43,8 @@
     "skip": "Omitir",
     "next": "Siguiente",
     "get_started": "Comenzar",
-    "login": "Iniciar sesión"
+    "login": "Iniciar sesión",
+    "start_reading": "Empezar a leer"
   },
 
   "settings": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -43,7 +43,8 @@
     "skip": "Passer",
     "next": "Suivant",
     "get_started": "Commencer",
-    "login": "Se connecter"
+    "login": "Se connecter",
+    "start_reading": "Commencer la lecture"
   },
 
   "settings": {

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -44,7 +44,8 @@
     "next": "Suivant",
     "get_started": "Commencer",
     "login": "Se connecter",
-    "start_reading": "Commencer la lecture"
+    "start_reading": "Commencer la lecture",
+    "whats_new": "Nouveautés"
   },
 
   "settings": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -44,7 +44,8 @@
     "next": "Próximo",
     "get_started": "Começar",
     "login": "Entrar",
-    "start_reading": "Começar a ler"
+    "start_reading": "Começar a ler",
+    "whats_new": "Novidades"
   },
 
   "settings": {

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -43,7 +43,8 @@
     "skip": "Pular",
     "next": "Próximo",
     "get_started": "Começar",
-    "login": "Entrar"
+    "login": "Entrar",
+    "start_reading": "Começar a ler"
   },
 
   "settings": {


### PR DESCRIPTION
## Summary

Adds a first-run feature onboarding tour (mirroring verse-mate-web PR #192) and folds it into the app's existing onboarding as one unified, theme-reactive flow. Two entry modes:

- **New users / first run** → the full **7-screen** tour: Verse Insight → Explanation Levels → Topics → **Greek & Hebrew** → **Inductive Method** → **Visuals** → Multiple Languages → *Start reading*.
- **Existing users after an app update** → a **"What's New"** pass showing only the new cards (**Greek & Hebrew · Inductive · Visuals**), with a "WHAT'S NEW" header and *Start reading* (no Log In).

All screens share one template (feature preview on top, gold eyebrow, serif title, description) and recreate the real in-app UI from theme tokens (no baked screenshots), so they respond to light/dark mode. The Visuals thumbnail uses a neutral hand-drawn placeholder by design (real BibleProject art is licensed).

## How it works

- `app/onboarding.tsx` — single `PagerView` flow; `?mode=whatsnew` filters to the new-feature cards.
- `app/_layout.tsx` — on launch: no `HAS_SEEN_ONBOARDING` → full tour; already onboarded but `versemate-whatsnew-seen` ≠ `WHATS_NEW_VERSION` → `/onboarding?mode=whatsnew`. Completing either flow stamps the version so What's New shows once.
- To surface future features, bump `WHATS_NEW_VERSION` and extend `WHATS_NEW_KEYS`.
- `components/onboarding/` — `OnboardingSlide` (template) + `OnboardingPreviews` (the recreated feature cards).
- New `onboarding.start_reading` / `onboarding.whats_new` strings added to all 5 locales.

## E2E

The flow stays a route dismissed via the existing **"Skip"** button, so the current Maestro setup flows are unaffected; stable testIDs added (`onboarding-skip` / `-next` / `-start` / `-login`). What's New only triggers for warm/existing users, so fresh-install (`clearState`) e2e runs always see the full flow.

## Test plan

- [x] `bun run type-check` clean
- [x] Biome + ESLint clean (only the repo's intentional `i18next/no-literal-string` warnings)
- [x] `npm test` — added render smoke tests for the previews + slide template (pass)
- [x] Rendered both modes (full + What's New) in light + dark from the Expo-web build to verify layout
- [ ] Verify on a real iOS/Android device (fonts, shadows, spacing differ slightly from web)
- [ ] Confirm existing-user upgrade path shows What's New once

https://claude.ai/code/session_01AxjtAGjDKA8fQ4UzwFu19R

---
_Generated by [Claude Code](https://claude.ai/code/session_01AxjtAGjDKA8fQ4UzwFu19R)_