### PR TITLE
feat: force upgrade prompt (VER-177)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 bun lint-staged
-node --max-old-space-size=4096 ./node_modules/.bin/tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo
+bun tsc --noEmit --skipLibCheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,2 @@
 bun lint-staged
-bun tsc --noEmit --skipLibCheck
+node --max-old-space-size=4096 ./node_modules/.bin/tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo

--- a/__tests__/mocks/handlers/index.ts
+++ b/__tests__/mocks/handlers/index.ts
@@ -21,6 +21,7 @@ import { recentlyViewedBooksHandlers } from './recently-viewed-books.handlers';
 import { topicsHandlers } from './topics.handlers';
 import { userPreferencesHandlers } from './user-preferences';
 import { verseHandlers } from './verses';
+import { versionPolicyHandlers } from './version-policy.handlers';
 
 // Combine all handlers
 // IMPORTANT: Bookmark, highlights, and notes handlers must come BEFORE bible handlers to prevent
@@ -38,6 +39,7 @@ export const handlers = [
   ...languagesHandlers, // Languages API handlers
   ...userPreferencesHandlers, // User preferences handlers
   ...topicsHandlers, // Topics API handlers
+  ...versionPolicyHandlers, // Version policy handlers
   ...bibleHandlers,
 ];
 
@@ -56,4 +58,5 @@ export {
   recentlyViewedBooksHandlers,
   topicsHandlers,
   userPreferencesHandlers,
+  versionPolicyHandlers,
 };

--- a/__tests__/mocks/handlers/version-policy.handlers.ts
+++ b/__tests__/mocks/handlers/version-policy.handlers.ts
@@ -1,0 +1,15 @@
+import { HttpResponse, http } from 'msw';
+
+const API_BASE_URL = 'http://localhost:4000';
+
+export const defaultVersionPolicyResponse = {
+  minVersion: '0.0.0',
+  version: '0.0.0',
+  releaseNotes: '',
+};
+
+export const versionPolicyHandlers = [
+  http.get(`${API_BASE_URL}/api/version-policy`, () =>
+    HttpResponse.json(defaultVersionPolicyResponse)
+  ),
+];

--- a/__tests__/screens/UpgradePromptScreen.test.tsx
+++ b/__tests__/screens/UpgradePromptScreen.test.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as Linking from 'expo-linking';
+import { useState } from 'react';
+import { Platform } from 'react-native';
+import { UpgradePromptScreen } from '@/src/screens/UpgradePromptScreen';
+import { checkVersionPolicy } from '@/src/services/versionPolicy';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+jest.mock('@/contexts/ThemeContext', () => ({
+  useTheme: () => ({
+    colors: {
+      backgroundElevated: '#fff',
+      textPrimary: '#000',
+      textSecondary: '#666',
+      gold: '#b09a6d',
+      white: '#fff',
+    },
+    spacing: { sm: 8, md: 12, lg: 16, xl: 20 },
+    typography: {
+      heading2: { fontSize: 20, fontWeight: '600', lineHeight: 28 },
+      body: { fontSize: 16, fontWeight: '400', lineHeight: 24 },
+    },
+  }),
+}));
+
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 0, left: 0 }),
+}));
+
+jest.mock('expo-linking', () => ({
+  openURL: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/lib/analytics', () => ({
+  analytics: { track: jest.fn() },
+  AnalyticsEvent: {
+    VERSION_POLICY_FETCHED: 'version_policy_fetched',
+    UPGRADE_PROMPT_SHOWN: 'upgrade_prompt_shown',
+    UPGRADE_PROMPT_CTA_TAPPED: 'upgrade_prompt_cta_tapped',
+    UPGRADE_PROMPT_DISMISSED: 'upgrade_prompt_dismissed',
+  },
+}));
+
+jest.mock('@/src/services/versionPolicy');
+
+const mockCheckVersionPolicy = checkVersionPolicy as jest.MockedFunction<typeof checkVersionPolicy>;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── T7: UpgradePromptScreen component ───────────────────────────────────────
+
+describe('UpgradePromptScreen', () => {
+  it('renders title, body, and both buttons', () => {
+    render(<UpgradePromptScreen currentVersion="1.5.0" minVersion="2.0.0" onDismiss={jest.fn()} />);
+
+    expect(screen.getByTestId('upgrade-prompt-title')).toBeTruthy();
+    expect(screen.getByTestId('upgrade-prompt-body')).toBeTruthy();
+    expect(screen.getByTestId('upgrade-prompt-update-now')).toBeTruthy();
+    expect(screen.getByTestId('upgrade-prompt-maybe-later')).toBeTruthy();
+  });
+
+  it('"Update Now" opens Play Store URL on Android', () => {
+    jest.spyOn(Platform, 'OS', 'get').mockReturnValue('android');
+
+    render(<UpgradePromptScreen currentVersion="1.5.0" minVersion="2.0.0" onDismiss={jest.fn()} />);
+
+    fireEvent.press(screen.getByTestId('upgrade-prompt-update-now'));
+
+    expect(Linking.openURL).toHaveBeenCalledWith(
+      'https://play.google.com/store/apps/details?id=org.versemate.app'
+    );
+  });
+
+  it('"Update Now" opens App Store URL on iOS', () => {
+    jest.spyOn(Platform, 'OS', 'get').mockReturnValue('ios');
+
+    render(<UpgradePromptScreen currentVersion="1.5.0" minVersion="2.0.0" onDismiss={jest.fn()} />);
+
+    fireEvent.press(screen.getByTestId('upgrade-prompt-update-now'));
+
+    const calledUrl = (Linking.openURL as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toMatch(/^https:\/\/apps\.apple\.com\//);
+  });
+
+  it('"Maybe Later" calls onDismiss', () => {
+    const onDismiss = jest.fn();
+
+    render(<UpgradePromptScreen currentVersion="1.5.0" minVersion="2.0.0" onDismiss={onDismiss} />);
+
+    fireEvent.press(screen.getByTestId('upgrade-prompt-maybe-later'));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('has correct a11y labels', () => {
+    render(<UpgradePromptScreen currentVersion="1.5.0" minVersion="2.0.0" onDismiss={jest.fn()} />);
+
+    expect(screen.getByLabelText('Update Now')).toBeTruthy();
+    expect(screen.getByLabelText('Maybe Later, skip upgrade')).toBeTruthy();
+  });
+});
+
+// ─── T8: startup integration — overlay shown/hidden based on mustUpgrade ─────
+
+function VersionGate() {
+  const [upgradeState, setUpgradeState] = useState<{
+    mustUpgrade: boolean;
+    currentVersion: string;
+    minVersion: string;
+    dismissed: boolean;
+  }>({ mustUpgrade: false, currentVersion: '', minVersion: '', dismissed: false });
+  const [checked, setChecked] = useState(false);
+
+  const runCheck = async () => {
+    const result = await checkVersionPolicy('1.5.0');
+    setUpgradeState({
+      mustUpgrade: result.mustUpgrade,
+      currentVersion: '1.5.0',
+      minVersion: result.minVersion,
+      dismissed: false,
+    });
+    setChecked(true);
+  };
+
+  if (!checked) {
+    runCheck();
+    return null;
+  }
+
+  return upgradeState.mustUpgrade && !upgradeState.dismissed ? (
+    <UpgradePromptScreen
+      currentVersion={upgradeState.currentVersion}
+      minVersion={upgradeState.minVersion}
+      onDismiss={() => setUpgradeState((prev) => ({ ...prev, dismissed: true }))}
+    />
+  ) : null;
+}
+
+describe('T8 startup integration', () => {
+  it('shows upgrade prompt when mustUpgrade is true', async () => {
+    mockCheckVersionPolicy.mockResolvedValueOnce({
+      mustUpgrade: true,
+      minVersion: '2.0.0',
+      version: '2.0.0',
+      releaseNotes: '',
+    });
+
+    render(<VersionGate />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upgrade-prompt-overlay')).toBeTruthy();
+    });
+  });
+
+  it('does not show upgrade prompt when mustUpgrade is false', async () => {
+    mockCheckVersionPolicy.mockResolvedValueOnce({
+      mustUpgrade: false,
+      minVersion: '1.0.0',
+      version: '2.0.0',
+      releaseNotes: '',
+    });
+
+    render(<VersionGate />);
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('upgrade-prompt-overlay')).toBeNull();
+    });
+  });
+
+  it('hides upgrade prompt after "Maybe Later" is pressed', async () => {
+    mockCheckVersionPolicy.mockResolvedValueOnce({
+      mustUpgrade: true,
+      minVersion: '2.0.0',
+      version: '2.0.0',
+      releaseNotes: '',
+    });
+
+    render(<VersionGate />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('upgrade-prompt-overlay')).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId('upgrade-prompt-maybe-later'));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('upgrade-prompt-overlay')).toBeNull();
+    });
+  });
+});

--- a/__tests__/services/versionPolicy.test.ts
+++ b/__tests__/services/versionPolicy.test.ts
@@ -14,10 +14,18 @@ jest.mock('@/lib/analytics', () => ({
 }));
 
 function makeResponse(body: object, status = 200): Response {
+  const bodyStr = JSON.stringify(body);
   return {
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(body),
+    text: () => Promise.resolve(bodyStr),
+    headers: {
+      get: (name: string) => {
+        if (name.toLowerCase() === 'content-type') return 'application/json';
+        return null;
+      },
+    },
   } as unknown as Response;
 }
 

--- a/__tests__/services/versionPolicy.test.ts
+++ b/__tests__/services/versionPolicy.test.ts
@@ -3,6 +3,16 @@ import { checkVersionPolicy } from '@/src/services/versionPolicy';
 
 process.env.EXPO_PUBLIC_API_URL = 'http://localhost:4000';
 
+jest.mock('@/lib/analytics', () => ({
+  analytics: { track: jest.fn() },
+  AnalyticsEvent: {
+    VERSION_POLICY_FETCHED: 'version_policy_fetched',
+    UPGRADE_PROMPT_SHOWN: 'upgrade_prompt_shown',
+    UPGRADE_PROMPT_CTA_TAPPED: 'upgrade_prompt_cta_tapped',
+    UPGRADE_PROMPT_DISMISSED: 'upgrade_prompt_dismissed',
+  },
+}));
+
 function makeResponse(body: object, status = 200): Response {
   return {
     ok: status >= 200 && status < 300,
@@ -15,7 +25,6 @@ let fetchSpy: jest.SpyInstance;
 
 beforeEach(async () => {
   await AsyncStorage.clear();
-  // Spy after MSW has wrapped global.fetch so we intercept at the right layer
   fetchSpy = jest.spyOn(global, 'fetch');
 });
 
@@ -25,7 +34,7 @@ afterEach(() => {
 
 describe('checkVersionPolicy', () => {
   describe('mustUpgrade determination', () => {
-    it('returns mustUpgrade: true when appVersion < minVersion', async () => {
+    it('returns mustUpgrade: true when currentVersion < minVersion', async () => {
       fetchSpy.mockResolvedValueOnce(
         makeResponse({ minVersion: '2.0.0', version: '2.0.0', releaseNotes: 'Breaking changes' })
       );
@@ -36,7 +45,7 @@ describe('checkVersionPolicy', () => {
       expect(result.minVersion).toBe('2.0.0');
     });
 
-    it('returns mustUpgrade: false when appVersion equals minVersion', async () => {
+    it('returns mustUpgrade: false when currentVersion equals minVersion', async () => {
       fetchSpy.mockResolvedValueOnce(
         makeResponse({ minVersion: '1.5.0', version: '1.5.0', releaseNotes: '' })
       );
@@ -46,7 +55,7 @@ describe('checkVersionPolicy', () => {
       expect(result.mustUpgrade).toBe(false);
     });
 
-    it('returns mustUpgrade: false when appVersion > minVersion', async () => {
+    it('returns mustUpgrade: false when currentVersion > minVersion', async () => {
       fetchSpy.mockResolvedValueOnce(
         makeResponse({ minVersion: '1.0.0', version: '2.0.0', releaseNotes: '' })
       );
@@ -54,6 +63,26 @@ describe('checkVersionPolicy', () => {
       const result = await checkVersionPolicy('2.1.0');
 
       expect(result.mustUpgrade).toBe(false);
+    });
+
+    it('handles prerelease correctly: 3.6.1-rc.1 < 3.6.1', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '3.6.1', version: '3.6.1', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('3.6.1-rc.1');
+
+      expect(result.mustUpgrade).toBe(true);
+    });
+
+    it('handles double-digit minor: 3.9.0 < 3.10.0', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '3.10.0', version: '3.10.0', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('3.9.0');
+
+      expect(result.mustUpgrade).toBe(true);
     });
   });
 

--- a/__tests__/services/versionPolicy.test.ts
+++ b/__tests__/services/versionPolicy.test.ts
@@ -1,0 +1,114 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { checkVersionPolicy } from '@/src/services/versionPolicy';
+
+process.env.EXPO_PUBLIC_API_URL = 'http://localhost:4000';
+
+function makeResponse(body: object, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+let fetchSpy: jest.SpyInstance;
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+  // Spy after MSW has wrapped global.fetch so we intercept at the right layer
+  fetchSpy = jest.spyOn(global, 'fetch');
+});
+
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+describe('checkVersionPolicy', () => {
+  describe('mustUpgrade determination', () => {
+    it('returns mustUpgrade: true when appVersion < minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '2.0.0', version: '2.0.0', releaseNotes: 'Breaking changes' })
+      );
+
+      const result = await checkVersionPolicy('1.5.0');
+
+      expect(result.mustUpgrade).toBe(true);
+      expect(result.minVersion).toBe('2.0.0');
+    });
+
+    it('returns mustUpgrade: false when appVersion equals minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '1.5.0', version: '1.5.0', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('1.5.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+
+    it('returns mustUpgrade: false when appVersion > minVersion', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        makeResponse({ minVersion: '1.0.0', version: '2.0.0', releaseNotes: '' })
+      );
+
+      const result = await checkVersionPolicy('2.1.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+  });
+
+  describe('fail-open on errors', () => {
+    it('returns mustUpgrade: false on network error', async () => {
+      fetchSpy.mockRejectedValueOnce(new TypeError('Network request failed'));
+
+      const result = await checkVersionPolicy('1.0.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+
+    it('returns mustUpgrade: false on 5xx response', async () => {
+      fetchSpy.mockResolvedValueOnce(makeResponse({ error: 'Internal server error' }, 500));
+
+      const result = await checkVersionPolicy('1.0.0');
+
+      expect(result.mustUpgrade).toBe(false);
+    });
+  });
+
+  describe('AsyncStorage cache', () => {
+    it('returns cached result within 5-minute TTL without re-fetching', async () => {
+      fetchSpy.mockResolvedValue(
+        makeResponse({ minVersion: '3.0.0', version: '3.0.0', releaseNotes: '' })
+      );
+
+      // First call — populates cache
+      const first = await checkVersionPolicy('2.0.0');
+      expect(first.mustUpgrade).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+      // Second call within TTL — uses cache, no additional fetch
+      const second = await checkVersionPolicy('2.0.0');
+      expect(second.mustUpgrade).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-fetches after cache TTL expires', async () => {
+      fetchSpy.mockResolvedValue(
+        makeResponse({ minVersion: '1.0.0', version: '1.0.0', releaseNotes: '' })
+      );
+
+      // Seed an expired cache entry
+      await AsyncStorage.setItem(
+        'VERSION_POLICY_CACHE',
+        JSON.stringify({
+          data: { minVersion: '1.0.0', version: '1.0.0', releaseNotes: '' },
+          fetchedAt: 0,
+        })
+      );
+
+      await checkVersionPolicy('2.0.0');
+
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -115,22 +115,23 @@ function RootLayoutInner() {
   const hasInitialized = useRef(false);
   const [upgradeState, setUpgradeState] = useState<{
     mustUpgrade: boolean;
-    appVersion: string;
+    currentVersion: string;
     minVersion: string;
     dismissed: boolean;
-  }>({ mustUpgrade: false, appVersion: '', minVersion: '', dismissed: false });
+  }>({ mustUpgrade: false, currentVersion: '', minVersion: '', dismissed: false });
 
   // Check version policy on app startup (T8)
   // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
   useEffect(() => {
     async function runVersionCheck() {
       if (Platform.OS === 'web') return;
-      const appVersion = (await import('expo-constants')).default.expoConfig?.version ?? '0.0.0';
-      const result = await checkVersionPolicy(appVersion);
+      const currentVersion =
+        (await import('expo-constants')).default.expoConfig?.version ?? '0.0.0';
+      const result = await checkVersionPolicy(currentVersion);
       if (result.mustUpgrade) {
         setUpgradeState({
           mustUpgrade: true,
-          appVersion,
+          currentVersion,
           minVersion: result.minVersion,
           dismissed: false,
         });
@@ -484,7 +485,7 @@ function RootLayoutInner() {
         <StatusBar style="auto" />
         {upgradeState.mustUpgrade && !upgradeState.dismissed && (
           <UpgradePromptScreen
-            appVersion={upgradeState.appVersion}
+            currentVersion={upgradeState.currentVersion}
             minVersion={upgradeState.minVersion}
             onDismiss={() => setUpgradeState((prev) => ({ ...prev, dismissed: true }))}
           />

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -26,7 +26,7 @@ import { Stack, useRouter, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import * as SystemUI from 'expo-system-ui';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { InteractionManager, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
@@ -53,6 +53,8 @@ import { setupClientInterceptors } from '@/lib/api/client-interceptors';
 import { ExpoAudioEngine } from '@/lib/audio/expoAudioEngine';
 import { StubAudioEngine } from '@/lib/audio/stubAudioEngine';
 import { I18nProvider } from '@/lib/i18n/I18nProvider';
+import { UpgradePromptScreen } from '@/src/screens/UpgradePromptScreen';
+import { checkVersionPolicy } from '@/src/services/versionPolicy';
 import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
 import { parseTopicShareUrl } from '@/utils/sharing/generate-topic-share-url';
 import { ONBOARDING_KEY } from './onboarding';
@@ -111,6 +113,31 @@ function RootLayoutInner() {
   const router = useRouter();
   const segments = useSegments();
   const hasInitialized = useRef(false);
+  const [upgradeState, setUpgradeState] = useState<{
+    mustUpgrade: boolean;
+    appVersion: string;
+    minVersion: string;
+    dismissed: boolean;
+  }>({ mustUpgrade: false, appVersion: '', minVersion: '', dismissed: false });
+
+  // Check version policy on app startup (T8)
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run once on mount
+  useEffect(() => {
+    async function runVersionCheck() {
+      if (Platform.OS === 'web') return;
+      const appVersion = (await import('expo-constants')).default.expoConfig?.version ?? '0.0.0';
+      const result = await checkVersionPolicy(appVersion);
+      if (result.mustUpgrade) {
+        setUpgradeState({
+          mustUpgrade: true,
+          appVersion,
+          minVersion: result.minVersion,
+          dismissed: false,
+        });
+      }
+    }
+    runVersionCheck();
+  }, []);
 
   // Check onboarding status
   // biome-ignore lint/correctness/useExhaustiveDependencies: router.replace is stable but not typed as such
@@ -455,6 +482,13 @@ function RootLayoutInner() {
           />
         </Stack>
         <StatusBar style="auto" />
+        {upgradeState.mustUpgrade && !upgradeState.dismissed && (
+          <UpgradePromptScreen
+            appVersion={upgradeState.appVersion}
+            minVersion={upgradeState.minVersion}
+            onDismiss={() => setUpgradeState((prev) => ({ ...prev, dismissed: true }))}
+          />
+        )}
       </ThemeProvider>
     </AppErrorBoundary>
   );

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "verse-mate-mobile",
@@ -15,6 +16,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@tanstack/react-query": "^5.90.2",
+        "@types/semver": "^7.7.1",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
@@ -69,6 +71,7 @@
         "react-native-webview": "13.15.0",
         "react-native-worklets": "0.5.1",
         "react-native-youtube-iframe": "^2.4.1",
+        "semver": "^7.8.1",
         "suncalc": "^1.9.0",
       },
       "devDependencies": {
@@ -750,6 +753,8 @@
 
     "@types/react-test-renderer": ["@types/react-test-renderer@19.1.0", "", { "dependencies": { "@types/react": "*" } }, "sha512-XD0WZrHqjNrxA/MaR9O22w/RNidWR9YZmBdRGI7wcnWGrv/3dA8wKCJ8m63Sn+tLJhcjmuhOi629N66W6kgWzQ=="],
 
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
@@ -828,11 +833,11 @@
 
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
-    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0"],
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0", "sha512-bZsFJJTpTGa5BkWWCKT846cVfr7mVHj8Z0WDLGySJYLWfp3AcOpCKj9qr9O1SkR/UGgxYJ2mdaQ5T8ugIlcDrA=="],
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#d9dadca", {}, "verse-mate-verse-mate-studies-d9dadca"],
 
-    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#fa6d815", {}, "verse-mate-verse-mate-visuals-fa6d815"],
+    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#fa6d815", {}, "verse-mate-verse-mate-visuals-fa6d815", "sha512-ufV5BXIwQnfLfk5SvcU/zzVuKMguXkW3E23VkyFsiU2uZHxaIj4meqO9t015vYF2802KPrLvy795dg0VrZcG1A=="],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 
@@ -2264,7 +2269,7 @@
 
     "schema-utils": ["schema-utils@4.3.3", "", { "dependencies": { "@types/json-schema": "^7.0.9", "ajv": "^8.9.0", "ajv-formats": "^2.1.1", "ajv-keywords": "^5.1.0" } }, "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA=="],
 
-    "semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+    "semver": ["semver@7.8.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg=="],
 
     "send": ["send@0.19.1", "", { "dependencies": { "debug": "2.6.9", "depd": "2.0.0", "destroy": "1.2.0", "encodeurl": "~2.0.0", "escape-html": "~1.0.3", "etag": "~1.8.1", "fresh": "0.5.2", "http-errors": "2.0.0", "mime": "1.6.0", "ms": "2.1.3", "on-finished": "2.4.1", "range-parser": "~1.2.1", "statuses": "2.0.1" } }, "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg=="],
 
@@ -2642,6 +2647,8 @@
 
     "@expo/cli/resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
+    "@expo/cli/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@expo/cli/undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
 
     "@expo/cli/wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
@@ -2650,11 +2657,19 @@
 
     "@expo/config/@expo/json-file": ["@expo/json-file@10.0.7", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw=="],
 
+    "@expo/config/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@expo/config-plugins/@expo/json-file": ["@expo/json-file@10.0.7", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-z2OTC0XNO6riZu98EjdNHC05l51ySeTto6GP7oSQrCvQgG9ARBwD1YvMQaVZ9wU7p/4LzSf1O7tckL3B45fPpw=="],
+
+    "@expo/config-plugins/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@expo/devcert/debug": ["debug@3.2.7", "", { "dependencies": { "ms": "^2.1.1" } }, "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ=="],
 
     "@expo/env/dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
+
+    "@expo/fingerprint/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "@expo/image-utils/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
@@ -2666,7 +2681,11 @@
 
     "@expo/metro-config/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
 
+    "@expo/prebuild-config/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
+    "@hey-api/openapi-ts/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
@@ -2690,6 +2709,8 @@
 
     "@react-native/codegen/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
 
+    "@react-native/community-cli-plugin/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "@react-native/dev-middleware/open": ["open@7.4.2", "", { "dependencies": { "is-docker": "^2.0.0", "is-wsl": "^2.1.1" } }, "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q=="],
 
     "@react-native/dev-middleware/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
@@ -2709,6 +2730,8 @@
     "@testing-library/react-native/pretty-format": ["pretty-format@30.0.5", "", { "dependencies": { "@jest/schemas": "30.0.5", "ansi-styles": "^5.2.0", "react-is": "^18.3.1" } }, "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "@typescript-eslint/typescript-estree/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "ajv/fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -2808,6 +2831,10 @@
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
+    "is-bun-module/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
+    "istanbul-lib-instrument/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "jest-config/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "jest-haste-map/fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
@@ -2819,6 +2846,8 @@
     "jest-runtime/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "jest-runtime/strip-bom": ["strip-bom@4.0.0", "", {}, "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w=="],
+
+    "jest-snapshot/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "jest-watch-select-projects/chalk": ["chalk@3.0.0", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg=="],
 
@@ -2850,6 +2879,8 @@
 
     "log-update/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 
+    "make-dir/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "metro/ci-info": ["ci-info@2.0.0", "", {}, "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="],
 
     "metro/hermes-parser": ["hermes-parser@0.32.0", "", { "dependencies": { "hermes-estree": "0.32.0" } }, "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw=="],
@@ -2869,6 +2900,8 @@
     "msw/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "npm-package-arg/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "ora/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
@@ -2898,11 +2931,17 @@
 
     "react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
+    "react-native/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
+
     "react-native/ws": ["ws@6.2.3", "", { "dependencies": { "async-limiter": "~1.0.0" } }, "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA=="],
+
+    "react-native-reanimated/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "react-native-web/@react-native/normalize-colors": ["@react-native/normalize-colors@0.74.89", "", {}, "sha512-qoMMXddVKVhZ8PA1AbUCk83trpd6N+1nF2A6k1i6LsQObyS92fELuk8kU/lQs6M7BsMHwqyLCpQJ1uFgNvIQXg=="],
 
     "react-native-web/memoize-one": ["memoize-one@6.0.0", "", {}, "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw=="],
+
+    "react-native-worklets/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
@@ -2927,6 +2966,8 @@
     "stacktrace-gps/source-map": ["source-map@0.5.6", "", {}, "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
+
+    "storybook/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "string-length/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
 

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -50,6 +50,7 @@ export {
   type UpgradePromptCtaTappedProperties,
   type UpgradePromptDismissedProperties,
   type UpgradePromptShownProperties,
+  type VersionPolicyFetchedProperties,
   type VersemateTooltipOpenedProperties,
   type ViewModeSwitchedProperties,
 } from './types';

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -47,6 +47,9 @@ export {
   type SignupCompletedProperties,
   type TopicSharedProperties,
   type UserProperties,
+  type UpgradePromptCtaTappedProperties,
+  type UpgradePromptDismissedProperties,
+  type UpgradePromptShownProperties,
   type VersemateTooltipOpenedProperties,
   type ViewModeSwitchedProperties,
 } from './types';

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -59,6 +59,7 @@ export enum AnalyticsEvent {
   AUDIO_SPEED_CHANGED = 'AUDIO_SPEED_CHANGED',
 
   // Force Upgrade Events (VER-177)
+  VERSION_POLICY_FETCHED = 'version_policy_fetched',
   UPGRADE_PROMPT_SHOWN = 'upgrade_prompt_shown',
   UPGRADE_PROMPT_CTA_TAPPED = 'upgrade_prompt_cta_tapped',
   UPGRADE_PROMPT_DISMISSED = 'upgrade_prompt_dismissed',
@@ -315,21 +316,25 @@ export interface AudioSpeedChangedProperties {
 // Force Upgrade Event Properties (VER-177)
 // ============================================================================
 
+export interface VersionPolicyFetchedProperties {
+  result: 'success' | 'error';
+  currentVersion: string;
+  minVersion: string;
+}
+
 export interface UpgradePromptShownProperties {
-  appVersion: string;
+  currentVersion: string;
   minVersion: string;
 }
 
 export interface UpgradePromptCtaTappedProperties {
-  appVersion: string;
-  minVersion: string;
   platform: 'ios' | 'android';
 }
 
-export type UpgradePromptDismissedProperties = {
-  appVersion: string;
+export interface UpgradePromptDismissedProperties {
+  currentVersion: string;
   minVersion: string;
-};
+}
 
 // ============================================================================
 // Event Properties Type Map
@@ -374,6 +379,7 @@ export interface EventProperties {
   [AnalyticsEvent.AUDIO_PLAYBACK_SEEK]: AudioPlaybackSeekProperties;
   [AnalyticsEvent.AUDIO_SPEED_CHANGED]: AudioSpeedChangedProperties;
   // Force Upgrade Events (VER-177)
+  [AnalyticsEvent.VERSION_POLICY_FETCHED]: VersionPolicyFetchedProperties;
   [AnalyticsEvent.UPGRADE_PROMPT_SHOWN]: UpgradePromptShownProperties;
   [AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED]: UpgradePromptCtaTappedProperties;
   [AnalyticsEvent.UPGRADE_PROMPT_DISMISSED]: UpgradePromptDismissedProperties;

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -57,6 +57,11 @@ export enum AnalyticsEvent {
   AUDIO_PLAYBACK_COMPLETED = 'AUDIO_PLAYBACK_COMPLETED',
   AUDIO_PLAYBACK_SEEK = 'AUDIO_PLAYBACK_SEEK',
   AUDIO_SPEED_CHANGED = 'AUDIO_SPEED_CHANGED',
+
+  // Force Upgrade Events (VER-177)
+  UPGRADE_PROMPT_SHOWN = 'upgrade_prompt_shown',
+  UPGRADE_PROMPT_CTA_TAPPED = 'upgrade_prompt_cta_tapped',
+  UPGRADE_PROMPT_DISMISSED = 'upgrade_prompt_dismissed',
 }
 
 // ============================================================================
@@ -307,6 +312,26 @@ export interface AudioSpeedChangedProperties {
 }
 
 // ============================================================================
+// Force Upgrade Event Properties (VER-177)
+// ============================================================================
+
+export interface UpgradePromptShownProperties {
+  appVersion: string;
+  minVersion: string;
+}
+
+export interface UpgradePromptCtaTappedProperties {
+  appVersion: string;
+  minVersion: string;
+  platform: 'ios' | 'android';
+}
+
+export type UpgradePromptDismissedProperties = {
+  appVersion: string;
+  minVersion: string;
+};
+
+// ============================================================================
 // Event Properties Type Map
 // ============================================================================
 
@@ -348,6 +373,10 @@ export interface EventProperties {
   [AnalyticsEvent.AUDIO_PLAYBACK_COMPLETED]: AudioPlaybackCompletedProperties;
   [AnalyticsEvent.AUDIO_PLAYBACK_SEEK]: AudioPlaybackSeekProperties;
   [AnalyticsEvent.AUDIO_SPEED_CHANGED]: AudioSpeedChangedProperties;
+  // Force Upgrade Events (VER-177)
+  [AnalyticsEvent.UPGRADE_PROMPT_SHOWN]: UpgradePromptShownProperties;
+  [AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED]: UpgradePromptCtaTappedProperties;
+  [AnalyticsEvent.UPGRADE_PROMPT_DISMISSED]: UpgradePromptDismissedProperties;
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@tanstack/react-query": "^5.90.2",
+    "@types/semver": "^7.7.1",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
@@ -98,6 +99,7 @@
     "react-native-webview": "13.15.0",
     "react-native-worklets": "0.5.1",
     "react-native-youtube-iframe": "^2.4.1",
+    "semver": "^7.8.1",
     "suncalc": "^1.9.0"
   },
   "devDependencies": {

--- a/src/screens/UpgradePromptScreen.tsx
+++ b/src/screens/UpgradePromptScreen.tsx
@@ -1,0 +1,134 @@
+import * as Linking from 'expo-linking';
+import { useEffect } from 'react';
+import { AccessibilityInfo, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { useTheme } from '@/contexts/ThemeContext';
+import { AnalyticsEvent, analytics } from '@/lib/analytics';
+
+// TODO: replace APPLE_STORE_ID constant with real App Store Connect ID
+const APPLE_STORE_ID = 'REPLACE_ME';
+
+const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=org.versemate.app';
+const IOS_STORE_URL = `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
+
+interface UpgradePromptScreenProps {
+  appVersion: string;
+  minVersion: string;
+  onDismiss: () => void;
+}
+
+export function UpgradePromptScreen({
+  appVersion,
+  minVersion,
+  onDismiss,
+}: UpgradePromptScreenProps) {
+  const { colors, spacing, typography } = useTheme();
+  const insets = useSafeAreaInsets();
+
+  useEffect(() => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_SHOWN, { appVersion, minVersion });
+    AccessibilityInfo.announceForAccessibility(
+      'An update is available for Verse Mate. Tap Update Now to upgrade or Maybe Later to continue.'
+    );
+  }, [appVersion, minVersion]);
+
+  const handleUpdateNow = () => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED, {
+      appVersion,
+      minVersion,
+      platform: Platform.OS === 'ios' ? 'ios' : 'android',
+    });
+    const url = Platform.OS === 'ios' ? IOS_STORE_URL : ANDROID_STORE_URL;
+    Linking.openURL(url);
+  };
+
+  const handleMaybeLater = () => {
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_DISMISSED, { appVersion, minVersion });
+    onDismiss();
+  };
+
+  const styles = StyleSheet.create({
+    overlay: {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0,0,0,0.55)',
+      justifyContent: 'center',
+      alignItems: 'center',
+      paddingHorizontal: spacing.lg,
+    },
+    card: {
+      backgroundColor: colors.backgroundElevated,
+      borderRadius: 16,
+      padding: spacing.xl,
+      width: '100%',
+      maxWidth: 380,
+      paddingBottom: insets.bottom > 0 ? insets.bottom + spacing.md : spacing.xl,
+    },
+    title: {
+      ...typography.heading2,
+      color: colors.textPrimary,
+      marginBottom: spacing.sm,
+    },
+    body: {
+      ...typography.body,
+      color: colors.textSecondary,
+      marginBottom: spacing.xl,
+    },
+    ctaButton: {
+      backgroundColor: colors.gold,
+      borderRadius: 8,
+      paddingVertical: spacing.md,
+      alignItems: 'center',
+      marginBottom: spacing.sm,
+    },
+    ctaText: {
+      ...typography.body,
+      fontWeight: '600',
+      color: colors.white,
+    },
+    dismissButton: {
+      alignItems: 'center',
+      paddingVertical: spacing.sm,
+    },
+    dismissText: {
+      ...typography.body,
+      color: colors.textSecondary,
+    },
+  });
+
+  return (
+    <View style={styles.overlay} testID="upgrade-prompt-overlay">
+      <View style={styles.card} testID="upgrade-prompt-card">
+        <Text style={styles.title} testID="upgrade-prompt-title">
+          Update Available
+        </Text>
+        <Text style={styles.body} testID="upgrade-prompt-body">
+          A new version of Verse Mate is required to continue. Please update to the latest version
+          to keep enjoying the app.
+        </Text>
+        <Pressable
+          style={styles.ctaButton}
+          onPress={handleUpdateNow}
+          accessibilityLabel="Update Now"
+          accessibilityRole="button"
+          testID="upgrade-prompt-update-now"
+        >
+          <Text style={styles.ctaText}>Update Now</Text>
+        </Pressable>
+        <Pressable
+          style={styles.dismissButton}
+          onPress={handleMaybeLater}
+          accessibilityLabel="Maybe Later, skip upgrade"
+          accessibilityRole="button"
+          testID="upgrade-prompt-maybe-later"
+        >
+          <Text style={styles.dismissText}>Maybe Later</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}

--- a/src/screens/UpgradePromptScreen.tsx
+++ b/src/screens/UpgradePromptScreen.tsx
@@ -6,15 +6,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/contexts/ThemeContext';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 
-// TODO: replace APPLE_STORE_ID constant with real App Store Connect ID
-const APPLE_STORE_ID = 'REPLACE_ME';
+const APPLE_STORE_ID = '6756897180';
 
 const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=org.versemate.app';
-// Falls back to App Store search if the store ID placeholder hasn't been replaced yet
-const IOS_STORE_URL =
-  APPLE_STORE_ID === 'REPLACE_ME'
-    ? 'https://apps.apple.com/search?term=VerseMate'
-    : `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
+const IOS_STORE_URL = `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
 
 interface UpgradePromptScreenProps {
   currentVersion: string;

--- a/src/screens/UpgradePromptScreen.tsx
+++ b/src/screens/UpgradePromptScreen.tsx
@@ -10,16 +10,20 @@ import { AnalyticsEvent, analytics } from '@/lib/analytics';
 const APPLE_STORE_ID = 'REPLACE_ME';
 
 const ANDROID_STORE_URL = 'https://play.google.com/store/apps/details?id=org.versemate.app';
-const IOS_STORE_URL = `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
+// Falls back to App Store search if the store ID placeholder hasn't been replaced yet
+const IOS_STORE_URL =
+  APPLE_STORE_ID === 'REPLACE_ME'
+    ? 'https://apps.apple.com/search?term=VerseMate'
+    : `https://apps.apple.com/app/id${APPLE_STORE_ID}`;
 
 interface UpgradePromptScreenProps {
-  appVersion: string;
+  currentVersion: string;
   minVersion: string;
   onDismiss: () => void;
 }
 
 export function UpgradePromptScreen({
-  appVersion,
+  currentVersion,
   minVersion,
   onDismiss,
 }: UpgradePromptScreenProps) {
@@ -27,16 +31,14 @@ export function UpgradePromptScreen({
   const insets = useSafeAreaInsets();
 
   useEffect(() => {
-    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_SHOWN, { appVersion, minVersion });
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_SHOWN, { currentVersion, minVersion });
     AccessibilityInfo.announceForAccessibility(
       'An update is available for Verse Mate. Tap Update Now to upgrade or Maybe Later to continue.'
     );
-  }, [appVersion, minVersion]);
+  }, [currentVersion, minVersion]);
 
   const handleUpdateNow = () => {
     analytics.track(AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED, {
-      appVersion,
-      minVersion,
       platform: Platform.OS === 'ios' ? 'ios' : 'android',
     });
     const url = Platform.OS === 'ios' ? IOS_STORE_URL : ANDROID_STORE_URL;
@@ -44,7 +46,7 @@ export function UpgradePromptScreen({
   };
 
   const handleMaybeLater = () => {
-    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_DISMISSED, { appVersion, minVersion });
+    analytics.track(AnalyticsEvent.UPGRADE_PROMPT_DISMISSED, { currentVersion, minVersion });
     onDismiss();
   };
 

--- a/src/services/versionPolicy.ts
+++ b/src/services/versionPolicy.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { lt as semverLt } from 'semver';
 
+import { client } from '@/src/api/generated/client.gen';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 
 const CACHE_KEY = 'VERSION_POLICY_CACHE';
@@ -25,15 +26,16 @@ export interface VersionPolicyResult {
   releaseNotes: string;
 }
 
-async function fetchVersionPolicy(baseUrl: string): Promise<VersionPolicyResponse> {
+async function fetchVersionPolicy(): Promise<VersionPolicyResponse> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    const response = await fetch(`${baseUrl}/api/version-policy`, {
+    const { data, error } = await client.get<{ 200: VersionPolicyResponse }, unknown, false>({
+      url: '/api/version-policy',
       signal: controller.signal,
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    return (await response.json()) as VersionPolicyResponse;
+    if (error || !data) throw new Error('Version policy fetch failed');
+    return data;
   } finally {
     clearTimeout(timeoutId);
   }
@@ -67,11 +69,6 @@ async function setCachedPolicy(data: VersionPolicyResponse): Promise<void> {
  * Fires version_policy_fetched analytics event with result: success|error.
  */
 export async function checkVersionPolicy(currentVersion: string): Promise<VersionPolicyResult> {
-  const baseUrl = process.env.EXPO_PUBLIC_API_URL ?? '';
-  if (__DEV__ && !baseUrl) {
-    console.warn('[versionPolicy] EXPO_PUBLIC_API_URL is not set — version check will fail open');
-  }
-
   const failOpen: VersionPolicyResult = {
     mustUpgrade: false,
     minVersion: '0.0.0',
@@ -82,7 +79,7 @@ export async function checkVersionPolicy(currentVersion: string): Promise<Versio
   try {
     let policy = await getCachedPolicy();
     if (!policy) {
-      policy = await fetchVersionPolicy(baseUrl);
+      policy = await fetchVersionPolicy();
       await setCachedPolicy(policy);
     }
     const mustUpgrade = semverLt(currentVersion, policy.minVersion) ?? false;

--- a/src/services/versionPolicy.ts
+++ b/src/services/versionPolicy.ts
@@ -1,4 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import { lt as semverLt } from 'semver';
+
+import { AnalyticsEvent, analytics } from '@/lib/analytics';
 
 const CACHE_KEY = 'VERSION_POLICY_CACHE';
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -20,16 +23,6 @@ export interface VersionPolicyResult {
   minVersion: string;
   version: string;
   releaseNotes: string;
-}
-
-/** Compare two semver strings X.Y.Z. Returns true if a < b. */
-function semverLessThan(a: string, b: string): boolean {
-  const parsePart = (s: string) => s.split('.').map((n) => parseInt(n, 10) || 0);
-  const [aMajor, aMinor, aPatch] = parsePart(a);
-  const [bMajor, bMinor, bPatch] = parsePart(b);
-  if (aMajor !== bMajor) return aMajor < bMajor;
-  if (aMinor !== bMinor) return aMinor < bMinor;
-  return aPatch < bPatch;
 }
 
 async function fetchVersionPolicy(baseUrl: string): Promise<VersionPolicyResponse> {
@@ -69,11 +62,16 @@ async function setCachedPolicy(data: VersionPolicyResponse): Promise<void> {
 
 /**
  * Check the version policy against the running app version.
- * Returns mustUpgrade: true if appVersion < minVersion.
+ * Returns mustUpgrade: true if appVersion < minVersion (uses semver.lt).
  * Fails open (mustUpgrade: false) on any network or parse error.
+ * Fires version_policy_fetched analytics event with result: success|error.
  */
-export async function checkVersionPolicy(appVersion: string): Promise<VersionPolicyResult> {
+export async function checkVersionPolicy(currentVersion: string): Promise<VersionPolicyResult> {
   const baseUrl = process.env.EXPO_PUBLIC_API_URL ?? '';
+  if (__DEV__ && !baseUrl) {
+    console.warn('[versionPolicy] EXPO_PUBLIC_API_URL is not set — version check will fail open');
+  }
+
   const failOpen: VersionPolicyResult = {
     mustUpgrade: false,
     minVersion: '0.0.0',
@@ -87,9 +85,19 @@ export async function checkVersionPolicy(appVersion: string): Promise<VersionPol
       policy = await fetchVersionPolicy(baseUrl);
       await setCachedPolicy(policy);
     }
-    const mustUpgrade = semverLessThan(appVersion, policy.minVersion);
+    const mustUpgrade = semverLt(currentVersion, policy.minVersion) ?? false;
+    analytics.track(AnalyticsEvent.VERSION_POLICY_FETCHED, {
+      result: 'success',
+      currentVersion,
+      minVersion: policy.minVersion,
+    });
     return { mustUpgrade, ...policy };
   } catch {
+    analytics.track(AnalyticsEvent.VERSION_POLICY_FETCHED, {
+      result: 'error',
+      currentVersion,
+      minVersion: '0.0.0',
+    });
     return failOpen;
   }
 }

--- a/src/services/versionPolicy.ts
+++ b/src/services/versionPolicy.ts
@@ -1,0 +1,95 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const CACHE_KEY = 'VERSION_POLICY_CACHE';
+const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+const FETCH_TIMEOUT_MS = 5000;
+
+interface VersionPolicyResponse {
+  minVersion: string;
+  version: string;
+  releaseNotes: string;
+}
+
+interface CachedVersionPolicy {
+  data: VersionPolicyResponse;
+  fetchedAt: number;
+}
+
+export interface VersionPolicyResult {
+  mustUpgrade: boolean;
+  minVersion: string;
+  version: string;
+  releaseNotes: string;
+}
+
+/** Compare two semver strings X.Y.Z. Returns true if a < b. */
+function semverLessThan(a: string, b: string): boolean {
+  const parsePart = (s: string) => s.split('.').map((n) => parseInt(n, 10) || 0);
+  const [aMajor, aMinor, aPatch] = parsePart(a);
+  const [bMajor, bMinor, bPatch] = parsePart(b);
+  if (aMajor !== bMajor) return aMajor < bMajor;
+  if (aMinor !== bMinor) return aMinor < bMinor;
+  return aPatch < bPatch;
+}
+
+async function fetchVersionPolicy(baseUrl: string): Promise<VersionPolicyResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${baseUrl}/api/version-policy`, {
+      signal: controller.signal,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    return (await response.json()) as VersionPolicyResponse;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+async function getCachedPolicy(): Promise<VersionPolicyResponse | null> {
+  try {
+    const raw = await AsyncStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const cached: CachedVersionPolicy = JSON.parse(raw);
+    if (Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.data;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function setCachedPolicy(data: VersionPolicyResponse): Promise<void> {
+  try {
+    const cached: CachedVersionPolicy = { data, fetchedAt: Date.now() };
+    await AsyncStorage.setItem(CACHE_KEY, JSON.stringify(cached));
+  } catch {
+    // Cache write failure is non-fatal
+  }
+}
+
+/**
+ * Check the version policy against the running app version.
+ * Returns mustUpgrade: true if appVersion < minVersion.
+ * Fails open (mustUpgrade: false) on any network or parse error.
+ */
+export async function checkVersionPolicy(appVersion: string): Promise<VersionPolicyResult> {
+  const baseUrl = process.env.EXPO_PUBLIC_API_URL ?? '';
+  const failOpen: VersionPolicyResult = {
+    mustUpgrade: false,
+    minVersion: '0.0.0',
+    version: '0.0.0',
+    releaseNotes: '',
+  };
+
+  try {
+    let policy = await getCachedPolicy();
+    if (!policy) {
+      policy = await fetchVersionPolicy(baseUrl);
+      await setCachedPolicy(policy);
+    }
+    const mustUpgrade = semverLessThan(appVersion, policy.minVersion);
+    return { mustUpgrade, ...policy };
+  } catch {
+    return failOpen;
+  }
+}


### PR DESCRIPTION
Spec: [VER-174](/VER/issues/VER-174)
Lane: Standard

## Summary

Implements the force upgrade flow for Expo / React Native (T6–T9):

- **T6** `src/services/versionPolicy.ts` — GET `/api/version-policy`, 5-min AsyncStorage cache, fail-open on network error/5xx, `semver.lt()` for version comparison
- **T7** `src/screens/UpgradePromptScreen.tsx` — modal overlay with "Update Now" (platform store deep-link) and "Maybe Later" (dismiss) buttons; iOS CTA falls back to App Store search until `APPLE_STORE_ID` is replaced
- **T8** `app/_layout.tsx` — version check on startup (skipped on web); renders `UpgradePromptScreen` overlay when `mustUpgrade && !dismissed`
- **T9** Analytics events: `version_policy_fetched`, `upgrade_prompt_shown`, `upgrade_prompt_cta_tapped`, `upgrade_prompt_dismissed`

## Changes vs round-1 CR feedback

- Replaced hand-rolled semver with `semver.lt()` (plan D3)
- Added `version_policy_fetched` analytics event (plan §Observability)
- Added dev warning when `EXPO_PUBLIC_API_URL` is unset
- iOS CTA fallback URL when `APPLE_STORE_ID === 'REPLACE_ME'`
- Fixed `UpgradePromptDismissedProperties` to `interface`
- Renamed `appVersion` → `currentVersion` throughout
- Added T8 integration tests (`VersionGate` wrapper: overlay shown/hidden/dismissed)
- Clean branch from `origin/main` — no unrelated commits

## Dev-infra change (acknowledged)

`.husky/pre-commit`: replaced `bun tsc --noEmit --skipLibCheck` with `node --max-old-space-size=4096 ./node_modules/.bin/tsc --noEmit --skipLibCheck --incremental --tsBuildInfoFile .tsbuildinfo` to prevent OOM (exit 137) on this machine's pre-commit hook. Intentionally bundled here since it was the blocker for this branch; a follow-up `chore(tooling):` PR is not needed as the fix is already in.

## Test plan

- [ ] `bun test __tests__/services/versionPolicy.test.ts` — 9 tests (mustUpgrade logic, prerelease, double-digit minor, fail-open, cache TTL)
- [ ] `bun test __tests__/screens/UpgradePromptScreen.test.tsx` — T7 render/a11y/store URL + T8 integration (CI env; RTL local env has known actImplementation issue)
- [ ] CI type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)