### PR TITLE
GH-265: Verse-of-the-Day widget — mobile

### DIFF
--- a/.maestro/widget/verse-of-the-day-deep-link-flow.yaml
+++ b/.maestro/widget/verse-of-the-day-deep-link-flow.yaml
@@ -1,0 +1,43 @@
+---
+appId: org.versemate.app
+name: Verse-of-the-Day Widget Deep Link Flow
+description: Tapping the widget deep link opens the chapter at the target verse
+tags:
+  - user-flow
+  - widget
+
+---
+
+# Verse-of-the-Day widget deep link (GH-265).
+#
+# The widget links to the Universal Link form with a verse range +
+# src=widget marker. The app's deep-link handler forwards it to the reader's
+# verse/endVerse params (scroll + highlight) and emits WIDGET_TAPPED.
+
+# Launch the app from the widget's deep link (John 3:16).
+- launchApp:
+    clearState: true
+    appId: org.versemate.app
+    arguments:
+      url: "https://app.versemate.org/bible/john/3?verseStart=16&src=widget"
+
+# Some launchers/CI show a system dialog first.
+- runFlow:
+    when:
+      visible: "Wait"
+    commands:
+      - tapOn: "Wait"
+
+# We should land in the chapter reader.
+- extendedWaitUntil:
+    visible:
+      id: "chapter-selector-button"
+    timeout: 30000
+
+- waitForAnimationToEnd
+
+# The target verse should be scrolled into view / present.
+- extendedWaitUntil:
+    visible:
+      id: "verse-group-16"
+    timeout: 30000

--- a/__tests__/app/deep-link-handling.test.tsx
+++ b/__tests__/app/deep-link-handling.test.tsx
@@ -5,10 +5,52 @@
  * Tests cover critical deep link behaviors without exhaustive coverage.
  */
 
-import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
+import { AnalyticsEvent } from '@/lib/analytics/types';
+import {
+  buildWidgetVerseRoute,
+  parseChapterShareUrl,
+} from '@/utils/sharing/generate-chapter-share-url';
 
 // Mock environment variable
 process.env.EXPO_PUBLIC_WEB_URL = 'https://app.versemate.org';
+
+// Mock the analytics service so we can assert WIDGET_TAPPED gating without the
+// real PostHog client.
+jest.mock('@/lib/analytics/analytics', () => ({
+  analytics: {
+    track: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+    registerSuperProperties: jest.fn(),
+    isEnabled: jest.fn(() => true),
+  },
+}));
+
+import { analytics } from '@/lib/analytics/analytics';
+
+/**
+ * Mirrors the widget-link branch of `handleDeepLink` in app/_layout.tsx:
+ * detect `src=widget`, emit WIDGET_TAPPED only for widget taps, and forward to
+ * the reader route via the shared `buildWidgetVerseRoute` helper. Kept in sync
+ * with the layout so the analytics gating and forwarding contract are covered
+ * without mounting the full provider tree.
+ */
+function forwardWidgetDeepLink(url: string): string | null {
+  const parsed = parseChapterShareUrl(url);
+  if (!parsed?.verseStart) return null;
+  const { bookId, chapterNumber, verseStart, verseEnd } = parsed;
+  const isWidget = url.includes('src=widget');
+  if (isWidget) {
+    analytics.track(AnalyticsEvent.WIDGET_TAPPED, {
+      bookId,
+      chapterNumber,
+      verseStart,
+      verseEnd,
+      source: 'verse-of-the-day',
+    });
+  }
+  return buildWidgetVerseRoute(bookId, chapterNumber, verseStart, verseEnd, isWidget);
+}
 
 describe('Deep Link Handling', () => {
   beforeEach(() => {
@@ -55,5 +97,97 @@ describe('Deep Link Handling', () => {
   it('returns null for non-numeric path components', () => {
     const result = parseChapterShareUrl('https://app.versemate.org/bible/john/three');
     expect(result).toBeNull();
+  });
+
+  // Verse-of-the-day widget deep links (GH-265 T-002).
+  describe('widget verse-range forwarding', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('forwards a single verse (?verseStart=16) to the reader as verse=16', () => {
+      const route = forwardWidgetDeepLink(
+        'https://app.versemate.org/bible/43/3?verseStart=16&src=widget'
+      );
+      expect(route).toBe('/bible/43/3?verse=16&src=widget');
+    });
+
+    it('forwards a passage (?verseStart=16&verseEnd=18) to verse=16&endVerse=18', () => {
+      const route = forwardWidgetDeepLink(
+        'https://app.versemate.org/bible/43/3?verseStart=16&verseEnd=18&src=widget'
+      );
+      expect(route).toBe('/bible/43/3?verse=16&endVerse=18&src=widget');
+    });
+
+    it('fires WIDGET_TAPPED when src=widget is present', () => {
+      forwardWidgetDeepLink(
+        'https://app.versemate.org/bible/43/3?verseStart=16&verseEnd=18&src=widget'
+      );
+      expect(analytics.track).toHaveBeenCalledTimes(1);
+      expect(analytics.track).toHaveBeenCalledWith(AnalyticsEvent.WIDGET_TAPPED, {
+        bookId: 43,
+        chapterNumber: 3,
+        verseStart: 16,
+        verseEnd: 18,
+        source: 'verse-of-the-day',
+      });
+    });
+
+    it('does NOT fire WIDGET_TAPPED for a non-widget verse link', () => {
+      const route = forwardWidgetDeepLink('https://app.versemate.org/bible/43/3?verseStart=16');
+      // Still forwards the verse, but without src=widget and without analytics.
+      expect(route).toBe('/bible/43/3?verse=16');
+      expect(analytics.track).not.toHaveBeenCalled();
+    });
+  });
+
+  // Chapter-screen WIDGET_OPENED_VERSE_DETAIL fire-once guard (GH-265 T-002 d).
+  // Mirrors the effect in app/bible/[bookId]/[chapterNumber].tsx: fire exactly
+  // once when params.src === 'widget' and a target verse is present.
+  describe('WIDGET_OPENED_VERSE_DETAIL fire-once guard', () => {
+    function makeGuardedTracker() {
+      let hasTracked = false;
+      return (params: { src?: string }, targetVerse: number | undefined) => {
+        if (params.src === 'widget' && targetVerse && !hasTracked) {
+          hasTracked = true;
+          analytics.track(AnalyticsEvent.WIDGET_OPENED_VERSE_DETAIL, {
+            bookId: 43,
+            chapterNumber: 3,
+            verseNumber: targetVerse,
+            source: 'widget',
+          });
+        }
+      };
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('emits exactly once even when the effect re-runs', () => {
+      const track = makeGuardedTracker();
+      track({ src: 'widget' }, 16);
+      track({ src: 'widget' }, 16); // re-render
+      track({ src: 'widget' }, 16); // re-render
+      expect(analytics.track).toHaveBeenCalledTimes(1);
+      expect(analytics.track).toHaveBeenCalledWith(AnalyticsEvent.WIDGET_OPENED_VERSE_DETAIL, {
+        bookId: 43,
+        chapterNumber: 3,
+        verseNumber: 16,
+        source: 'widget',
+      });
+    });
+
+    it('does not emit when not arriving from the widget', () => {
+      const track = makeGuardedTracker();
+      track({ src: undefined }, 16);
+      expect(analytics.track).not.toHaveBeenCalled();
+    });
+
+    it('does not emit without a target verse', () => {
+      const track = makeGuardedTracker();
+      track({ src: 'widget' }, undefined);
+      expect(analytics.track).not.toHaveBeenCalled();
+    });
   });
 });

--- a/__tests__/utils/chapter-share-url.test.ts
+++ b/__tests__/utils/chapter-share-url.test.ts
@@ -128,4 +128,36 @@ describe('parseChapterShareUrl', () => {
     const result = parseChapterShareUrl('https://app.versemate.org/bible/1/1');
     expect(result).toBeNull();
   });
+
+  // Verse-of-the-day widget deep link (GH-265): optional verse range params.
+  it('parses a single-verse widget deep link (verseStart)', () => {
+    const result = parseChapterShareUrl(
+      'https://app.versemate.org/bible/john/3?verseStart=16&src=widget'
+    );
+    expect(result).toEqual({ bookId: 43, chapterNumber: 3, verseStart: 16 });
+  });
+
+  it('parses a passage widget deep link (verseStart + verseEnd)', () => {
+    const result = parseChapterShareUrl(
+      'https://app.versemate.org/bible/45/8?verseStart=38&verseEnd=39'
+    );
+    expect(result).toEqual({
+      bookId: 45,
+      chapterNumber: 8,
+      verseStart: 38,
+      verseEnd: 39,
+    });
+  });
+
+  it('omits verse keys when no verse params present', () => {
+    const result = parseChapterShareUrl('https://app.versemate.org/bible/john/3');
+    expect(result).toEqual({ bookId: 43, chapterNumber: 3 });
+  });
+
+  it('ignores invalid verse params', () => {
+    const result = parseChapterShareUrl(
+      'https://app.versemate.org/bible/john/3?verseStart=abc&verseEnd=0'
+    );
+    expect(result).toEqual({ bookId: 43, chapterNumber: 3 });
+  });
 });

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the Android Verse-of-the-Day widget task handler (GH-265).
+ *
+ * Covers:
+ *  - buildDeepLink ↔ parseChapterShareUrl cross-module contract: the deep link
+ *    the handler emits must round-trip back to the same bookId/chapter/verse
+ *    through the real parser (locks the host + path + query-param shape).
+ *  - fetchVerse: happy path, empty pool (fallback message), and fetch error.
+ *
+ * EXPO_PUBLIC_WEB_URL is pinned so the deep link the handler builds shares a
+ * host with the parser's expected base URL (L-003).
+ */
+
+// Pin web/api hosts BEFORE importing the handler — both read process.env at
+// module load time.
+process.env.EXPO_PUBLIC_WEB_URL = 'https://app.versemate.org';
+process.env.EXPO_PUBLIC_API_URL = 'https://api.versemate.org';
+
+// react-native-android-widget pulls in native-only code at import; the handler
+// only references its JSX widget components, which we don't render here.
+jest.mock('react-native-android-widget', () => ({
+  FlexWidget: 'FlexWidget',
+  TextWidget: 'TextWidget',
+}));
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { buildDeepLink, fetchVerse } from '@/widgets/widget-task-handler';
+import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
+
+const originalFetch = global.fetch;
+
+describe('widget-task-handler', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  describe('buildDeepLink ↔ parseChapterShareUrl round-trip', () => {
+    it('round-trips a single-verse reference', () => {
+      const ref = { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null };
+      const url = buildDeepLink(ref);
+
+      // src=widget must survive for the layout to fire WIDGET_TAPPED.
+      expect(url).toContain('src=widget');
+      expect(url).toContain('verseStart=16');
+      expect(url).not.toContain('verseEnd');
+
+      const parsed = parseChapterShareUrl(url);
+      expect(parsed).toEqual({ bookId: 43, chapterNumber: 3, verseStart: 16 });
+    });
+
+    it('round-trips a passage reference (verseStart + verseEnd)', () => {
+      const ref = { bookId: 45, chapterNumber: 8, verseStart: 38, verseEnd: 39 };
+      const url = buildDeepLink(ref);
+
+      expect(url).toContain('verseStart=38');
+      expect(url).toContain('verseEnd=39');
+
+      const parsed = parseChapterShareUrl(url);
+      expect(parsed).toEqual({
+        bookId: 45,
+        chapterNumber: 8,
+        verseStart: 38,
+        verseEnd: 39,
+      });
+    });
+
+    it('falls back to Genesis 1 when no reference is provided', () => {
+      const url = buildDeepLink(undefined);
+      const parsed = parseChapterShareUrl(url);
+      expect(parsed).toEqual({ bookId: 1, chapterNumber: 1 });
+    });
+  });
+
+  describe('fetchVerse', () => {
+    it('returns verse text + reference on the happy path', async () => {
+      await AsyncStorage.setItem('bible-version', 'KJV');
+      const apiResponse = {
+        empty: false,
+        referenceText: 'John 3:16',
+        verses: [{ verseNumber: 16, text: 'For God so loved the world' }],
+        reference: { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null },
+      };
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => apiResponse,
+      }) as unknown as typeof fetch;
+
+      const result = await fetchVerse();
+
+      // Uses the stored version in the request.
+      expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('bible_version=KJV');
+      expect(result.verseText).toBe('For God so loved the world');
+      expect(result.reference).toBe('John 3:16');
+      expect(parseChapterShareUrl(result.deepLink)).toEqual({
+        bookId: 43,
+        chapterNumber: 3,
+        verseStart: 16,
+      });
+    });
+
+    it('returns the fallback message when the verse pool is empty', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({ empty: true, fallbackMessage: 'No verse today' }),
+      }) as unknown as typeof fetch;
+
+      const result = await fetchVerse();
+
+      expect(result.verseText).toBe('No verse today');
+      expect(result.reference).toBe('VerseMate');
+      // No reference → Genesis 1 fallback link.
+      expect(parseChapterShareUrl(result.deepLink)).toEqual({ bookId: 1, chapterNumber: 1 });
+    });
+
+    it('returns a branded fallback when fetch throws', async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+      const result = await fetchVerse();
+
+      expect(result.verseText).toBe("Open VerseMate to see today's verse");
+      expect(result.reference).toBe('VerseMate');
+      expect(parseChapterShareUrl(result.deepLink)).toEqual({ bookId: 1, chapterNumber: 1 });
+    });
+  });
+});

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -98,6 +98,24 @@ describe('widget-task-handler', () => {
       });
     });
 
+    it('sends pid when a user id is stored, omits it otherwise (PD-7)', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        json: async () => ({ empty: true, fallbackMessage: 'x' }),
+      }) as unknown as typeof fetch;
+
+      // Logged out: no widget-user-id stored → no pid param.
+      await AsyncStorage.removeItem('widget-user-id');
+      global.fetch = fetchMock;
+      await fetchVerse();
+      expect((fetchMock as jest.Mock).mock.calls[0][0]).not.toContain('pid=');
+
+      // Logged in: id mirrored into AsyncStorage → pid param present.
+      await AsyncStorage.setItem('widget-user-id', 'user-123');
+      await fetchVerse();
+      expect((fetchMock as jest.Mock).mock.calls[1][0]).toContain('pid=user-123');
+      await AsyncStorage.removeItem('widget-user-id');
+    });
+
     it('returns the fallback message when the verse pool is empty', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         json: async () => ({ empty: true, fallbackMessage: 'No verse today' }),

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -88,7 +88,7 @@ describe('widget-task-handler', () => {
       const result = await fetchVerse();
 
       // Uses the stored version in the request.
-      expect((global.fetch as jest.Mock).mock.calls[0][0]).toContain('bible_version=KJV');
+      expect((global.fetch as unknown as jest.Mock).mock.calls[0][0]).toContain('bible_version=KJV');
       expect(result.verseText).toBe('For God so loved the world');
       expect(result.reference).toBe('John 3:16');
       expect(parseChapterShareUrl(result.deepLink)).toEqual({
@@ -107,12 +107,12 @@ describe('widget-task-handler', () => {
       await AsyncStorage.removeItem('widget-user-id');
       global.fetch = fetchMock;
       await fetchVerse();
-      expect((fetchMock as jest.Mock).mock.calls[0][0]).not.toContain('pid=');
+      expect((fetchMock as unknown as jest.Mock).mock.calls[0][0]).not.toContain('pid=');
 
       // Logged in: id mirrored into AsyncStorage → pid param present.
       await AsyncStorage.setItem('widget-user-id', 'user-123');
       await fetchVerse();
-      expect((fetchMock as jest.Mock).mock.calls[1][0]).toContain('pid=user-123');
+      expect((fetchMock as unknown as jest.Mock).mock.calls[1][0]).toContain('pid=user-123');
       await AsyncStorage.removeItem('widget-user-id');
     });
 

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -24,8 +24,8 @@ jest.mock('react-native-android-widget', () => ({
 }));
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { buildDeepLink, fetchVerse } from '@/widgets/widget-task-handler';
 import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
+import { buildDeepLink, fetchVerse } from '@/widgets/widget-task-handler';
 
 const originalFetch = global.fetch;
 
@@ -88,7 +88,9 @@ describe('widget-task-handler', () => {
       const result = await fetchVerse();
 
       // Uses the stored version in the request.
-      expect((global.fetch as unknown as jest.Mock).mock.calls[0][0]).toContain('bible_version=KJV');
+      expect((global.fetch as unknown as jest.Mock).mock.calls[0][0]).toContain(
+        'bible_version=KJV'
+      );
       expect(result.verseText).toBe('For God so loved the world');
       expect(result.reference).toBe('John 3:16');
       expect(parseChapterShareUrl(result.deepLink)).toEqual({
@@ -130,7 +132,9 @@ describe('widget-task-handler', () => {
     });
 
     it('returns a branded fallback when fetch throws', async () => {
-      global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
 
       const result = await fetchVerse();
 

--- a/app.config.js
+++ b/app.config.js
@@ -13,6 +13,13 @@ const config = {
     bundleIdentifier: 'org.versemate.app',
     supportsTablet: true,
     associatedDomains: ['applinks:app.versemate.org'],
+    // App Group shared between the app and the Verse-of-the-Day widget
+    // extension (GH-265). The app writes the user's preferred Bible version
+    // here; the widget reads it. The widget target declares the same group
+    // in targets/widget/expo-target.config.js.
+    entitlements: {
+      'com.apple.security.application-groups': ['group.org.versemate.app'],
+    },
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
       NSPhotoLibraryUsageDescription:
@@ -146,6 +153,29 @@ const config = {
         microphonePermission: 'Allow Verse Mate to use the microphone for voice-to-text input.',
         speechRecognitionPermission:
           'Allow Verse Mate to use speech recognition for voice-to-text input.',
+      },
+    ],
+    // Verse-of-the-Day widget (GH-265).
+    // iOS: @bacons/apple-targets generates the WidgetKit extension from
+    // targets/widget/ during prebuild. Android: react-native-android-widget
+    // registers the AppWidgetProvider + the JS-rendered widget.
+    '@bacons/apple-targets',
+    [
+      'react-native-android-widget',
+      {
+        widgets: [
+          {
+            name: 'VerseOfTheDay',
+            label: 'Verse of the Day',
+            description: "Today's Bible verse from VerseMate",
+            minWidth: '180dp',
+            minHeight: '110dp',
+            targetCellWidth: 4,
+            targetCellHeight: 2,
+            resizeMode: 'horizontal|vertical',
+            updatePeriodMillis: 86400000, // ~daily; OS-throttled periodic refresh
+          },
+        ],
       },
     ],
   ],

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -27,7 +27,7 @@ import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import * as SystemUI from 'expo-system-ui';
 import { useEffect, useRef, useState } from 'react';
-import { InteractionManager, Platform } from 'react-native';
+import { AppState, type AppStateStatus, InteractionManager, Platform } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import 'react-native-reanimated';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -56,7 +56,10 @@ import { StubAudioEngine } from '@/lib/audio/stubAudioEngine';
 import { I18nProvider } from '@/lib/i18n/I18nProvider';
 import { UpgradePromptScreen } from '@/src/screens/UpgradePromptScreen';
 import { checkVersionPolicy } from '@/src/services/versionPolicy';
-import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
+import {
+  buildWidgetVerseRoute,
+  parseChapterShareUrl,
+} from '@/utils/sharing/generate-chapter-share-url';
 import { parseTopicShareUrl } from '@/utils/sharing/generate-topic-share-url';
 import { ONBOARDING_KEY } from './onboarding';
 
@@ -288,11 +291,9 @@ function RootLayoutInner() {
               source: 'verse-of-the-day',
             });
           }
-          const verseParams = new URLSearchParams();
-          verseParams.set('verse', String(verseStart));
-          if (verseEnd) verseParams.set('endVerse', String(verseEnd));
-          if (isWidget) verseParams.set('src', 'widget');
-          router.replace(`/bible/${bookId}/${chapterNumber}?${verseParams.toString()}`);
+          router.replace(
+            buildWidgetVerseRoute(bookId, chapterNumber, verseStart, verseEnd, isWidget)
+          );
           return;
         }
 
@@ -342,6 +343,42 @@ function RootLayoutInner() {
       }
     };
   }, [router]);
+
+  // Best-effort Android widget-install detection (GH-265, Task 18.4).
+  // On every foreground, query whether the Verse-of-the-Day widget is on the
+  // home screen via react-native-android-widget's getWidgetInfo. Emit
+  // WIDGET_INSTALLED once (guarded by an AsyncStorage flag so it fires a single
+  // time per install, not on every foreground). Android-only and fully
+  // best-effort — any failure is swallowed.
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const WIDGET_INSTALLED_TRACKED_KEY = 'widget-installed-tracked';
+
+    const checkWidgetInstalled = async () => {
+      try {
+        const alreadyTracked = await AsyncStorage.getItem(WIDGET_INSTALLED_TRACKED_KEY);
+        if (alreadyTracked === 'true') return;
+
+        const { getWidgetInfo } = await import('react-native-android-widget');
+        const widgets = await getWidgetInfo('VerseOfTheDay');
+        if (widgets.length > 0) {
+          analytics.track(AnalyticsEvent.WIDGET_INSTALLED, { platform: 'android' });
+          await AsyncStorage.setItem(WIDGET_INSTALLED_TRACKED_KEY, 'true');
+        }
+      } catch {
+        // Best-effort: widget module unavailable or query failed — ignore.
+      }
+    };
+
+    // Run on mount (covers cold start) and on each foreground transition.
+    checkWidgetInstalled();
+    const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'active') checkWidgetInstalled();
+    });
+
+    return () => subscription.remove();
+  }, []);
 
   // Web: copy data-testid → id for Maestro web E2E compatibility
   // Maestro's web driver uses Selenium which matches `id` attribute, not `data-testid`.

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,6 +41,7 @@ import { OfflineProvider } from '@/contexts/OfflineContext';
 import { ThemeProvider as CustomThemeProvider, useTheme } from '@/contexts/ThemeContext';
 import { ToastProvider } from '@/contexts/ToastContext';
 import { preloadAllTopicsCache } from '@/hooks/topics/use-cached-topics';
+import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
   trackAudioPlaybackCompleted,
   trackAudioPlaybackPaused,
@@ -256,7 +257,7 @@ function RootLayoutInner() {
           return;
         }
 
-        const { bookId, chapterNumber } = chapterParsed;
+        const { bookId, chapterNumber, verseStart, verseEnd } = chapterParsed;
 
         // Validate bookId (parser already validates 1-66 range)
         if (bookId < 1 || bookId > 66) {
@@ -273,7 +274,27 @@ function RootLayoutInner() {
           return;
         }
 
-        // TODO: Track analytics - deep_link_navigation_success with { bookId, chapterNumber }
+        // Verse-of-the-day widget deep link carries ?verseStart (and ?src=widget).
+        // Forward to the reader's existing `verse`/`endVerse` params (scroll +
+        // highlight) and emit the re-entry analytics event.
+        const isWidget = url.includes('src=widget');
+        if (verseStart) {
+          if (isWidget) {
+            analytics.track(AnalyticsEvent.WIDGET_TAPPED, {
+              bookId,
+              chapterNumber,
+              verseStart,
+              verseEnd,
+              source: 'verse-of-the-day',
+            });
+          }
+          const verseParams = new URLSearchParams();
+          verseParams.set('verse', String(verseStart));
+          if (verseEnd) verseParams.set('endVerse', String(verseEnd));
+          if (isWidget) verseParams.set('src', 'widget');
+          router.replace(`/bible/${bookId}/${chapterNumber}?${verseParams.toString()}`);
+          return;
+        }
 
         // Navigate to the chapter
         router.replace(`/bible/${bookId}/${chapterNumber}`);

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -135,6 +135,7 @@ export default function ChapterScreen() {
     verse?: string;
     endVerse?: string;
     tab?: string;
+    src?: string;
   }>();
   const targetVerse = params.verse ? Number(params.verse) : undefined;
   const targetEndVerse = params.endVerse ? Number(params.endVerse) : undefined;
@@ -242,6 +243,22 @@ export default function ChapterScreen() {
       }
     }
   }, [targetVerse, activeView, setActiveView]);
+
+  // Verse-of-the-day widget re-entry: when arriving from the widget on a
+  // specific verse, record the dive-deeper event once. The existing
+  // targetVerse flow scrolls to and highlights the verse.
+  const hasTrackedWidgetOpen = useRef(false);
+  useEffect(() => {
+    if (params.src === 'widget' && targetVerse && !hasTrackedWidgetOpen.current) {
+      hasTrackedWidgetOpen.current = true;
+      analytics.track(AnalyticsEvent.WIDGET_OPENED_VERSE_DETAIL, {
+        bookId,
+        chapterNumber,
+        verseNumber: targetVerse,
+        source: 'widget',
+      });
+    }
+  }, [params.src, targetVerse, bookId, chapterNumber]);
 
   // Handle deep-linked insight tab parameter
   // When user opens a shared insight URL, navigate to that specific tab

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -892,7 +892,7 @@ export default function SettingsScreen() {
                   Verse of the Day widget
                 </Text>
                 <Text style={styles.manageDownloadsSubtitle}>
-                  Add today's verse to your home screen
+                  Add the verse of the day to your home screen
                 </Text>
               </View>
               <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -868,6 +868,38 @@ export default function SettingsScreen() {
         {/* Theme Selector Section */}
         <ThemeSelector />
 
+        {/* Home Screen Widget — mobile only (GH-265) */}
+        {Platform.OS !== 'web' && (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Home Screen Widget</Text>
+            <Pressable
+              style={[styles.selectButton, styles.manageDownloadsButton]}
+              onPress={() => router.push('/widget-info')}
+              accessibilityLabel="Set up the verse of the day home screen widget"
+              accessibilityRole="button"
+            >
+              <Ionicons
+                name="calendar-outline"
+                size={20}
+                color={colors.textPrimary}
+                style={styles.manageDownloadsIcon}
+              />
+              <View style={styles.manageDownloadsTextContainer}>
+                <Text
+                  style={[styles.selectButtonText, styles.manageDownloadsTitle]}
+                  numberOfLines={1}
+                >
+                  Verse of the Day widget
+                </Text>
+                <Text style={styles.manageDownloadsSubtitle}>
+                  Add today's verse to your home screen
+                </Text>
+              </View>
+              <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
+            </Pressable>
+          </View>
+        )}
+
         {/* Downloads & Offline — hidden on web (online-only) */}
         {Platform.OS !== 'web' && (
           <View style={styles.section}>

--- a/app/widget-info.tsx
+++ b/app/widget-info.tsx
@@ -5,8 +5,11 @@
  * explains how to add the Verse-of-the-Day home-screen widget per platform.
  *
  * NOTE: the Android programmatic pin-request (AppWidgetManager
- * .requestPinAppWidget, D-35) is wired once the native widget module lands;
- * until then both platforms show manual instructions.
+ * .requestPinAppWidget, D-35) is intentionally NOT implemented. The
+ * react-native-android-widget dependency (v0.20.x) exposes no pin-request API
+ * (no requestPinAppWidget / requestWidgetPin), so wiring it would require a
+ * custom native module. Until that module exists, both platforms show manual
+ * instructions. See GH-265 R-008.
  */
 import { Ionicons } from '@expo/vector-icons';
 import { Stack } from 'expo-router';

--- a/app/widget-info.tsx
+++ b/app/widget-info.tsx
@@ -1,0 +1,86 @@
+/**
+ * Widget setup / install instructions (GH-265).
+ *
+ * Discovery is settings-only (no push, no onboarding nag). This screen
+ * explains how to add the Verse-of-the-Day home-screen widget per platform.
+ *
+ * NOTE: the Android programmatic pin-request (AppWidgetManager
+ * .requestPinAppWidget, D-35) is wired once the native widget module lands;
+ * until then both platforms show manual instructions.
+ */
+import { Ionicons } from '@expo/vector-icons';
+import { Stack } from 'expo-router';
+import { Platform, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+
+const IOS_STEPS = [
+  'Touch and hold an empty area of your Home Screen until the apps jiggle.',
+  'Tap the "+" (Edit / Add Widget) button in the top corner.',
+  'Search for "VerseMate" and pick the Verse of the Day widget.',
+  'Choose a size and tap "Add Widget", then "Done".',
+];
+
+const ANDROID_STEPS = [
+  'Touch and hold an empty area of your Home Screen.',
+  'Tap "Widgets".',
+  'Find "VerseMate" and the Verse of the Day widget.',
+  'Touch and hold it, then drag it to your Home Screen.',
+];
+
+export default function WidgetInfoScreen() {
+  const { colors } = useTheme();
+  const steps = Platform.OS === 'ios' ? IOS_STEPS : ANDROID_STEPS;
+
+  return (
+    <>
+      <Stack.Screen options={{ title: 'Home Screen Widget' }} />
+      <ScrollView
+        style={{ backgroundColor: colors.background }}
+        contentContainerStyle={styles.content}
+        testID="widget-info-screen"
+      >
+        <View style={styles.hero}>
+          <Ionicons name="calendar-outline" size={40} color={colors.primary} />
+          <Text style={[styles.title, { color: colors.textPrimary }]}>Verse of the Day</Text>
+          <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
+            A fresh verse on your home screen each day. Tap it to open the passage in VerseMate.
+          </Text>
+        </View>
+
+        <Text style={[styles.sectionLabel, { color: colors.textPrimary }]}>How to add it</Text>
+        {steps.map((step, i) => (
+          <View key={step} style={styles.step}>
+            <View style={[styles.stepNumber, { backgroundColor: colors.primary }]}>
+              <Text style={styles.stepNumberText}>{i + 1}</Text>
+            </View>
+            <Text style={[styles.stepText, { color: colors.textPrimary }]}>{step}</Text>
+          </View>
+        ))}
+
+        <Text style={[styles.footnote, { color: colors.textSecondary }]}>
+          The widget shows the verse in your preferred translation and refreshes automatically each
+          day.
+        </Text>
+      </ScrollView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: { padding: 20, gap: 8 },
+  hero: { alignItems: 'center', gap: 8, marginBottom: 16 },
+  title: { fontSize: 22, fontWeight: '700' },
+  subtitle: { fontSize: 15, textAlign: 'center', lineHeight: 21 },
+  sectionLabel: { fontSize: 16, fontWeight: '600', marginTop: 8, marginBottom: 4 },
+  step: { flexDirection: 'row', alignItems: 'flex-start', gap: 12, paddingVertical: 8 },
+  stepNumber: {
+    width: 26,
+    height: 26,
+    borderRadius: 13,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  stepNumberText: { color: '#fff', fontWeight: '700' },
+  stepText: { flex: 1, fontSize: 15, lineHeight: 21 },
+  footnote: { fontSize: 13, marginTop: 16, lineHeight: 19 },
+});

--- a/app/widget-info.tsx
+++ b/app/widget-info.tsx
@@ -40,7 +40,7 @@ export default function WidgetInfoScreen() {
         testID="widget-info-screen"
       >
         <View style={styles.hero}>
-          <Ionicons name="calendar-outline" size={40} color={colors.primary} />
+          <Ionicons name="calendar-outline" size={40} color={colors.gold} />
           <Text style={[styles.title, { color: colors.textPrimary }]}>Verse of the Day</Text>
           <Text style={[styles.subtitle, { color: colors.textSecondary }]}>
             A fresh verse on your home screen each day. Tap it to open the passage in VerseMate.
@@ -50,7 +50,7 @@ export default function WidgetInfoScreen() {
         <Text style={[styles.sectionLabel, { color: colors.textPrimary }]}>How to add it</Text>
         {steps.map((step, i) => (
           <View key={step} style={styles.step}>
-            <View style={[styles.stepNumber, { backgroundColor: colors.primary }]}>
+            <View style={[styles.stepNumber, { backgroundColor: colors.gold }]}>
               <Text style={styles.stepNumberText}>{i + 1}</Text>
             </View>
             <Text style={[styles.stepText, { color: colors.textPrimary }]}>{step}</Text>

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,10 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "verse-mate-mobile",
       "dependencies": {
+        "@bacons/apple-targets": "^4.0.7",
         "@expo/vector-icons": "^15.0.3",
         "@gorhom/bottom-sheet": "^5.2.14",
         "@react-native-async-storage/async-storage": "^2.2.0",
@@ -59,6 +59,7 @@
         "react-dom": "19.1.0",
         "react-i18next": "^17.0.6",
         "react-native": "0.81.5",
+        "react-native-android-widget": "^0.20.3",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-markdown-display": "^7.0.2",
         "react-native-modal": "^14.0.0-rc.1",
@@ -66,6 +67,7 @@
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "^5.6.1",
         "react-native-screens": "~4.16.0",
+        "react-native-shared-group-preferences": "^1.1.24",
         "react-native-svg": "15.12.1",
         "react-native-web": "~0.21.0",
         "react-native-webview": "13.15.0",
@@ -307,6 +309,10 @@
 
     "@babel/types": ["@babel/types@7.28.4", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.27.1" } }, "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q=="],
 
+    "@bacons/apple-targets": ["@bacons/apple-targets@4.0.7", "", { "dependencies": { "@bacons/xcode": "1.0.0-alpha.32", "@react-native/normalize-colors": "^0.79.2", "debug": "^4.3.4", "glob": "^10.4.2" }, "peerDependencies": { "expo": ">=52" } }, "sha512-DwD8gbz2vjbmLatR5qlWjrTocG/Ku4d2Kz/rIF4yzREPZtVBHMepVPCH7gEEgZw4PBTtWQe3XMGrPkomNp7QUg=="],
+
+    "@bacons/xcode": ["@bacons/xcode@1.0.0-alpha.32", "", { "dependencies": { "@expo/plist": "^0.0.18", "debug": "^4.3.4", "uuid": "^8.3.2" } }, "sha512-OGpH7+yMbWC2cgYZon5B+VVadH9HsB2V/abtEiplA65XnSuV4GAYAVixOCDc5k182WkfoakfdM0zW6U9cbcsbw=="],
+
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
 
     "@biomejs/biome": ["@biomejs/biome@2.2.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.2.4", "@biomejs/cli-darwin-x64": "2.2.4", "@biomejs/cli-linux-arm64": "2.2.4", "@biomejs/cli-linux-arm64-musl": "2.2.4", "@biomejs/cli-linux-x64": "2.2.4", "@biomejs/cli-linux-x64-musl": "2.2.4", "@biomejs/cli-win32-arm64": "2.2.4", "@biomejs/cli-win32-x64": "2.2.4" }, "bin": { "biome": "bin/biome" } }, "sha512-TBHU5bUy/Ok6m8c0y3pZiuO/BZoY/OcGxoLlrfQof5s8ISVwbVBdFINPQZyFfKwil8XibYWb7JMwnT8wT4WVPg=="],
@@ -493,6 +499,8 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@isaacs/ttlcache": ["@isaacs/ttlcache@1.4.1", "", {}, "sha512-RQgQ4uQ+pLbqXfOmieB91ejmLwvSgv9nLx6sT6sD83s7umBypgg+OIBOBbEUiJXrfpnp9j0mRhYYdzp9uqq3lA=="],
@@ -566,6 +574,8 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@playwright/test": ["@playwright/test@1.55.1", "", { "dependencies": { "playwright": "1.55.1" }, "bin": { "playwright": "cli.js" } }, "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig=="],
 
@@ -641,7 +651,7 @@
 
     "@react-native/js-polyfills": ["@react-native/js-polyfills@0.81.5", "", {}, "sha512-fB7M1CMOCIUudTRuj7kzxIBTVw2KXnsgbQ6+4cbqSxo8NmRRhA0Ul4ZUzZj3rFd3VznTL4Brmocv1oiN0bWZ8w=="],
 
-    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+    "@react-native/normalize-colors": ["@react-native/normalize-colors@0.79.7", "", {}, "sha512-RrvewhdanEWhlyrHNWGXGZCc6MY0JGpNgRzA8y6OomDz0JmlnlIsbBHbNpPnIrt9Jh2KaV10KTscD1Ry8xU9gQ=="],
 
     "@react-native/virtualized-lists": ["@react-native/virtualized-lists@0.81.5", "", { "dependencies": { "invariant": "^2.2.4", "nullthrows": "^1.1.1" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "*", "react-native": "*" }, "optionalPeers": ["@types/react"] }, "sha512-UVXgV/db25OPIvwZySeToXD/9sKKhOdkcWmmf4Jh8iBZuyfML+/5CasaZ1E7Lqg6g3uqVQq75NqIwkYmORJMPw=="],
 
@@ -1229,6 +1239,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.222", "", {}, "sha512-gA7psSwSwQRE60CEoLz6JBCQPIxNeuzB2nL8vE03GK/OHxlvykbLyeiumQy1iH5C2f3YbRAZpGCMT12a/9ih9w=="],
@@ -1471,6 +1483,8 @@
 
     "for-each": ["for-each@0.3.5", "", { "dependencies": { "is-callable": "^1.2.7" } }, "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
 
     "freeport-async": ["freeport-async@2.0.0", "", {}, "sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ=="],
@@ -1696,6 +1710,8 @@
     "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
 
     "iterator.prototype": ["iterator.prototype@1.1.5", "", { "dependencies": { "define-data-property": "^1.1.4", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "get-proto": "^1.0.0", "has-symbols": "^1.1.0", "set-function-name": "^2.0.2" } }, "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jest": ["jest@29.7.0", "", { "dependencies": { "@jest/core": "^29.7.0", "@jest/types": "^29.6.3", "import-local": "^3.0.2", "jest-cli": "^29.7.0" }, "peerDependencies": { "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0" }, "optionalPeers": ["node-notifier"], "bin": { "jest": "bin/jest.js" } }, "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw=="],
 
@@ -2025,6 +2041,8 @@
 
     "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
@@ -2143,6 +2161,8 @@
 
     "react-native": ["react-native@0.81.5", "", { "dependencies": { "@jest/create-cache-key-function": "^29.7.0", "@react-native/assets-registry": "0.81.5", "@react-native/codegen": "0.81.5", "@react-native/community-cli-plugin": "0.81.5", "@react-native/gradle-plugin": "0.81.5", "@react-native/js-polyfills": "0.81.5", "@react-native/normalize-colors": "0.81.5", "@react-native/virtualized-lists": "0.81.5", "abort-controller": "^3.0.0", "anser": "^1.4.9", "ansi-regex": "^5.0.0", "babel-jest": "^29.7.0", "babel-plugin-syntax-hermes-parser": "0.29.1", "base64-js": "^1.5.1", "commander": "^12.0.0", "flow-enums-runtime": "^0.0.6", "glob": "^7.1.1", "invariant": "^2.2.4", "jest-environment-node": "^29.7.0", "memoize-one": "^5.0.0", "metro-runtime": "^0.83.1", "metro-source-map": "^0.83.1", "nullthrows": "^1.1.1", "pretty-format": "^29.7.0", "promise": "^8.3.0", "react-devtools-core": "^6.1.5", "react-refresh": "^0.14.0", "regenerator-runtime": "^0.13.2", "scheduler": "0.26.0", "semver": "^7.1.3", "stacktrace-parser": "^0.1.10", "whatwg-fetch": "^3.0.0", "ws": "^6.2.3", "yargs": "^17.6.2" }, "peerDependencies": { "@types/react": "^19.1.0", "react": "^19.1.0" }, "optionalPeers": ["@types/react"], "bin": { "react-native": "cli.js" } }, "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw=="],
 
+    "react-native-android-widget": ["react-native-android-widget@0.20.3", "", { "peerDependencies": { "expo": ">=54.0.0", "react": "*", "react-native": "*" }, "optionalPeers": ["expo"] }, "sha512-/HZpZda3h4xACK5anrdSuPsL3shqMZ/m5wxL/sk+DTjEI24Yj5/kROUJAQ0uwG4evjPoaLi4x++fuLC9a7qYnw=="],
+
     "react-native-animatable": ["react-native-animatable@1.4.0", "", { "dependencies": { "prop-types": "^15.8.1" } }, "sha512-DZwaDVWm2NBvBxf7I0wXKXLKb/TxDnkV53sWhCvei1pRyTX3MVFpkvdYBknNBqPrxYuAIlPxEp7gJOidIauUkw=="],
 
     "react-native-fit-image": ["react-native-fit-image@1.5.5", "", { "dependencies": { "prop-types": "^15.5.10" } }, "sha512-Wl3Vq2DQzxgsWKuW4USfck9zS7YzhvLNPpkwUUCF90bL32e1a0zOVQ3WsJILJOwzmPdHfzZmWasiiAUNBkhNkg=="],
@@ -2164,6 +2184,8 @@
     "react-native-safe-area-context": ["react-native-safe-area-context@5.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-/wJE58HLEAkATzhhX1xSr+fostLsK8Q97EfpfMDKo8jlOc1QKESSX/FQrhk7HhQH/2uSaox4Y86sNaI02kteiA=="],
 
     "react-native-screens": ["react-native-screens@4.16.0", "", { "dependencies": { "react-freeze": "^1.0.0", "react-native-is-edge-to-edge": "^1.2.1", "warn-once": "^0.1.0" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q=="],
+
+    "react-native-shared-group-preferences": ["react-native-shared-group-preferences@1.1.24", "", { "peerDependencies": { "react-native": ">=0.41.2" } }, "sha512-lncFBltdqXLp8H87wNZUg/P7KvaCqscQ/8GXvrRl0RIUBVVSzrKdAQyBTcsHb7mkMULmph73u41/6nQ5BvUchw=="],
 
     "react-native-svg": ["react-native-svg@15.12.1", "", { "dependencies": { "css-select": "^5.1.0", "css-tree": "^1.1.3", "warn-once": "0.1.1" }, "peerDependencies": { "react": "*", "react-native": "*" } }, "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g=="],
 
@@ -2367,6 +2389,8 @@
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "string.prototype.matchall": ["string.prototype.matchall@4.0.12", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-properties": "^1.2.1", "es-abstract": "^1.23.6", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.6", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "internal-slot": "^1.1.0", "regexp.prototype.flags": "^1.5.3", "set-function-name": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA=="],
 
     "string.prototype.repeat": ["string.prototype.repeat@1.0.0", "", { "dependencies": { "define-properties": "^1.1.3", "es-abstract": "^1.17.5" } }, "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w=="],
@@ -2378,6 +2402,8 @@
     "string.prototype.trimstart": ["string.prototype.trimstart@1.0.8", "", { "dependencies": { "call-bind": "^1.0.7", "define-properties": "^1.2.1", "es-object-atoms": "^1.0.0" } }, "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-bom": ["strip-bom@3.0.0", "", {}, "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA=="],
 
@@ -2523,7 +2549,7 @@
 
     "utils-merge": ["utils-merge@1.0.1", "", {}, "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA=="],
 
-    "uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
@@ -2581,6 +2607,8 @@
 
     "wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "write-file-atomic": ["write-file-atomic@4.0.2", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^3.0.7" } }, "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg=="],
@@ -2630,6 +2658,10 @@
     "@babel/highlight/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 
     "@babel/plugin-transform-runtime/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@bacons/apple-targets/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "@bacons/xcode/@expo/plist": ["@expo/plist@0.0.18", "", { "dependencies": { "@xmldom/xmldom": "~0.7.0", "base64-js": "^1.2.3", "xmlbuilder": "^14.0.0" } }, "sha512-+48gRqUiz65R21CZ/IXa7RNBXgAI/uPSdvJqoN9x1hfL44DNbUoWHgHiEXTx7XelcATpDwNTz6sHLfy0iNqf+w=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -2681,6 +2713,8 @@
 
     "@expo/metro-config/hermes-parser": ["hermes-parser@0.29.1", "", { "dependencies": { "hermes-estree": "0.29.1" } }, "sha512-xBHWmUtRC5e/UL0tI7Ivt2riA/YBq9+SiYFU7C1oBa/j2jYGlIF9043oak1F47ihuDIxQ5nbsKueYJDRY02UgA=="],
 
+    "@expo/prebuild-config/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+
     "@expo/prebuild-config/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@expo/xcpretty/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
@@ -2688,6 +2722,12 @@
     "@hey-api/openapi-ts/semver": ["semver@7.7.2", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
@@ -2799,9 +2839,13 @@
 
     "expo-modules-autolinking/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
 
+    "expo-navigation-bar/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+
     "expo-router/fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
+
+    "expo-system-ui/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
 
     "expo-updates/arg": ["arg@4.1.0", "", {}, "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg=="],
 
@@ -2927,6 +2971,8 @@
 
     "react-i18next/use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "react-native/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
+
     "react-native/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
 
     "react-native/glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
@@ -2997,6 +3043,8 @@
 
     "write-file-atomic/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "xcode/uuid": ["uuid@7.0.3", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg=="],
+
     "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
 
     "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
@@ -3006,6 +3054,12 @@
     "@babel/highlight/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "@babel/highlight/chalk/supports-color": ["supports-color@5.5.0", "", { "dependencies": { "has-flag": "^3.0.0" } }, "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow=="],
+
+    "@bacons/apple-targets/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "@bacons/xcode/@expo/plist/@xmldom/xmldom": ["@xmldom/xmldom@0.7.13", "", {}, "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g=="],
+
+    "@bacons/xcode/@expo/plist/xmlbuilder": ["xmlbuilder@14.0.0", "", {}, "sha512-ts+B2rSe4fIckR6iquDjsKbQFK2NlUk6iG5nf14mDEyldgoc2nEKZ3jZWMPTxGQwVgToSjt6VGIho1H8/fNFTg=="],
 
     "@eslint/config-array/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
@@ -3020,6 +3074,12 @@
     "@expo/metro-config/@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
 
     "@expo/metro-config/hermes-parser/hermes-estree": ["hermes-estree@0.29.1", "", {}, "sha512-jl+x31n4/w+wEqm0I2r4CMimukLbLQEYpisys5oCre611CI5fc9TxhqkBBCJ1edDG4Kza0f7CgNz8xVMLZQOmQ=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
 
@@ -3142,6 +3202,8 @@
     "@babel/highlight/chalk/ansi-styles/color-convert": ["color-convert@1.9.3", "", { "dependencies": { "color-name": "1.1.3" } }, "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg=="],
 
     "@babel/highlight/chalk/supports-color/has-flag": ["has-flag@3.0.0", "", {}, "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="],
+
+    "@bacons/apple-targets/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/auth/token-storage';
 import { clearTokenCache } from '@/lib/api/client-interceptors';
 import { analytics, AnalyticsEvent } from '@/lib/analytics';
+import { syncWidgetUserId } from '@/hooks/use-shared-widget-prefs';
 import {
   getAuthSession,
   postAuthLogin,
@@ -215,6 +216,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   // Get PostHog instance for analytics
   const posthog = usePostHog();
+
+  // Mirror the user's id into the widget container so the home-screen widget
+  // shows this user's personal verse (PD-7); cleared on logout. Memoize the id
+  // so the effect deps are a primitive (Biome react-hooks rule).
+  const widgetUserId = user?.id ?? null;
+  useEffect(() => {
+    void syncWidgetUserId(widgetUserId);
+  }, [widgetUserId]);
 
   /**
    * Fetch user session from backend and cache the result for offline use.

--- a/hooks/use-bible-version.ts
+++ b/hooks/use-bible-version.ts
@@ -15,6 +15,7 @@
 
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
+import { syncWidgetBibleVersion } from '@/hooks/use-shared-widget-prefs';
 import { getPostHogInstance } from '@/lib/analytics/posthog-provider';
 
 const BIBLE_VERSION_KEY = 'bible-version';
@@ -83,6 +84,10 @@ export function useBibleVersion() {
           $set: { preferred_bible_version: version },
         });
       }
+
+      // Mirror to the iOS widget's App Group so the home-screen widget renders
+      // in the newly-selected version (GH-265). Fire-and-forget; no-op on Android.
+      void syncWidgetBibleVersion(version);
 
       notifyBibleVersionChanged();
     } catch (error) {

--- a/hooks/use-shared-widget-prefs.ts
+++ b/hooks/use-shared-widget-prefs.ts
@@ -1,20 +1,26 @@
 /**
- * Bridge the user's preferred Bible version into the iOS widget's shared
- * container (GH-265).
+ * Bridge per-user widget data (preferred Bible version + personalization id)
+ * into the widget's shared container (GH-265).
  *
- * The iOS Verse-of-the-Day widget runs in a separate process and reads the
- * preferred version from the App Group `group.org.versemate.app`. We mirror
- * the version there whenever it changes. Android needs nothing here — its
- * widget task handler reads the same AsyncStorage key directly (shared JS
- * sandbox).
+ * The iOS Verse-of-the-Day widget runs in a separate process and reads from
+ * the App Group `group.org.versemate.app`, so we mirror values there. The
+ * Android widget task handler reads the same AsyncStorage keys directly
+ * (shared JS sandbox).
  *
- * Authored without an Apple toolchain — verify the App Group write on device.
+ * Authored without an Apple toolchain — verify the App Group writes on device.
  */
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import SharedGroupPreferences from 'react-native-shared-group-preferences';
 
 const APP_GROUP = 'group.org.versemate.app';
 const VERSION_KEY = 'preferred_bible_version';
+// Personalization id (the logged-in user's own id). The Android widget reads
+// it from AsyncStorage (shared JS sandbox); the iOS widget reads it from the
+// App Group. Used as `pid` so the widget shows the user's personal verse
+// (PD-7). Cleared on logout so the widget reverts to the global verse.
+const USER_ID_ASYNC_KEY = 'widget-user-id';
+const USER_ID_GROUP_KEY = 'widget_user_id';
 
 export async function syncWidgetBibleVersion(version: string): Promise<void> {
   // iOS-only: Android's widget reads AsyncStorage in its own JS task handler.
@@ -24,6 +30,37 @@ export async function syncWidgetBibleVersion(version: string): Promise<void> {
   } catch (error) {
     if (__DEV__) {
       console.warn('[widget] failed to sync Bible version to App Group:', error);
+    }
+  }
+}
+
+/**
+ * Mirror the logged-in user's id into the widget container so the widget can
+ * request that user's personal verse of the day (PD-7). Pass `null` on logout
+ * to clear it (the widget then shows the global verse). Best-effort: failures
+ * are swallowed so they never break auth or the widget.
+ *
+ * Android reads the AsyncStorage key directly (shared JS sandbox); iOS reads
+ * the App Group, so we mirror there too.
+ */
+export async function syncWidgetUserId(userId: string | null): Promise<void> {
+  try {
+    if (userId) {
+      await AsyncStorage.setItem(USER_ID_ASYNC_KEY, userId);
+    } else {
+      await AsyncStorage.removeItem(USER_ID_ASYNC_KEY);
+    }
+    if (Platform.OS === 'ios') {
+      // No delete API — store empty string to represent "no user".
+      await SharedGroupPreferences.setItem(
+        USER_ID_GROUP_KEY,
+        userId ?? '',
+        APP_GROUP,
+      );
+    }
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[widget] failed to sync user id:', error);
     }
   }
 }

--- a/hooks/use-shared-widget-prefs.ts
+++ b/hooks/use-shared-widget-prefs.ts
@@ -1,0 +1,29 @@
+/**
+ * Bridge the user's preferred Bible version into the iOS widget's shared
+ * container (GH-265).
+ *
+ * The iOS Verse-of-the-Day widget runs in a separate process and reads the
+ * preferred version from the App Group `group.org.versemate.app`. We mirror
+ * the version there whenever it changes. Android needs nothing here — its
+ * widget task handler reads the same AsyncStorage key directly (shared JS
+ * sandbox).
+ *
+ * Authored without an Apple toolchain — verify the App Group write on device.
+ */
+import { Platform } from 'react-native';
+import SharedGroupPreferences from 'react-native-shared-group-preferences';
+
+const APP_GROUP = 'group.org.versemate.app';
+const VERSION_KEY = 'preferred_bible_version';
+
+export async function syncWidgetBibleVersion(version: string): Promise<void> {
+  // iOS-only: Android's widget reads AsyncStorage in its own JS task handler.
+  if (Platform.OS !== 'ios') return;
+  try {
+    await SharedGroupPreferences.setItem(VERSION_KEY, version, APP_GROUP);
+  } catch (error) {
+    if (__DEV__) {
+      console.warn('[widget] failed to sync Bible version to App Group:', error);
+    }
+  }
+}

--- a/hooks/use-shared-widget-prefs.ts
+++ b/hooks/use-shared-widget-prefs.ts
@@ -52,11 +52,7 @@ export async function syncWidgetUserId(userId: string | null): Promise<void> {
     }
     if (Platform.OS === 'ios') {
       // No delete API — store empty string to represent "no user".
-      await SharedGroupPreferences.setItem(
-        USER_ID_GROUP_KEY,
-        userId ?? '',
-        APP_GROUP,
-      );
+      await SharedGroupPreferences.setItem(USER_ID_GROUP_KEY, userId ?? '', APP_GROUP);
     }
   } catch (error) {
     if (__DEV__) {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+// App entry point.
+//
+// Wraps the standard Expo Router entry to also register the Android
+// Verse-of-the-Day widget task handler (GH-265). registerWidgetTaskHandler is
+// a no-op outside Android, so this is safe on all platforms.
+import 'expo-router/entry';
+import { registerWidgetTaskHandler } from 'react-native-android-widget';
+import { widgetTaskHandler } from './widgets/widget-task-handler';
+
+registerWidgetTaskHandler(widgetTaskHandler);

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -63,6 +63,11 @@ export enum AnalyticsEvent {
   UPGRADE_PROMPT_SHOWN = 'upgrade_prompt_shown',
   UPGRADE_PROMPT_CTA_TAPPED = 'upgrade_prompt_cta_tapped',
   UPGRADE_PROMPT_DISMISSED = 'upgrade_prompt_dismissed',
+
+  // Verse-of-the-Day Widget Events (GH-265)
+  WIDGET_TAPPED = 'WIDGET_TAPPED',
+  WIDGET_OPENED_VERSE_DETAIL = 'WIDGET_OPENED_VERSE_DETAIL',
+  WIDGET_INSTALLED = 'WIDGET_INSTALLED',
 }
 
 // ============================================================================
@@ -340,6 +345,26 @@ export interface UpgradePromptDismissedProperties {
 // Event Properties Type Map
 // ============================================================================
 
+// Verse-of-the-Day Widget Events (GH-265)
+export interface WidgetTappedProperties {
+  bookId: number;
+  chapterNumber: number;
+  verseStart?: number;
+  verseEnd?: number;
+  source: string;
+}
+
+export interface WidgetOpenedVerseDetailProperties {
+  bookId: number;
+  chapterNumber: number;
+  verseNumber: number;
+  source: string;
+}
+
+export interface WidgetInstalledProperties {
+  platform: 'ios' | 'android';
+}
+
 /**
  * Maps each AnalyticsEvent to its corresponding properties type
  * Enables type-safe tracking calls
@@ -383,6 +408,10 @@ export interface EventProperties {
   [AnalyticsEvent.UPGRADE_PROMPT_SHOWN]: UpgradePromptShownProperties;
   [AnalyticsEvent.UPGRADE_PROMPT_CTA_TAPPED]: UpgradePromptCtaTappedProperties;
   [AnalyticsEvent.UPGRADE_PROMPT_DISMISSED]: UpgradePromptDismissedProperties;
+  // Verse-of-the-Day Widget Events (GH-265)
+  [AnalyticsEvent.WIDGET_TAPPED]: WidgetTappedProperties;
+  [AnalyticsEvent.WIDGET_OPENED_VERSE_DETAIL]: WidgetOpenedVerseDetailProperties;
+  [AnalyticsEvent.WIDGET_INSTALLED]: WidgetInstalledProperties;
 }
 
 // ============================================================================

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "verse-mate-mobile",
-  "main": "expo-router/entry",
+  "main": "index.js",
   "version": "1.3.0",
   "scripts": {
     "start": "expo start",
@@ -33,6 +33,7 @@
     "validate": "bun run lint && bun run type-check && bun run test"
   },
   "dependencies": {
+    "@bacons/apple-targets": "^4.0.7",
     "@expo/vector-icons": "^15.0.3",
     "@gorhom/bottom-sheet": "^5.2.14",
     "@react-native-async-storage/async-storage": "^2.2.0",
@@ -87,6 +88,7 @@
     "react-dom": "19.1.0",
     "react-i18next": "^17.0.6",
     "react-native": "0.81.5",
+    "react-native-android-widget": "^0.20.3",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-markdown-display": "^7.0.2",
     "react-native-modal": "^14.0.0-rc.1",
@@ -94,6 +96,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "^5.6.1",
     "react-native-screens": "~4.16.0",
+    "react-native-shared-group-preferences": "^1.1.24",
     "react-native-svg": "15.12.1",
     "react-native-web": "~0.21.0",
     "react-native-webview": "13.15.0",

--- a/targets/widget/expo-target.config.js
+++ b/targets/widget/expo-target.config.js
@@ -1,0 +1,17 @@
+/**
+ * @bacons/apple-targets config for the Verse-of-the-Day WidgetKit extension
+ * (GH-265). Generated into a native target by `expo prebuild`.
+ *
+ * The App Group must match the main app (app.config.js ios.entitlements) so
+ * the widget can read the user's preferred Bible version written by the JS app.
+ *
+ * NOTE: authored without a local Apple toolchain — verify on a machine with
+ * Xcode (`expo prebuild -p ios` then open the workspace).
+ */
+module.exports = {
+  type: "widget",
+  name: "VerseOfTheDay",
+  entitlements: {
+    "com.apple.security.application-groups": ["group.org.versemate.app"],
+  },
+};

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -17,6 +17,10 @@ import SwiftUI
 
 private let appGroup = "group.org.versemate.app"
 private let versionKeyDefaultsKey = "preferred_bible_version"
+// Personalization id (the logged-in user's own id) mirrored from the app via
+// the App Group; sent as `pid` so the widget shows the user's personal verse
+// (PD-7). Empty/absent when logged out → the endpoint serves the global verse.
+private let userIdDefaultsKey = "widget_user_id"
 private let cacheKey = "votd_last_response"
 private let apiBaseURL = "https://api.versemate.org"
 // KNOWN PROD-ONLY CONSTANT (GH-265 / L-003): the iOS widget extension is a
@@ -63,6 +67,11 @@ private func preferredVersion() -> String {
   sharedDefaults()?.string(forKey: versionKeyDefaultsKey) ?? defaultVersion
 }
 
+private func personalizationId() -> String? {
+  let id = sharedDefaults()?.string(forKey: userIdDefaultsKey)
+  return (id?.isEmpty == false) ? id : nil
+}
+
 private func localDateString() -> String {
   let f = DateFormatter()
   f.dateFormat = "yyyy-MM-dd"
@@ -86,10 +95,14 @@ private func fetchVerseOfTheDay(completion: @escaping (VerseOfTheDay?) -> Void) 
   guard
     var components = URLComponents(string: "\(apiBaseURL)/bible/verse-of-the-day")
   else { completion(cachedResponse()); return }
-  components.queryItems = [
+  var items = [
     URLQueryItem(name: "date", value: date),
     URLQueryItem(name: "bible_version", value: version),
   ]
+  if let pid = personalizationId() {
+    items.append(URLQueryItem(name: "pid", value: pid))
+  }
+  components.queryItems = items
   guard let url = components.url else { completion(cachedResponse()); return }
 
   let task = URLSession.shared.dataTask(with: url) { data, _, _ in

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -19,6 +19,15 @@ private let appGroup = "group.org.versemate.app"
 private let versionKeyDefaultsKey = "preferred_bible_version"
 private let cacheKey = "votd_last_response"
 private let apiBaseURL = "https://api.versemate.org"
+// KNOWN PROD-ONLY CONSTANT (GH-265 / L-003): the iOS widget extension is a
+// separate process and cannot read the JS `EXPO_PUBLIC_WEB_URL` at runtime, so
+// this host is hardcoded to production. It MUST match the deployed web host that
+// the JS deep-link parser (parseChapterShareUrl) validates against — on the JS
+// side that value comes from EXPO_PUBLIC_WEB_URL. On a non-prod build whose web
+// host differs, an iOS widget tap would deep-link to a host the parser rejects
+// (falling back to Genesis 1). If non-prod iOS widget taps ever need to work,
+// inject the host at build time (e.g. an Info.plist value derived from the same
+// env, read here via Bundle.main.object(forInfoDictionaryKey:)).
 private let webBaseURL = "https://app.versemate.org"
 private let defaultVersion = "NASB1995"
 

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -1,0 +1,190 @@
+// Verse-of-the-Day iOS widget (GH-265).
+//
+// Authored without a local Apple toolchain — NOT compiled/run/device-tested.
+// Verify with `expo prebuild -p ios` + Xcode before release.
+//
+// Behavior:
+//  - Reads the user's preferred Bible version from the shared App Group
+//    (written by the JS app via react-native-shared-group-preferences).
+//  - Fetches GET /bible/verse-of-the-day in that version.
+//  - Renders verse + reference, adapting across widget families.
+//  - Tapping deep-links to the Universal Link form with the verse range so
+//    the app scrolls to the verse and emits WIDGET_TAPPED.
+//  - On error, shows the last cached entry (App Group) or a branded fallback.
+
+import WidgetKit
+import SwiftUI
+
+private let appGroup = "group.org.versemate.app"
+private let versionKeyDefaultsKey = "preferred_bible_version"
+private let cacheKey = "votd_last_response"
+private let apiBaseURL = "https://api.versemate.org"
+private let webBaseURL = "https://app.versemate.org"
+private let defaultVersion = "NASB1995"
+
+// MARK: - Model
+
+struct VerseOfTheDay: Codable {
+  let empty: Bool
+  let referenceText: String?
+  let verses: [Verse]?
+  let date: String?
+  let reference: Reference?
+  let fallbackMessage: String?
+
+  struct Verse: Codable {
+    let verseNumber: Int
+    let text: String
+  }
+  struct Reference: Codable {
+    let bookId: Int
+    let chapterNumber: Int
+    let verseStart: Int
+    let verseEnd: Int?
+  }
+}
+
+// MARK: - Shared helpers
+
+private func sharedDefaults() -> UserDefaults? {
+  UserDefaults(suiteName: appGroup)
+}
+
+private func preferredVersion() -> String {
+  sharedDefaults()?.string(forKey: versionKeyDefaultsKey) ?? defaultVersion
+}
+
+private func localDateString() -> String {
+  let f = DateFormatter()
+  f.dateFormat = "yyyy-MM-dd"
+  f.calendar = Calendar.current
+  f.timeZone = TimeZone.current
+  return f.string(from: Date())
+}
+
+private func cacheResponse(_ data: Data) {
+  sharedDefaults()?.set(data, forKey: cacheKey)
+}
+
+private func cachedResponse() -> VerseOfTheDay? {
+  guard let data = sharedDefaults()?.data(forKey: cacheKey) else { return nil }
+  return try? JSONDecoder().decode(VerseOfTheDay.self, from: data)
+}
+
+private func fetchVerseOfTheDay(completion: @escaping (VerseOfTheDay?) -> Void) {
+  let version = preferredVersion()
+  let date = localDateString()
+  guard
+    var components = URLComponents(string: "\(apiBaseURL)/bible/verse-of-the-day")
+  else { completion(cachedResponse()); return }
+  components.queryItems = [
+    URLQueryItem(name: "date", value: date),
+    URLQueryItem(name: "bible_version", value: version),
+  ]
+  guard let url = components.url else { completion(cachedResponse()); return }
+
+  let task = URLSession.shared.dataTask(with: url) { data, _, _ in
+    guard let data = data,
+      let decoded = try? JSONDecoder().decode(VerseOfTheDay.self, from: data)
+    else {
+      completion(cachedResponse())  // stale-cache fallback
+      return
+    }
+    if !decoded.empty { cacheResponse(data) }
+    completion(decoded)
+  }
+  task.resume()
+}
+
+private func deepLinkURL(_ ref: VerseOfTheDay.Reference) -> URL? {
+  var s = "\(webBaseURL)/bible/\(ref.bookId)/\(ref.chapterNumber)?verseStart=\(ref.verseStart)"
+  if let end = ref.verseEnd { s += "&verseEnd=\(end)" }
+  s += "&src=widget"
+  return URL(string: s)
+}
+
+// MARK: - Timeline
+
+struct VerseEntry: TimelineEntry {
+  let date: Date
+  let verse: VerseOfTheDay?
+}
+
+struct Provider: TimelineProvider {
+  func placeholder(in context: Context) -> VerseEntry {
+    VerseEntry(date: Date(), verse: cachedResponse())
+  }
+
+  func getSnapshot(in context: Context, completion: @escaping (VerseEntry) -> Void) {
+    completion(VerseEntry(date: Date(), verse: cachedResponse()))
+  }
+
+  func getTimeline(in context: Context, completion: @escaping (Timeline<VerseEntry>) -> Void) {
+    fetchVerseOfTheDay { verse in
+      let entry = VerseEntry(date: Date(), verse: verse)
+      // Refresh at the next local midnight.
+      let nextMidnight =
+        Calendar.current.nextDate(
+          after: Date(),
+          matching: DateComponents(hour: 0, minute: 1),
+          matchingPolicy: .nextTime
+        ) ?? Date().addingTimeInterval(3600)
+      completion(Timeline(entries: [entry], policy: .after(nextMidnight)))
+    }
+  }
+}
+
+// MARK: - View
+
+struct VerseOfTheDayWidgetView: View {
+  @Environment(\.widgetFamily) var family
+  let entry: VerseEntry
+
+  private var verseText: String {
+    guard let v = entry.verse, v.empty == false, let verses = v.verses else {
+      return entry.verse?.fallbackMessage ?? "Open VerseMate to see today's verse"
+    }
+    return verses.map { $0.text }.joined(separator: " ")
+  }
+
+  private var reference: String {
+    entry.verse?.referenceText ?? "VerseMate"
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(verseText)
+        .font(family == .systemSmall ? .caption : .body)
+        .lineLimit(family == .systemSmall ? 4 : 6)
+        .minimumScaleFactor(0.8)
+      Spacer(minLength: 2)
+      HStack {
+        Text(reference)
+          .font(.caption2.weight(.semibold))
+          .foregroundColor(.secondary)
+        Spacer()
+        Text("VerseMate")
+          .font(.caption2)
+          .foregroundColor(.secondary.opacity(0.7))
+      }
+    }
+    .padding(12)
+    .widgetURL(entry.verse?.reference.flatMap(deepLinkURL))
+  }
+}
+
+// MARK: - Widget
+
+@main
+struct VerseOfTheDayWidget: Widget {
+  let kind = "VerseOfTheDayWidget"
+
+  var body: some WidgetConfiguration {
+    StaticConfiguration(kind: kind, provider: Provider()) { entry in
+      VerseOfTheDayWidgetView(entry: entry)
+    }
+    .configurationDisplayName("Verse of the Day")
+    .description("Today's Bible verse from VerseMate.")
+    .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+  }
+}

--- a/utils/sharing/generate-chapter-share-url.ts
+++ b/utils/sharing/generate-chapter-share-url.ts
@@ -158,3 +158,35 @@ export function parseChapterShareUrl(url: string): {
     return null;
   }
 }
+
+/**
+ * Builds the in-app reader route for a verse-of-the-day widget deep link.
+ *
+ * Maps the parsed `verseStart`/`verseEnd` onto the reader's existing
+ * `verse`/`endVerse` query params (which drive scroll-to + highlight). When the
+ * link came from the widget (`?src=widget`), `src=widget` is preserved so the
+ * chapter screen can fire its WIDGET_OPENED_VERSE_DETAIL re-entry event.
+ *
+ * Pure string builder — extracted from the deep-link handler so the forwarding
+ * mapping is unit-testable (GH-265 T-002).
+ *
+ * @param bookId - Validated Bible book ID (1-66)
+ * @param chapterNumber - Validated chapter number (>= 1)
+ * @param verseStart - First verse to scroll to / highlight
+ * @param verseEnd - Optional last verse of the passage
+ * @param isWidget - Whether the originating link carried `?src=widget`
+ * @returns Reader route, e.g. `/bible/43/3?verse=16&endVerse=18&src=widget`
+ */
+export function buildWidgetVerseRoute(
+  bookId: number,
+  chapterNumber: number,
+  verseStart: number,
+  verseEnd: number | undefined,
+  isWidget: boolean
+): string {
+  const verseParams = new URLSearchParams();
+  verseParams.set('verse', String(verseStart));
+  if (verseEnd) verseParams.set('endVerse', String(verseEnd));
+  if (isWidget) verseParams.set('src', 'widget');
+  return `/bible/${bookId}/${chapterNumber}?${verseParams.toString()}`;
+}

--- a/utils/sharing/generate-chapter-share-url.ts
+++ b/utils/sharing/generate-chapter-share-url.ts
@@ -90,9 +90,12 @@ export function generateChapterShareUrl(
  * parseChapterShareUrl('https://example.com/wrong/path')
  * // Returns: null
  */
-export function parseChapterShareUrl(
-  url: string
-): { bookId: number; chapterNumber: number } | null {
+export function parseChapterShareUrl(url: string): {
+  bookId: number;
+  chapterNumber: number;
+  verseStart?: number;
+  verseEnd?: number;
+} | null {
   const baseUrl = process.env.EXPO_PUBLIC_WEB_URL;
 
   if (!baseUrl) {
@@ -134,7 +137,22 @@ export function parseChapterShareUrl(
       return null;
     }
 
-    return { bookId, chapterNumber };
+    // Optional verse range (used by the verse-of-the-day widget deep link):
+    // ?verseStart=N&verseEnd=M. Invalid/absent values are simply omitted.
+    const parsePositiveInt = (raw: string | null): number | undefined => {
+      if (!raw) return undefined;
+      const n = Number.parseInt(raw, 10);
+      return Number.isNaN(n) || n < 1 ? undefined : n;
+    };
+    const verseStart = parsePositiveInt(urlObj.searchParams.get('verseStart'));
+    const verseEnd = parsePositiveInt(urlObj.searchParams.get('verseEnd'));
+
+    return {
+      bookId,
+      chapterNumber,
+      ...(verseStart !== undefined ? { verseStart } : {}),
+      ...(verseEnd !== undefined ? { verseEnd } : {}),
+    };
   } catch (error) {
     console.warn('Failed to parse chapter share URL:', error);
     return null;

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -1,0 +1,59 @@
+/**
+ * Android Verse-of-the-Day widget UI (GH-265).
+ *
+ * react-native-android-widget renders this RN-like tree into a native
+ * RemoteViews widget. Authored without an Android build — verify with
+ * `expo prebuild -p android` + a device/emulator.
+ */
+import { FlexWidget, TextWidget } from "react-native-android-widget";
+
+export interface VerseOfTheDayWidgetProps {
+  verseText: string;
+  reference: string;
+  /** Universal-link deep link with verse range + src=widget. */
+  deepLink: string;
+}
+
+export function VerseOfTheDayWidget({
+  verseText,
+  reference,
+  deepLink,
+}: VerseOfTheDayWidgetProps) {
+  return (
+    <FlexWidget
+      style={{
+        height: "match_parent",
+        width: "match_parent",
+        flexDirection: "column",
+        justifyContent: "space-between",
+        backgroundColor: "#ffffff",
+        borderRadius: 16,
+        padding: 14,
+      }}
+      clickAction="OPEN_VERSE"
+      clickActionData={{ url: deepLink }}
+    >
+      <TextWidget
+        text={verseText}
+        maxLines={6}
+        style={{ fontSize: 15, color: "#1a1a1a" }}
+      />
+      <FlexWidget
+        style={{
+          flexDirection: "row",
+          justifyContent: "space-between",
+          width: "match_parent",
+        }}
+      >
+        <TextWidget
+          text={reference}
+          style={{ fontSize: 12, color: "#6b6b6b", fontWeight: "600" }}
+        />
+        <TextWidget
+          text="VerseMate"
+          style={{ fontSize: 11, color: "#9b9b9b" }}
+        />
+      </FlexWidget>
+    </FlexWidget>
+  );
+}

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -1,0 +1,111 @@
+/**
+ * Android widget task handler (GH-265).
+ *
+ * Runs in a headless JS context when the OS adds/updates the widget or the
+ * user taps it. Fetches today's verse in the user's preferred translation
+ * (read from the same AsyncStorage key the app uses — Android shares the JS
+ * sandbox, so no App Group is needed), renders the widget tree, and opens the
+ * deep link on tap.
+ *
+ * Authored without an Android build — verify on device/emulator.
+ */
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { Linking } from "react-native";
+import type { WidgetTaskHandlerProps } from "react-native-android-widget";
+import { VerseOfTheDayWidget } from "./VerseOfTheDayWidget";
+
+const BIBLE_VERSION_KEY = "bible-version";
+const DEFAULT_VERSION = "NASB1995";
+const FALLBACK_MESSAGE = "Open VerseMate to see today's verse";
+const WEB_BASE_URL = "https://app.versemate.org";
+
+interface VerseResponse {
+  empty: boolean;
+  referenceText?: string;
+  verses?: { verseNumber: number; text: string }[];
+  reference?: {
+    bookId: number;
+    chapterNumber: number;
+    verseStart: number;
+    verseEnd: number | null;
+  };
+  fallbackMessage?: string;
+}
+
+function localDate(): string {
+  const n = new Date();
+  return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
+}
+
+function buildDeepLink(ref?: VerseResponse["reference"]): string {
+  if (!ref) return `${WEB_BASE_URL}/bible/1/1?src=widget`;
+  let url = `${WEB_BASE_URL}/bible/${ref.bookId}/${ref.chapterNumber}?verseStart=${ref.verseStart}`;
+  if (ref.verseEnd) url += `&verseEnd=${ref.verseEnd}`;
+  return `${url}&src=widget`;
+}
+
+async function fetchVerse(): Promise<{
+  verseText: string;
+  reference: string;
+  deepLink: string;
+}> {
+  const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
+  const version =
+    (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
+
+  try {
+    const res = await fetch(
+      `${apiBase}/bible/verse-of-the-day?date=${localDate()}&bible_version=${version}`
+    );
+    const data = (await res.json()) as VerseResponse;
+    if (data.empty || !data.verses?.length) {
+      return {
+        verseText: data.fallbackMessage ?? FALLBACK_MESSAGE,
+        reference: "VerseMate",
+        deepLink: buildDeepLink(data.reference),
+      };
+    }
+    return {
+      verseText: data.verses.map((v) => v.text).join(" "),
+      reference: data.referenceText ?? "VerseMate",
+      deepLink: buildDeepLink(data.reference),
+    };
+  } catch {
+    return {
+      verseText: FALLBACK_MESSAGE,
+      reference: "VerseMate",
+      deepLink: `${WEB_BASE_URL}/bible/1/1?src=widget`,
+    };
+  }
+}
+
+export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
+  switch (props.widgetAction) {
+    case "WIDGET_ADDED":
+    case "WIDGET_UPDATE":
+    case "WIDGET_RESIZED": {
+      const { verseText, reference, deepLink } = await fetchVerse();
+      props.renderWidget(
+        <VerseOfTheDayWidget
+          verseText={verseText}
+          reference={reference}
+          deepLink={deepLink}
+        />
+      );
+      break;
+    }
+    case "WIDGET_CLICK": {
+      if (props.clickAction === "OPEN_VERSE") {
+        const url = props.clickActionData?.url;
+        if (typeof url === "string") {
+          Linking.openURL(url).catch(() => {
+            /* no-op: launcher without deep-link support */
+          });
+        }
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -16,6 +16,10 @@ import { VerseOfTheDayWidget } from "./VerseOfTheDayWidget";
 
 const BIBLE_VERSION_KEY = "bible-version";
 const DEFAULT_VERSION = "NASB1995";
+// Personalization id (the logged-in user's own id) the app mirrors into
+// AsyncStorage; sent as `pid` so the widget shows the user's personal verse
+// (PD-7). Absent when logged out → the endpoint serves the global verse.
+const USER_ID_KEY = "widget-user-id";
 const FALLBACK_MESSAGE = "Open VerseMate to see today's verse";
 
 /**
@@ -62,11 +66,12 @@ export async function fetchVerse(): Promise<{
   const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
   const version =
     (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
+  const pid = await AsyncStorage.getItem(USER_ID_KEY);
 
   try {
-    const res = await fetch(
-      `${apiBase}/bible/verse-of-the-day?date=${localDate()}&bible_version=${version}`
-    );
+    let url = `${apiBase}/bible/verse-of-the-day?date=${localDate()}&bible_version=${version}`;
+    if (pid) url += `&pid=${encodeURIComponent(pid)}`;
+    const res = await fetch(url);
     const data = (await res.json()) as VerseResponse;
     if (data.empty || !data.verses?.length) {
       return {

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -17,7 +17,17 @@ import { VerseOfTheDayWidget } from "./VerseOfTheDayWidget";
 const BIBLE_VERSION_KEY = "bible-version";
 const DEFAULT_VERSION = "NASB1995";
 const FALLBACK_MESSAGE = "Open VerseMate to see today's verse";
-const WEB_BASE_URL = "https://app.versemate.org";
+
+/**
+ * Base web host for the tap deep link.
+ *
+ * Must match the host the deep-link parser expects: parseChapterShareUrl
+ * (utils/sharing/generate-chapter-share-url.ts) rejects any URL whose host
+ * differs from `EXPO_PUBLIC_WEB_URL`. Deriving from the same env here keeps the
+ * widget link and the parser in sync on every build (staging/preview/dev),
+ * instead of hardcoding prod. Falls back to prod when the env is unset.
+ */
+const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? "https://app.versemate.org";
 
 interface VerseResponse {
   empty: boolean;
@@ -37,14 +47,14 @@ function localDate(): string {
   return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
 }
 
-function buildDeepLink(ref?: VerseResponse["reference"]): string {
+export function buildDeepLink(ref?: VerseResponse["reference"]): string {
   if (!ref) return `${WEB_BASE_URL}/bible/1/1?src=widget`;
   let url = `${WEB_BASE_URL}/bible/${ref.bookId}/${ref.chapterNumber}?verseStart=${ref.verseStart}`;
   if (ref.verseEnd) url += `&verseEnd=${ref.verseEnd}`;
   return `${url}&src=widget`;
 }
 
-async function fetchVerse(): Promise<{
+export async function fetchVerse(): Promise<{
   verseText: string;
   reference: string;
   deepLink: string;


### PR DESCRIPTION
## Summary

Mobile side of the Verse-of-the-Day home-screen widget (GH-265). Backend + admin: verse-mate#266.

This PR is split into a **verified JS/UI layer** (landed) and the **native widget** (remaining — needs a machine with Xcode / Android toolchain).

### ✅ Landed & verified (tsc clean, parser unit-tested, Maestro flow)
- `parseChapterShareUrl` parses optional `?verseStart`/`&verseEnd` (backward compatible).
- Deep-link handler forwards the verse range to the reader's `verse`/`endVerse` params and emits `WIDGET_TAPPED` when `src=widget`.
- Chapter reader emits `WIDGET_OPENED_VERSE_DETAIL` on widget arrival (existing `targetVerse` flow scrolls to + highlights the verse).
- Analytics events `WIDGET_TAPPED` / `WIDGET_OPENED_VERSE_DETAIL` / `WIDGET_INSTALLED` + typed properties.
- Settings → "Home Screen Widget" row → `/widget-info` screen with platform-aware install instructions.
- Tests: verse-param cases in `chapter-share-url.test.ts`; `.maestro/widget/verse-of-the-day-deep-link-flow.yaml`.

### ⏳ Remaining — native widget (per D-21, on this PR/branch)
The widget UI + build wiring can't be built/run/device-tested in the dev sandbox, so it's staged as follow-up commits on this branch:
- **iOS** via `@bacons/apple-targets`: WidgetKit extension (`targets/VerseMateWidget/`) — SwiftUI view + `TimelineProvider`, `URLSession` fetch of `GET /bible/verse-of-the-day`, reads preferred version from App Group `group.org.versemate.app`, deep links via the Universal Link form.
- **Android** via `react-native-android-widget`: JS-defined widget + task handler (fetch + render + `WorkManager` daily refresh).
- App Group / shared-prefs wiring for the version string; `app.config.js` plugin registration; `expo prebuild` verification.
- Android programmatic pin-request (D-35) in the info screen.

### Deep-link contract
`https://app.versemate.org/bible/{bookId}/{chapterNumber}?verseStart=N&verseEnd=M&src=widget` (Universal/App Link form — what `parseChapterShareUrl` handles).

## Test plan
- [ ] CI: type-check, Biome/ESLint
- [ ] CI: `chapter-share-url.test.ts`
- [ ] Device: build with native widget, add widget, tap → opens chapter at verse
- [ ] Device: widget renders preferred translation, refreshes at local midnight

Spec: `devspace/specs/2026-06-05-1317-verse-of-the-day-widget/`

🤖 Generated with Claude Code