### PR TITLE
feat(study): DB-backed studies via useStudy (language + offline fallback)

### DIFF
--- a/__tests__/components/bible/StudyPanel.test.tsx
+++ b/__tests__/components/bible/StudyPanel.test.tsx
@@ -37,6 +37,9 @@ jest.mock('react-native-markdown-display', () => {
 const mockUseStudy = jest.fn();
 jest.mock('@/src/api', () => ({
   useStudy: (...args: unknown[]) => mockUseStudy(...args),
+  // Labels are now DB-backed via useStudyLabels; in tests resolve the same
+  // bundled chrome the component used before (no network / react-query).
+  useStudyLabels: (lang?: string) => jest.requireActual('@versemate/studies').getStudyLabels(lang),
 }));
 
 // Pin the content language so the test doesn't depend on AsyncStorage / auth.

--- a/__tests__/components/bible/StudyPanel.test.tsx
+++ b/__tests__/components/bible/StudyPanel.test.tsx
@@ -8,11 +8,14 @@
  *   - per-card toggling
  *   - Copy button invokes the clipboard with the serialized payload
  *
- * The `@versemate/studies` package is mocked so tests stay deterministic and
- * don't depend on shipped chapter content evolving over time.
+ * Data now flows through the `useStudy` hook (DB-backed study endpoint with a
+ * bundled offline fallback), so the hook is mocked to return deterministic
+ * study payloads. `getStudyLabels` (fixed Precept-method chrome) resolves from
+ * the real `@versemate/studies` package — it's a pure lookup.
  */
 
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import * as Clipboard from 'expo-clipboard';
 import type React from 'react';
 import { StudyPanel } from '@/components/bible/StudyPanel';
 import { ThemeProvider } from '@/contexts/ThemeContext';
@@ -30,12 +33,21 @@ jest.mock('react-native-markdown-display', () => {
   };
 });
 
-const mockGetStudyFor = jest.fn();
-jest.mock('@versemate/studies', () => ({
-  getStudyFor: (...args: unknown[]) => mockGetStudyFor(...args),
+// Study data source — the DB-backed hook. Driven per-test.
+const mockUseStudy = jest.fn();
+jest.mock('@/src/api', () => ({
+  useStudy: (...args: unknown[]) => mockUseStudy(...args),
 }));
 
-import * as Clipboard from 'expo-clipboard';
+// Pin the content language so the test doesn't depend on AsyncStorage / auth.
+jest.mock('@/hooks/use-preferred-language', () => ({
+  usePreferredLanguage: () => 'en-US',
+}));
+
+// Keep the real (pure) label lookup for the fixed UI chrome.
+jest.mock('@versemate/studies', () => ({
+  getStudyLabels: jest.requireActual('@versemate/studies').getStudyLabels,
+}));
 
 const renderWithTheme = (component: React.ReactElement) =>
   render(<ThemeProvider>{component}</ThemeProvider>);
@@ -87,8 +99,7 @@ describe('StudyPanel', () => {
   });
 
   it('shows loading state before the chapter resolves', () => {
-    // Never resolve so loading state stays visible
-    mockGetStudyFor.mockReturnValue(new Promise(() => {}));
+    mockUseStudy.mockReturnValue({ data: undefined, isLoading: true });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
 
@@ -96,7 +107,7 @@ describe('StudyPanel', () => {
   });
 
   it('shows empty state when no study is available', async () => {
-    mockGetStudyFor.mockResolvedValue(null);
+    mockUseStudy.mockReturnValue({ data: null, isLoading: false });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={99} />);
 
@@ -104,7 +115,7 @@ describe('StudyPanel', () => {
   });
 
   it('renders title + theme line and starts collapsed', async () => {
-    mockGetStudyFor.mockResolvedValue(minimalStudy);
+    mockUseStudy.mockReturnValue({ data: minimalStudy, isLoading: false });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
 
@@ -118,7 +129,7 @@ describe('StudyPanel', () => {
   });
 
   it('Expand All reveals all card bodies; Collapse All hides them again', async () => {
-    mockGetStudyFor.mockResolvedValue(minimalStudy);
+    mockUseStudy.mockReturnValue({ data: minimalStudy, isLoading: false });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
 
@@ -136,7 +147,7 @@ describe('StudyPanel', () => {
   });
 
   it('toggling an individual step card overrides bulk state', async () => {
-    mockGetStudyFor.mockResolvedValue(minimalStudy);
+    mockUseStudy.mockReturnValue({ data: minimalStudy, isLoading: false });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
 
@@ -148,7 +159,7 @@ describe('StudyPanel', () => {
   });
 
   it('Copy button writes the serialized payload to the clipboard', async () => {
-    mockGetStudyFor.mockResolvedValue(minimalStudy);
+    mockUseStudy.mockReturnValue({ data: minimalStudy, isLoading: false });
 
     renderWithTheme(<StudyPanel bookId={59} chapter={1} />);
 

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -92,6 +92,30 @@ const LANGUAGE_NAMES: Record<string, string> = {
   id: 'Indonesian',
 };
 
+// Native (endonym) display name per base ISO code, region stripped — the
+// language dropdown shows "Native (English)" (e.g. "Español (Spanish)") with
+// the region carried only by the underlying code (es-MX), not the label.
+const LANGUAGE_NATIVE_NAMES: Record<string, string> = {
+  en: 'English',
+  ro: 'Română',
+  es: 'Español',
+  pt: 'Português',
+  ru: 'Русский',
+  uk: 'Українська',
+  fr: 'Français',
+  de: 'Deutsch',
+  it: 'Italiano',
+  hi: 'हिन्दी',
+};
+
+// Drop region qualifiers from a free-form language name — a trailing
+// "(Region)" or " de Region" — for languages not in the curated maps above.
+const stripRegionQualifier = (s: string): string =>
+  s
+    .replace(/\s*\([^)]*\)\s*/g, ' ')
+    .replace(/\s+de\s+.+$/i, '')
+    .trim();
+
 export default function SettingsScreen() {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
@@ -592,11 +616,19 @@ export default function SettingsScreen() {
     clearError();
   };
 
+  // "Native (English)" with the region stripped from both — e.g.
+  // "Español (Spanish)", not "Español de México (Mexican Spanish)". Prefer the
+  // curated maps (clean endonym/English per base ISO), falling back to a
+  // region-stripped form of the DB names for any language not in them. The
+  // region is preserved in `lang.code` (es-MX), just not shown.
   const formatLanguageDisplay = (lang: Language) => {
-    if (lang.name === lang.nativeName) {
-      return lang.name;
+    const base = lang.code.toLowerCase().split('-')[0];
+    const english = LANGUAGE_NAMES[base] ?? stripRegionQualifier(lang.name);
+    const native = LANGUAGE_NATIVE_NAMES[base] ?? stripRegionQualifier(lang.nativeName);
+    if (native === english) {
+      return english;
     }
-    return `${lang.nativeName} (${lang.name})`;
+    return `${native} (${english})`;
   };
 
   /**

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@types/semver": "^7.7.1",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
-        "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
+        "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
@@ -835,7 +835,7 @@
 
     "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0"],
 
-    "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#d9dadca", {}, "verse-mate-verse-mate-studies-d9dadca"],
+    "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#b91fa3c", {}, "verse-mate-verse-mate-studies-b91fa3c"],
 
     "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#fa6d815", {}, "verse-mate-verse-mate-visuals-fa6d815"],
 

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -21,7 +21,7 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { getStudyFor, type InductiveStudy } from '@versemate/studies';
+import type { InductiveStudy } from '@versemate/studies';
 import type {
   StepBullets,
   StepContrasts,
@@ -39,6 +39,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Pressable, Share, StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useTheme } from '@/contexts/ThemeContext';
+import { usePreferredLanguage } from '@/hooks/use-preferred-language';
+import { useStudy } from '@/src/api';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
 
 export interface StudyPanelProps {
@@ -56,20 +58,14 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
   const styles = useMemo(() => createStyles(colors), [colors]);
   const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
 
-  const [study, setStudy] = useState<InductiveStudy | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
-  useEffect(() => {
-    let cancelled = false;
-    setLoading(true);
-    getStudyFor(bookId, chapter).then((s) => {
-      if (cancelled) return;
-      setStudy(s);
-      setLoading(false);
-    });
-    return () => {
-      cancelled = true;
-    };
-  }, [bookId, chapter]);
+  // Study language follows the same content-language axis as AI explanations.
+  // The DB-backed study endpoint serves the translation for this language when
+  // one exists and falls back to English; useStudy additionally falls back to
+  // the bundled package offline. See useStudy in src/api/hooks.ts.
+  const language = usePreferredLanguage();
+  const { data: studyData, isLoading } = useStudy(bookId, chapter, language);
+  const study: InductiveStudy | null = studyData ?? null;
+  const loading = isLoading;
 
   // Bulk state drives the default for every section. Per-card overrides
   // win when the user toggles individually after a bulk action.

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -21,7 +21,7 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import type { InductiveStudy } from '@versemate/studies';
+import { getStudyLabels, type InductiveStudy } from '@versemate/studies';
 import type {
   StepBullets,
   StepContrasts,
@@ -63,6 +63,9 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
   // one exists and falls back to English; useStudy additionally falls back to
   // the bundled package offline. See useStudy in src/api/hooks.ts.
   const language = usePreferredLanguage();
+  // Fixed Precept-method UI chrome, localized once per language (English
+  // fallback). See @versemate/studies labels.
+  const labels = getStudyLabels(language);
   const { data: studyData, isLoading } = useStudy(bookId, chapter, language);
   const study: InductiveStudy | null = studyData ?? null;
   const loading = isLoading;
@@ -150,7 +153,9 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
     }
   }
   if (study.interpretation.intro) allIds.push('interpretation-intro');
-  for (const m of study.interpretation.movements) allIds.push(`mv-${m.number}`);
+  study.interpretation.movements.forEach((m, i) => {
+    allIds.push(`mv-${m.number ?? i}`);
+  });
   allIds.push('application');
 
   const allOpen = allIds.every((id) => isOpen(id));
@@ -164,7 +169,7 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
       {/* Title row + Copy / Share */}
       <View style={styles.titleRow}>
         <Text style={styles.title} testID={`${testID}-title`} accessibilityRole="header">
-          Inductive Study of {study.title}
+          {labels.inductiveStudyOf} {study.title}
         </Text>
         <View style={styles.titleActions}>
           <Pressable
@@ -210,26 +215,23 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
           testID={`${testID}-toggle-all`}
           hitSlop={6}
         >
-          <Text style={styles.expandAllText}>{allOpen ? 'Collapse All' : 'Expand All'}</Text>
+          <Text style={styles.expandAllText}>
+            {allOpen ? labels.collapseAll : labels.expandAll}
+          </Text>
         </Pressable>
       </View>
 
       {/* OBSERVATION */}
-      <SectionHeading label="Observation — 9 Inductive Steps" colors={colors} styles={styles} />
+      <SectionHeading label={labels.observationSection} colors={colors} styles={styles} />
       <Card
         open={isOpen('observation-intro')}
         onToggle={() => toggle('observation-intro')}
-        heading="About the nine observation steps"
+        heading={labels.aboutObservationTitle}
         colors={colors}
         styles={styles}
         testID={`${testID}-observation-intro`}
       >
-        <Text style={styles.sectionIntro}>
-          Observation asks what the text says — slowing down to mark the keywords, contrasts,
-          repetitions, and structural cues the author left for you. Each of the nine steps below
-          builds the evidence the interpretation that follows is built on. Don&apos;t skip ahead;
-          the meaning comes from what you observed.
-        </Text>
+        <Text style={styles.sectionIntro}>{labels.aboutObservationBody.replace(/\*/g, '')}</Text>
       </Card>
       {study.steps.map((step) => (
         <StepCard
@@ -245,12 +247,12 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
       ))}
 
       {/* INTERPRETATION */}
-      <SectionHeading label="Interpretation" colors={colors} styles={styles} />
+      <SectionHeading label={labels.interpretationSection} colors={colors} styles={styles} />
       {study.interpretation.intro ? (
         <Card
           open={isOpen('interpretation-intro')}
           onToggle={() => toggle('interpretation-intro')}
-          heading="About the interpretation movements"
+          heading={labels.aboutInterpretationTitle}
           colors={colors}
           styles={styles}
           testID={`${testID}-interpretation-intro`}
@@ -258,27 +260,27 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
           <Text style={styles.sectionIntro}>{study.interpretation.intro}</Text>
         </Card>
       ) : null}
-      {study.interpretation.movements.map((movement) => (
+      {study.interpretation.movements.map((movement, mvIdx) => (
         <Card
-          key={movement.number}
-          open={isOpen(`mv-${movement.number}`)}
-          onToggle={() => toggle(`mv-${movement.number}`)}
-          heading={`Movement ${movement.number} — ${movement.title}`}
+          key={movement.number ?? mvIdx}
+          open={isOpen(`mv-${movement.number ?? mvIdx}`)}
+          onToggle={() => toggle(`mv-${movement.number ?? mvIdx}`)}
+          heading={`${labels.movement} ${movement.number} — ${movement.title}`}
           subPill={movement.range}
           colors={colors}
           styles={styles}
-          testID={`${testID}-movement-${movement.number}`}
+          testID={`${testID}-movement-${movement.number ?? mvIdx}`}
         >
           <MovementBody movement={movement} styles={styles} markdownStyles={markdownStyles} />
         </Card>
       ))}
 
       {/* APPLICATION */}
-      <SectionHeading label="Application" colors={colors} styles={styles} />
+      <SectionHeading label={labels.applicationSection} colors={colors} styles={styles} />
       <Card
         open={isOpen('application')}
         onToggle={() => toggle('application')}
-        heading="Apply, one question per movement"
+        heading={labels.applyOneQuestion}
         colors={colors}
         styles={styles}
         testID={`${testID}-application`}
@@ -462,6 +464,7 @@ function QAStep({
 }
 
 function KeywordsStep({ step, styles }: { step: StepKeywords; styles: Styles }) {
+  const labels = getStudyLabels(usePreferredLanguage());
   // Each keyword is wrapped in its own card (darker background, padding, rounded)
   // to match the web layout. The word + Greek + count badge sit on the top row,
   // the verses listing comes next, and the definition reads underneath.
@@ -477,7 +480,7 @@ function KeywordsStep({ step, styles }: { step: StepKeywords; styles: Styles }) 
             </View>
           </View>
           <Text style={styles.keywordVerses}>
-            <Text style={styles.keywordVersesLabel}>VERSES </Text>
+            <Text style={styles.keywordVersesLabel}>{labels.versesLabel} </Text>
             {kw.verses}
           </Text>
           {kw.definition ? <Text style={styles.keywordDef}>{kw.definition}</Text> : null}
@@ -643,10 +646,11 @@ function SegmentsStep({
   styles: Styles;
   markdownStyles: MarkdownStyles;
 }) {
+  const labels = getStudyLabels(usePreferredLanguage());
   return (
     <View>
       <View style={styles.themeBlock}>
-        <Text style={styles.themeLabel}>CHAPTER THEME</Text>
+        <Text style={styles.themeLabel}>{labels.chapterThemeLabel}</Text>
         <Text style={styles.themeHeadline}>{step.themeHeadline}</Text>
       </View>
       {step.segments.map((seg, i) => (

--- a/components/bible/StudyPanel.tsx
+++ b/components/bible/StudyPanel.tsx
@@ -21,7 +21,7 @@
  */
 
 import { Ionicons } from '@expo/vector-icons';
-import { getStudyLabels, type InductiveStudy } from '@versemate/studies';
+import type { InductiveStudy } from '@versemate/studies';
 import type {
   StepBullets,
   StepContrasts,
@@ -40,7 +40,7 @@ import { Pressable, Share, StyleSheet, Text, View } from 'react-native';
 import Markdown from 'react-native-markdown-display';
 import { useTheme } from '@/contexts/ThemeContext';
 import { usePreferredLanguage } from '@/hooks/use-preferred-language';
-import { useStudy } from '@/src/api';
+import { useStudy, useStudyLabels } from '@/src/api';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
 
 export interface StudyPanelProps {
@@ -63,9 +63,10 @@ export function StudyPanel({ bookId, chapter, testID = 'study-panel' }: StudyPan
   // one exists and falls back to English; useStudy additionally falls back to
   // the bundled package offline. See useStudy in src/api/hooks.ts.
   const language = usePreferredLanguage();
-  // Fixed Precept-method UI chrome, localized once per language (English
-  // fallback). See @versemate/studies labels.
-  const labels = getStudyLabels(language);
+  // Fixed Precept-method UI chrome, localized per language. DB-backed
+  // (useStudyLabels) so a new language's chrome ships without an app release,
+  // with the bundled @versemate/studies map as offline/English fallback.
+  const labels = useStudyLabels(language);
   const { data: studyData, isLoading } = useStudy(bookId, chapter, language);
   const study: InductiveStudy | null = studyData ?? null;
   const loading = isLoading;
@@ -464,7 +465,7 @@ function QAStep({
 }
 
 function KeywordsStep({ step, styles }: { step: StepKeywords; styles: Styles }) {
-  const labels = getStudyLabels(usePreferredLanguage());
+  const labels = useStudyLabels(usePreferredLanguage());
   // Each keyword is wrapped in its own card (darker background, padding, rounded)
   // to match the web layout. The word + Greek + count badge sit on the top row,
   // the verses listing comes next, and the definition reads underneath.
@@ -646,7 +647,7 @@ function SegmentsStep({
   styles: Styles;
   markdownStyles: MarkdownStyles;
 }) {
-  const labels = getStudyLabels(usePreferredLanguage());
+  const labels = useStudyLabels(usePreferredLanguage());
   return (
     <View>
       <View style={styles.themeBlock}>

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/semver": "^7.7.1",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
-    "@versemate/studies": "github:verse-mate/verse-mate-studies#d9dadca",
+    "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
     "axios": "^1.12.2",
     "expo": "~54.0.27",

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,6 +1,7 @@
 // Custom React Query hooks wrapping the generated options
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { getStudyFor, type InductiveStudy } from '@versemate/studies';
 import { useEffect, useMemo, useState } from 'react';
 // Offline mode imports
 import { BIBLE_BOOKS, getBookById } from '@/constants/bible-books';
@@ -1068,6 +1069,51 @@ export const useTopicExplanation = (
     data: query.data && 'explanation' in query.data ? query.data.explanation : null,
   };
 };
+
+// ============================================================================
+// Study Hook
+// ============================================================================
+
+/**
+ * Inductive study for a chapter, localized to `language` with English fallback.
+ *
+ * Fetches the DB-backed study from the backend (which serves the translation
+ * for `language` when one exists, English otherwise). On any network/API
+ * failure — or for a chapter the backend doesn't have — it falls back to the
+ * bundled `@versemate/studies` content, so the Study tab keeps working offline
+ * with exactly the content that shipped before the DB migration.
+ */
+export function useStudy(bookId: number, chapter: number, language?: string) {
+  return useQuery({
+    queryKey: ['study', bookId, chapter, language ?? 'en-US'],
+    enabled: bookId > 0 && chapter > 0,
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async (): Promise<InductiveStudy | null> => {
+      const baseUrl = process.env.EXPO_PUBLIC_API_URL || 'https://api.versemate.org';
+      try {
+        const accessToken = await getAccessToken();
+        const headers: HeadersInit = {};
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
+        }
+        const qs = language ? `?lang=${encodeURIComponent(language)}` : '';
+        const response = await fetch(`${baseUrl}/bible/study/${bookId}/${chapter}${qs}`, {
+          method: 'GET',
+          headers,
+        });
+        if (response.ok) {
+          const data = (await response.json()) as {
+            study?: { content?: InductiveStudy } | null;
+          };
+          if (data?.study?.content) return data.study.content;
+        }
+      } catch {
+        // network/offline → bundled fallback below
+      }
+      return (await getStudyFor(bookId, chapter)) ?? null;
+    },
+  });
+}
 
 // ============================================================================
 // Recently Viewed Books Hooks

--- a/src/api/hooks.ts
+++ b/src/api/hooks.ts
@@ -1,7 +1,12 @@
 // Custom React Query hooks wrapping the generated options
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { getStudyFor, type InductiveStudy } from '@versemate/studies';
+import {
+  getStudyFor,
+  getStudyLabels,
+  type InductiveStudy,
+  type StudyLabels,
+} from '@versemate/studies';
 import { useEffect, useMemo, useState } from 'react';
 // Offline mode imports
 import { BIBLE_BOOKS, getBookById } from '@/constants/bible-books';
@@ -1113,6 +1118,48 @@ export function useStudy(bookId: number, chapter: number, language?: string) {
       return (await getStudyFor(bookId, chapter)) ?? null;
     },
   });
+}
+
+/**
+ * Inductive-study UI chrome labels for the given language.
+ *
+ * Two-tier: the bundled `getStudyLabels` map (en/ro/es) is the synchronous
+ * default/offline fallback; the DB-backed `/bible/study-labels` row (any
+ * enabled language) is fetched and merged OVER it. A language with no row — or
+ * a key the row omits — degrades to English per-key, and new languages go live
+ * with no app release. Keyed by base ISO so every chapter + sub-renderer shares
+ * one cached fetch.
+ */
+export function useStudyLabels(language?: string): StudyLabels {
+  const base = (language ?? 'en').toLowerCase().split('-')[0];
+  const query = useQuery({
+    queryKey: ['study-labels', base],
+    staleTime: Number.POSITIVE_INFINITY,
+    queryFn: async (): Promise<Partial<StudyLabels> | null> => {
+      const baseUrl = process.env.EXPO_PUBLIC_API_URL || 'https://api.versemate.org';
+      try {
+        const accessToken = await getAccessToken();
+        const headers: HeadersInit = {};
+        if (accessToken) {
+          headers.Authorization = `Bearer ${accessToken}`;
+        }
+        const response = await fetch(
+          `${baseUrl}/bible/study-labels?lang=${encodeURIComponent(language ?? 'en')}`,
+          { method: 'GET', headers }
+        );
+        if (response.ok) {
+          const data = (await response.json()) as {
+            labels?: Record<string, string> | null;
+          };
+          return (data?.labels as Partial<StudyLabels> | undefined) ?? null;
+        }
+      } catch {
+        // network/offline → bundled fallback below
+      }
+      return null;
+    },
+  });
+  return { ...getStudyLabels(language), ...(query.data ?? {}) };
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

Replaces the bundled `getStudyFor()` call in `StudyPanel` with a new **`useStudy(bookId, chapter, language)`** React Query hook that fetches the DB-backed inductive study from `GET /bible/study/:bookId/:chapter?lang=`.

Pairs with backend PR `verse-mate#257` (`feat/studies-db-and-translation`).

## Behaviour

- Backend serves the translation for the current content language when one exists, English otherwise.
- `useStudy` **additionally falls back to the bundled `@versemate/studies` content on any network/API failure** → the Study tab keeps working offline with the exact content that shipped before the migration. (The package is intentionally retained as the offline fallback.)
- Study language follows the existing **`preferred_language`** axis (same as AI explanations) via `usePreferredLanguage`, threaded through `StudyPanel`.

## Files

- `src/api/hooks.ts`: new `useStudy` hook (manual fetch + bundled fallback, `staleTime: Infinity`, language in query key).
- `components/bible/StudyPanel.tsx`: loader swapped from `getStudyFor` → `useStudy`, `usePreferredLanguage` threaded in.

## Tested / not tested

- ✅ `tsc --noEmit` clean.
- ⚠️ **Not yet runtime-verified on device/simulator** (no PC/sim available this session) — needs a manual pass on the Study tab (English + a translated language + offline) once the backend endpoint is deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)