### PR TITLE
MOBILE-1001: Landscape & reader UX bug batch (#1 #2 #3 #5 #7 #9)

### DIFF
--- a/__tests__/components/bible/AutoHighlightTooltip.test.tsx
+++ b/__tests__/components/bible/AutoHighlightTooltip.test.tsx
@@ -169,4 +169,33 @@ describe('AutoHighlightTooltip', () => {
     // Tooltip now always starts expanded, so verse insight should be immediately visible
     expect(screen.getByText(/God loved the world so much/)).toBeTruthy();
   });
+
+  /**
+   * MOBILE-1001 #9: the analysis is no longer trapped in a fixed-height inner
+   * ScrollView — the whole modal body scrolls as one region. Guard that the
+   * Analysis heading + body AND the action footer all render together, so the
+   * full analysis stays reachable alongside the buttons.
+   */
+  it('renders the full analysis together with the action footer (single scroll region, #9)', () => {
+    renderWithProviders(
+      <AutoHighlightTooltip
+        autoHighlight={mockAutoHighlight}
+        visible={true}
+        onClose={mockOnClose}
+        onSaveAsUserHighlight={mockOnSave}
+        isLoggedIn={true}
+      />
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(500);
+    });
+
+    // Analysis content is present (not clipped/trapped)...
+    expect(screen.getByText('Analysis')).toBeTruthy();
+    expect(screen.getByText(/God loved the world so much/)).toBeTruthy();
+    // ...and the fixed action footer is reachable in the same view.
+    expect(screen.getByText('Copy')).toBeTruthy();
+    expect(screen.getByText('Share')).toBeTruthy();
+  });
 });

--- a/__tests__/components/bible/ChapterContentTabs.test.tsx
+++ b/__tests__/components/bible/ChapterContentTabs.test.tsx
@@ -144,4 +144,39 @@ describe('ChapterContentTabs', () => {
     expect(screen.getByText('Visuals')).toBeTruthy();
     expect(screen.queryByText('Detailed')).toBeNull();
   });
+
+  /**
+   * Test 7 (MOBILE-1001 #1): when the track is too narrow to fit all pills,
+   * each pill clamps to the minimum width (88) instead of squashing — the row
+   * then overflows into the horizontal ScrollView so it scrolls sideways.
+   * usable = 200 - 8 (padding) - 3*4 (gaps) = 180; 180/4 = 45 < 88 → clamp to 88.
+   */
+  it('clamps pills to a minimum width when the track is narrow (#1)', () => {
+    renderWithTheme(
+      <ChapterContentTabs activeTab="summary" onTabChange={mockOnTabChange} showStudy showVisuals />
+    );
+
+    fireEvent(screen.getByTestId('chapter-content-tabs-track'), 'layout', {
+      nativeEvent: { layout: { width: 200, height: 44, x: 0, y: 0 } },
+    });
+
+    expect(screen.getByTestId('tab-summary')).toHaveStyle({ width: 88 });
+    expect(screen.getByTestId('tab-visuals')).toHaveStyle({ width: 88 });
+  });
+
+  /**
+   * Test 8 (MOBILE-1001 #1): when there is room, pills split the track evenly
+   * (no scroll needed). usable = 800 - 8 - 12 = 780; 780/4 = 195 > 88.
+   */
+  it('splits pills evenly across the row when there is room (#1)', () => {
+    renderWithTheme(
+      <ChapterContentTabs activeTab="summary" onTabChange={mockOnTabChange} showStudy showVisuals />
+    );
+
+    fireEvent(screen.getByTestId('chapter-content-tabs-track'), 'layout', {
+      nativeEvent: { layout: { width: 800, height: 44, x: 0, y: 0 } },
+    });
+
+    expect(screen.getByTestId('tab-summary')).toHaveStyle({ width: 195 });
+  });
 });

--- a/__tests__/components/settings/LexiconUnderlineToggle.test.tsx
+++ b/__tests__/components/settings/LexiconUnderlineToggle.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * LexiconUnderlineToggle Component Tests
+ *
+ * The Settings → Reading toggle for lexicon underlines (MOBILE-1001 #7).
+ * Verifies it reflects the persisted preference and updates it on interaction.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import type React from 'react';
+import { LexiconUnderlineToggle } from '@/components/settings/LexiconUnderlineToggle';
+import { ThemeProvider } from '@/contexts/ThemeContext';
+import { __TEST_ONLY_RESET_CACHE } from '@/hooks/bible/use-lexicon-underlines';
+
+const STORAGE_KEY = '@versemate:lexicon_underlines';
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider>{component}</ThemeProvider>);
+
+describe('LexiconUnderlineToggle', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    __TEST_ONLY_RESET_CACHE();
+  });
+
+  afterEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('renders the switch in the on state by default', async () => {
+    renderWithTheme(<LexiconUnderlineToggle />);
+
+    const toggle = await screen.findByTestId('lexicon-underline-toggle');
+    await waitFor(() => {
+      expect(toggle.props.value).toBe(true);
+    });
+  });
+
+  it('turning it off updates the switch and persists the preference', async () => {
+    renderWithTheme(<LexiconUnderlineToggle />);
+
+    const toggle = await screen.findByTestId('lexicon-underline-toggle');
+
+    await act(async () => {
+      fireEvent(toggle, 'valueChange', false);
+    });
+
+    await waitFor(() => {
+      expect(toggle.props.value).toBe(false);
+    });
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+});

--- a/__tests__/hooks/bible/use-lexicon-underlines.test.ts
+++ b/__tests__/hooks/bible/use-lexicon-underlines.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useLexiconUnderlines Hook Tests
+ *
+ * Tests for the lexicon-underline preference hook (MOBILE-1001 #7): default
+ * value, AsyncStorage persistence round-trip, and the module-level pub/sub
+ * that keeps every mounted consumer (e.g. the reader) in sync with a Settings
+ * toggle without a remount.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+import {
+  __TEST_ONLY_RESET_CACHE,
+  useLexiconUnderlines,
+} from '@/hooks/bible/use-lexicon-underlines';
+
+const STORAGE_KEY = '@versemate:lexicon_underlines';
+
+// AsyncStorage is automatically mocked by @react-native-async-storage/async-storage
+
+describe('useLexiconUnderlines', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    __TEST_ONLY_RESET_CACHE();
+  });
+
+  afterEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('defaults to true (underlines shown) when no stored value exists', async () => {
+    const { result } = renderHook(() => useLexiconUnderlines());
+
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.showUnderlines).toBe(true);
+  });
+
+  it('loads a persisted "off" preference from AsyncStorage on mount', async () => {
+    await AsyncStorage.setItem(STORAGE_KEY, 'false');
+
+    const { result } = renderHook(() => useLexiconUnderlines());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.showUnderlines).toBe(false);
+  });
+
+  it('persists changes to AsyncStorage', async () => {
+    const { result } = renderHook(() => useLexiconUnderlines());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.setShowUnderlines(false);
+    });
+
+    expect(result.current.showUnderlines).toBe(false);
+    expect(await AsyncStorage.getItem(STORAGE_KEY)).toBe('false');
+  });
+
+  it('notifies all mounted consumers live when the preference changes', async () => {
+    // Two independent consumers (e.g. the reader + the settings toggle).
+    const a = renderHook(() => useLexiconUnderlines());
+    const b = renderHook(() => useLexiconUnderlines());
+
+    await waitFor(() => {
+      expect(a.result.current.isLoading).toBe(false);
+      expect(b.result.current.isLoading).toBe(false);
+    });
+
+    // Toggle off via consumer A...
+    await act(async () => {
+      await a.result.current.setShowUnderlines(false);
+    });
+
+    // ...consumer B reflects it without a remount (module-level pub/sub).
+    expect(a.result.current.showUnderlines).toBe(false);
+    expect(b.result.current.showUnderlines).toBe(false);
+  });
+});

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -19,6 +19,7 @@
 import { Ionicons } from '@expo/vector-icons';
 import * as Haptics from 'expo-haptics';
 import { router, useLocalSearchParams } from 'expo-router';
+import * as ScreenOrientation from 'expo-screen-orientation';
 import {
   useCallback,
   useDeferredValue,
@@ -242,6 +243,20 @@ export default function ChapterScreen() {
       }
     }
   }, [targetVerse, activeView, setActiveView]);
+
+  // Orientation (MOBILE-1001 #2): the whole reader is landscape-capable, not
+  // just the Visuals tab. Unlock once when the reader mounts and re-lock to
+  // portrait only when leaving the reader entirely. Previously the Visuals tab
+  // owned this and re-locked PORTRAIT_UP on unmount, so rotating to landscape
+  // on the Bible/Summary/By Line tabs snapped back to portrait. Owning it at
+  // the screen level also removes the per-tab lock/unlock churn that the PDF
+  // share-on-resume crash (#5) reproduced from.
+  useEffect(() => {
+    ScreenOrientation.unlockAsync().catch(() => {});
+    return () => {
+      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP).catch(() => {});
+    };
+  }, []);
 
   // Handle deep-linked insight tab parameter
   // When user opens a shared insight URL, navigate to that specific tab

--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -30,7 +30,7 @@ import {
   useTransition,
 } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { AppState, Pressable, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   Easing,
   interpolate,
@@ -253,7 +253,21 @@ export default function ChapterScreen() {
   // share-on-resume crash (#5) reproduced from.
   useEffect(() => {
     ScreenOrientation.unlockAsync().catch(() => {});
+
+    // MOBILE-1001 #5: on resume from background the reader could stick in a
+    // stale layout (e.g. landscape-sized content rendered in portrait — see the
+    // black dead-zone in the reported screenshot), which then crashed. Re-assert
+    // the reader's orientation policy whenever the app returns to the foreground
+    // so the layout reconciles to the device's current orientation instead of a
+    // cached one.
+    const sub = AppState.addEventListener('change', (next) => {
+      if (next === 'active') {
+        ScreenOrientation.unlockAsync().catch(() => {});
+      }
+    });
+
     return () => {
+      sub.remove();
       ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP).catch(() => {});
     };
   }, []);

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -36,6 +36,7 @@ import { DeleteAccountPasswordModal } from '@/components/account/DeleteAccountPa
 import { DeleteAccountWarningModal } from '@/components/account/DeleteAccountWarningModal';
 import { Button } from '@/components/Button';
 import { FontSizeSelector } from '@/components/settings/FontSizeSelector';
+import { LexiconUnderlineToggle } from '@/components/settings/LexiconUnderlineToggle';
 import { ThemeSelector } from '@/components/settings/ThemeSelector';
 import { Avatar } from '@/components/ui/Avatar';
 import { TextInput } from '@/components/ui/TextInput';
@@ -864,6 +865,9 @@ export default function SettingsScreen() {
 
         {/* Font Size Section */}
         <FontSizeSelector />
+
+        {/* Reading — lexicon underline toggle (#7) */}
+        <LexiconUnderlineToggle />
 
         {/* Theme Selector Section */}
         <ThemeSelector />

--- a/components/bible/AutoHighlightTooltip.tsx
+++ b/components/bible/AutoHighlightTooltip.tsx
@@ -302,8 +302,9 @@ export function AutoHighlightTooltip({
   ).current;
 
   // Animated style for expansion (Reanimated — runs on UI thread)
+  // Fade in only — no maxHeight clamp. The old fixed-height inner ScrollView
+  // trapped the analysis scroll (#9); the modal body now scrolls as one region.
   const insightAnimatedStyle = useAnimatedStyle(() => ({
-    maxHeight: interpolate(expansionAnim.value, [0, 1], [0, 400]),
     opacity: interpolate(expansionAnim.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 
@@ -457,10 +458,14 @@ export function AutoHighlightTooltip({
           <Text style={styles.verseMateHeader}>Verse Insight</Text>
         </View>
 
-        {/* Content */}
+        {/* Content — single scroll region so the full analysis is reachable (#9). */}
         <View style={styles.contentContainer}>
-          <View style={styles.scrollContainer}>
-            <View {...panResponder.panHandlers} style={{ paddingHorizontal: spacing.lg }}>
+          <ScrollView
+            style={styles.scrollContainer}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={{ paddingHorizontal: spacing.lg }}>
               {/* Title with optional color indicator */}
               <View style={styles.titleRow}>
                 <Text style={styles.title}>{autoHighlight.theme_name}</Text>
@@ -502,13 +507,9 @@ export function AutoHighlightTooltip({
                 ) : insightText ? (
                   <>
                     <Text style={styles.analysisTitle}>Analysis</Text>
-                    <ScrollView
-                      style={styles.insightScroll}
-                      contentContainerStyle={styles.insightScrollContent}
-                      showsVerticalScrollIndicator={false}
-                    >
+                    <View style={[styles.insightScroll, styles.insightScrollContent]}>
                       <Markdown style={markdownStyles}>{insightText}</Markdown>
-                    </ScrollView>
+                    </View>
                   </>
                 ) : (
                   <View style={styles.emptyInsightContainer}>
@@ -519,7 +520,7 @@ export function AutoHighlightTooltip({
                 )}
               </Reanimated.View>
             </View>
-          </View>
+          </ScrollView>
 
           {/* Actions Footer */}
           <View style={styles.actionsContainer}>

--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -415,62 +415,76 @@ export function BibleExplanationsPanel({
       {/* Tab Selector */}
 
       <View style={styles.tabContainer}>
-        <View
-          style={styles.tabsRow}
-          onLayout={(event) => {
-            const { width } = event.nativeEvent.layout;
-            // Container has 4px padding each side + 4px gap between
-            // tabs, so usable width = W - 8 - (N-1)*4 for N tabs.
-            const n = tabs.length;
-            const usableWidth = width - 8 - (n - 1) * 4;
-            setTabWidth(usableWidth / n);
-          }}
+        {/* Horizontal scroll so the fixed-width pills can be reached by
+            scrolling sideways when the right panel is narrowed, instead of
+            being clipped off the edge (MOBILE-1001 #1). Centred while they
+            fit via the content container. */}
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.tabScrollContent}
+          keyboardShouldPersistTaps="handled"
         >
-          {/* Sliding active indicator. Animation indices match `tabs` order. */}
-          <Animated.View
-            style={[
-              styles.slidingIndicator,
-              {
-                width: tabWidth,
-                transform: [
-                  {
-                    translateX: slideAnim.interpolate({
-                      // inputRange must be monotonically increasing
-                      // with length === outputRange.length; both built
-                      // from `tabs.length` so this scales with the
-                      // optional Visuals tab.
-                      inputRange: tabs.length < 2 ? [0, 1] : tabs.map((_, i) => i),
-                      outputRange:
-                        tabs.length < 2
-                          ? [0, tabWidth + 4]
-                          : tabs.map((_, i) => i * (tabWidth + 4)),
-                    }),
-                  },
-                ],
-              },
-            ]}
-          />
+          <View
+            style={styles.tabsRow}
+            onLayout={(event) => {
+              const { width } = event.nativeEvent.layout;
+              // Container has 4px padding each side + 4px gap between
+              // tabs, so usable width = W - 8 - (N-1)*4 for N tabs.
+              const n = tabs.length;
+              const usableWidth = width - 8 - (n - 1) * 4;
+              setTabWidth(usableWidth / n);
+            }}
+          >
+            {/* Sliding active indicator. Animation indices match `tabs` order. */}
+            <Animated.View
+              style={[
+                styles.slidingIndicator,
+                {
+                  width: tabWidth,
+                  transform: [
+                    {
+                      translateX: slideAnim.interpolate({
+                        // inputRange must be monotonically increasing
+                        // with length === outputRange.length; both built
+                        // from `tabs.length` so this scales with the
+                        // optional Visuals tab.
+                        inputRange: tabs.length < 2 ? [0, 1] : tabs.map((_, i) => i),
+                        outputRange:
+                          tabs.length < 2
+                            ? [0, tabWidth + 4]
+                            : tabs.map((_, i) => i * (tabWidth + 4)),
+                      }),
+                    },
+                  ],
+                },
+              ]}
+            />
 
-          {tabs.map((tab) => {
-            const isActive = activeTab === tab.id;
-            return (
-              <Pressable
-                key={tab.id}
-                style={styles.tab}
-                onPress={() => handleTabChange(tab.id)}
-                accessibilityRole="tab"
-                accessibilityState={{ selected: isActive }}
-                testID={`${testID}-tab-${tab.id}`}
-              >
-                <Text
-                  style={[styles.tabText, isActive ? styles.tabTextActive : styles.tabTextInactive]}
+            {tabs.map((tab) => {
+              const isActive = activeTab === tab.id;
+              return (
+                <Pressable
+                  key={tab.id}
+                  style={styles.tab}
+                  onPress={() => handleTabChange(tab.id)}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: isActive }}
+                  testID={`${testID}-tab-${tab.id}`}
                 >
-                  {tab.label}
-                </Text>
-              </Pressable>
-            );
-          })}
-        </View>
+                  <Text
+                    style={[
+                      styles.tabText,
+                      isActive ? styles.tabTextActive : styles.tabTextInactive,
+                    ]}
+                  >
+                    {tab.label}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+        </ScrollView>
       </View>
 
       {/* Content Area — one ScrollView per tab for independent scroll
@@ -677,6 +691,12 @@ function createStyles(
       backgroundColor: colors.background,
       paddingHorizontal: spacing.lg,
       paddingVertical: spacing.lg,
+    },
+    // Centre the pill row while it fits; allow horizontal scroll when the
+    // fixed-width pills overflow a narrow panel (#1).
+    tabScrollContent: {
+      flexGrow: 1,
+      justifyContent: 'center',
     },
     tabsRow: {
       backgroundColor: colors.backgroundElevated,

--- a/components/bible/ChapterContentTabs.tsx
+++ b/components/bible/ChapterContentTabs.tsx
@@ -19,7 +19,7 @@
 
 import * as Haptics from 'expo-haptics';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Pressable, ScrollView, StyleSheet, View } from 'react-native';
 import Animated, {
   Easing,
   interpolateColor,
@@ -229,7 +229,7 @@ export function ChapterContentTabs({
 
   return (
     <View style={styles.container} testID="chapter-content-tabs">
-      <View style={styles.scrollTrack} onLayout={handleLayout}>
+      <View style={styles.scrollTrack} onLayout={handleLayout} testID="chapter-content-tabs-track">
         <ScrollView
           ref={scrollRef}
           horizontal

--- a/components/bible/ChapterContentTabs.tsx
+++ b/components/bible/ChapterContentTabs.tsx
@@ -18,8 +18,8 @@
  */
 
 import * as Haptics from 'expo-haptics';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   Easing,
   interpolateColor,
@@ -82,6 +82,16 @@ const BASE_TABS: readonly Tab[] = [
 const DETAILED_TAB: Tab = { id: 'detailed', label: 'Detailed' };
 const STUDY_TAB: Tab = { id: 'study', label: 'Study' };
 const VISUALS_TAB: Tab = { id: 'visuals', label: 'Visuals' };
+
+/**
+ * Minimum width a single pill is allowed to shrink to. When the container is
+ * wide enough, tabs split the space evenly (usable / N) and fill the row. When
+ * the container narrows (e.g. the split-view right pane is dragged small) the
+ * even width would drop below this floor, so we clamp to it and the row becomes
+ * horizontally scrollable instead of squashing the labels — matching the web
+ * behaviour Andy expects (MOBILE-1001 #1).
+ */
+const MIN_TAB_WIDTH = 88;
 
 /**
  * ChapterContentTabs Component
@@ -155,6 +165,11 @@ export function ChapterContentTabs({
   );
 
   const [tabWidth, setTabWidth] = useState(0);
+  // Available width of the pill track (the visible row, not the scroll content).
+  // Used to keep the row at least full-width when tabs fit, and to centre the
+  // active tab when the row overflows and scrolls.
+  const [trackWidth, setTrackWidth] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
 
   /**
    * Handle tab press
@@ -180,8 +195,22 @@ export function ChapterContentTabs({
     const { width } = event.nativeEvent.layout;
     const n = tabs.length;
     const usableWidth = width - 8 - (n - 1) * 4;
-    setTabWidth(usableWidth / n);
+    // Even split when there's room; clamp to MIN_TAB_WIDTH when narrow so the
+    // row scrolls horizontally instead of cramming the labels (#1).
+    setTabWidth(Math.max(usableWidth / n, MIN_TAB_WIDTH));
+    setTrackWidth(width);
   };
+
+  // When the active tab changes and the row is scrollable, bring the active
+  // pill into view (centred when possible). No-op while everything fits.
+  useEffect(() => {
+    if (trackWidth <= 0 || tabWidth <= 0) return;
+    const idx = getTabIndex(activeTab);
+    if (idx < 0) return;
+    const tabStart = idx * (tabWidth + 4);
+    const target = Math.max(0, tabStart - (trackWidth - tabWidth) / 2);
+    scrollRef.current?.scrollTo({ x: target, animated: true });
+  }, [activeTab, tabWidth, trackWidth, getTabIndex]);
 
   // Indicator translateX animation runs on the UI thread driven by
   // animatedIndex (smoothed targetIndex). Translates to index * (tabWidth + 4).
@@ -200,26 +229,38 @@ export function ChapterContentTabs({
 
   return (
     <View style={styles.container} testID="chapter-content-tabs">
-      <View style={styles.tabsRow} onLayout={handleLayout}>
-        {/* Sliding active indicator */}
-        <Animated.View
-          style={[styles.slidingIndicator, { width: tabWidth }, indicatorAnimatedStyle]}
-        />
-
-        {tabs.map((tab, index) => (
-          <TabButton
-            key={tab.id}
-            tab={tab}
-            index={index}
-            animatedIndex={animatedIndex}
-            activeColor={activeColor}
-            inactiveColor={inactiveColor}
-            onPress={handleTabPress}
-            disabled={disabled}
-            activeTab={activeTab}
-            styles={styles}
+      <View style={styles.scrollTrack} onLayout={handleLayout}>
+        <ScrollView
+          ref={scrollRef}
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          // The pill track stays at least as wide as the visible area so it
+          // fills the row when tabs fit; when their clamped widths overflow it,
+          // this ScrollView lets the user scroll sideways (#1).
+          contentContainerStyle={[styles.tabsRow, trackWidth > 0 && { minWidth: trackWidth }]}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Sliding active indicator */}
+          <Animated.View
+            style={[styles.slidingIndicator, { width: tabWidth }, indicatorAnimatedStyle]}
           />
-        ))}
+
+          {tabs.map((tab, index) => (
+            <TabButton
+              key={tab.id}
+              tab={tab}
+              index={index}
+              width={tabWidth}
+              animatedIndex={animatedIndex}
+              activeColor={activeColor}
+              inactiveColor={inactiveColor}
+              onPress={handleTabPress}
+              disabled={disabled}
+              activeTab={activeTab}
+              styles={styles}
+            />
+          ))}
+        </ScrollView>
       </View>
     </View>
   );
@@ -233,6 +274,7 @@ export function ChapterContentTabs({
 function TabButton({
   tab,
   index,
+  width,
   animatedIndex,
   activeColor,
   inactiveColor,
@@ -243,6 +285,7 @@ function TabButton({
 }: {
   tab: Tab;
   index: number;
+  width: number;
   animatedIndex: SharedValue<number>;
   activeColor: string;
   inactiveColor: string;
@@ -264,6 +307,7 @@ function TabButton({
       onPress={() => onPress(tab.id)}
       style={({ pressed }) => [
         styles.tab,
+        width > 0 && { width },
         pressed && styles.tabPressed,
         disabled && styles.tabDisabled,
       ]}
@@ -291,13 +335,19 @@ const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => 
       borderBottomWidth: 1,
       borderBottomColor: colors.gold,
     },
+    // Visible track wrapping the horizontal ScrollView. onLayout here measures
+    // the available width (used for even-split vs. clamp + active-tab centring).
+    scrollTrack: {
+      width: '100%',
+    },
     tabsRow: {
       backgroundColor: colors.backgroundElevated,
       borderRadius: 100,
       padding: 4,
       flexDirection: 'row',
       gap: 4,
-      justifyContent: 'space-between',
+      // No justifyContent: tabs have explicit widths (even-split or clamped),
+      // so they fill the track exactly when fitting and scroll when overflowing.
       position: 'relative',
       minHeight: 36,
     },
@@ -310,7 +360,6 @@ const createStyles = (colors: ReturnType<typeof getColors>, mode: ThemeMode) => 
       left: 4,
     },
     tab: {
-      flex: 1,
       borderRadius: 100,
       paddingVertical: 2,
       paddingHorizontal: spacing.sm,

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -34,6 +34,7 @@ import {
 } from 'react-native';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useLexiconUnderlines } from '@/hooks/bible/use-lexicon-underlines';
 import type { Highlight } from '@/hooks/bible/use-highlights';
 import type { AutoHighlight } from '@/types/auto-highlights';
 
@@ -306,6 +307,9 @@ export function HighlightedText({
   // Without lexicon wiring we keep the legacy long-press → dictionary path
   // intact so BibleExplanationsPanel / TopicContentPanel still work.
   const lexiconMode = Boolean(alignment && onLexiconWordPress);
+  // User preference (#7): when off, lexicon words stay tappable but lose the
+  // gold underline hint. Read here so the worklets below can gate the style.
+  const { showUnderlines: showLexUnderlines } = useLexiconUnderlines();
   const longPressEnabled = !lexiconMode && Boolean(onWordSelect || onWordLongPress);
 
   // Lookup maps for lex highlighting:
@@ -939,7 +943,11 @@ export function HighlightedText({
         if (multi) {
           const endIdx = idx + multi.parts.length - 1;
           const lastToken = tokens[endIdx];
-          const lexStyle = multi.isTheme ? lexiconWordStyles.theme : lexiconWordStyles.regular;
+          const lexStyle = !showLexUnderlines
+            ? undefined
+            : multi.isTheme
+              ? lexiconWordStyles.theme
+              : lexiconWordStyles.regular;
 
           // Build the inner phrase: include all internal spaces (joined as
           // one continuous underline) and, if the LAST word has trailing
@@ -1023,7 +1031,11 @@ export function HighlightedText({
       // --- 2. Single-word lex match (preserves exact prior behavior) -----
       const lexHit = lexHits[idx];
       if (lexHit && onLexiconWordPress) {
-        const lexStyle = lexHit.isTheme ? lexiconWordStyles.theme : lexiconWordStyles.regular;
+        const lexStyle = !showLexUnderlines
+          ? undefined
+          : lexHit.isTheme
+            ? lexiconWordStyles.theme
+            : lexiconWordStyles.regular;
         const match = token.word.match(/^([\p{L}\p{M}\p{N}'’-]+)(.*)$/u);
         const wordCore = match ? match[1] : token.word;
         const trailing = match ? match[2] : '';
@@ -1280,8 +1292,12 @@ const selectionStyles = StyleSheet.create({
  * or a full-SVG text renderer (loses native selection + a11y). Both
  * are out of scope for this pass — captured as TODO below.
  */
-const LEX_UNDERLINE = '#B09A6D';
-const LEX_UNDERLINE_THEME = '#C7B074';
+// Lightened for MOBILE-1001 #7 ("make line thinner"). RN can't set underline
+// thickness cross-platform, so we lower the alpha to make the line read as
+// lighter/thinner. iOS honors textDecorationColor (Andy's platform); on Android
+// textDecorationColor is a no-op so the underline stays the system default.
+const LEX_UNDERLINE = 'rgba(176,154,109,0.55)';
+const LEX_UNDERLINE_THEME = 'rgba(199,176,116,0.75)';
 // Thin solid underline on both iOS and Android.
 //
 // We don't use `textDecorationStyle: 'dotted'` because it's iOS-only (RN

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -34,8 +34,8 @@ import {
 } from 'react-native';
 import { getHighlightColor } from '@/constants/highlight-colors';
 import { useTheme } from '@/contexts/ThemeContext';
-import { useLexiconUnderlines } from '@/hooks/bible/use-lexicon-underlines';
 import type { Highlight } from '@/hooks/bible/use-highlights';
+import { useLexiconUnderlines } from '@/hooks/bible/use-lexicon-underlines';
 import type { AutoHighlight } from '@/types/auto-highlights';
 
 /**

--- a/components/bible/LexiconPopover.tsx
+++ b/components/bible/LexiconPopover.tsx
@@ -29,7 +29,7 @@ import {
 } from '@gorhom/bottom-sheet';
 import type { AlignedToken, LexEntry, RelatedWord } from '@versemate/lexicon';
 import { useCallback, useEffect, useMemo, useRef } from 'react';
-import { ActivityIndicator, StyleSheet, Text, View } from 'react-native';
+import { ActivityIndicator, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
 import { type LemmaCard, useLemma } from '@/hooks/use-lemma';
 import { fontSizes, fontWeights, type getColors, lineHeights, spacing } from '@/theme/tokens';
@@ -140,6 +140,20 @@ export function LexiconPopover({
   // custom modal's `maxHeight: 85%`.
   const snapPoints = useMemo(() => ['85%'], []);
 
+  // In landscape the full-width 85% sheet swallows nearly the whole screen
+  // (#3). Constrain it to a centred column so the reader stays visible on
+  // either side. Portrait keeps the default full-width bottom sheet.
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+  const isLandscape = windowWidth > windowHeight;
+  const landscapeSheetStyle = useMemo(() => {
+    if (!isLandscape) return undefined;
+    const width = Math.min(560, windowWidth * 0.62);
+    // gorhom's sheet container is absolutely positioned (left:0), so alignSelf
+    // can't centre it — offset it manually to sit centred with the reader
+    // visible on both sides.
+    return { width, marginLeft: Math.max(0, (windowWidth - width) / 2) };
+  }, [isLandscape, windowWidth]);
+
   // Open + close spring physics that match AutoHighlightTooltip (the
   // verse-insight modal). User explicitly asked for parity on both
   // directions; AutoHighlightTooltip's snap-back/close uses
@@ -193,6 +207,7 @@ export function LexiconPopover({
       enableDynamicSizing={false}
       animationConfigs={animationConfigs}
       backdropComponent={renderBackdrop}
+      style={landscapeSheetStyle}
       backgroundStyle={styles.background}
       handleIndicatorStyle={styles.handleIndicator}
       handleStyle={styles.handle}

--- a/components/bible/VerseMateTooltip.tsx
+++ b/components/bible/VerseMateTooltip.tsx
@@ -484,8 +484,11 @@ export function VerseMateTooltip({
   ).current;
 
   // Animated style for expansion (Reanimated — runs on UI thread)
+  // Fade the insight in. We deliberately no longer animate (or cap) maxHeight
+  // here: clamping the analysis to a fixed-height inner box and nesting a
+  // ScrollView inside it trapped the scroll so the full analysis couldn't be
+  // reached (#9). The whole modal body now scrolls as one region instead.
   const insightAnimatedStyle = useAnimatedStyle(() => ({
-    maxHeight: interpolate(expansionAnim.value, [0, 1], [0, screenHeight * 0.6]),
     opacity: interpolate(expansionAnim.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 
@@ -531,10 +534,15 @@ export function VerseMateTooltip({
           <Text style={styles.verseMateHeader}>Verse Insight</Text>
         </View>
 
-        {/* Content */}
+        {/* Content — single scroll region so the full analysis is always
+            reachable (#9). Actions footer stays fixed below. */}
         <View style={styles.contentContainer}>
-          <View style={styles.scrollContainer}>
-            <View {...panResponder.panHandlers} style={{ paddingHorizontal: spacing.lg }}>
+          <ScrollView
+            style={styles.scrollContainer}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View style={{ paddingHorizontal: spacing.lg }}>
               {/* Title with optional color indicator */}
               <View style={styles.titleRow}>
                 <Text style={styles.title}>{verseReference}</Text>
@@ -564,13 +572,9 @@ export function VerseMateTooltip({
                 ) : insightText ? (
                   <>
                     <Text style={styles.analysisTitle}>Analysis</Text>
-                    <ScrollView
-                      style={styles.insightScroll}
-                      contentContainerStyle={styles.insightScrollContent}
-                      showsVerticalScrollIndicator={false}
-                    >
+                    <View style={[styles.insightScroll, styles.insightScrollContent]}>
                       <Markdown style={markdownStyles}>{insightText}</Markdown>
-                    </ScrollView>
+                    </View>
                   </>
                 ) : (
                   <View style={styles.emptyInsightContainer}>
@@ -582,7 +586,7 @@ export function VerseMateTooltip({
                 )}
               </Reanimated.View>
             </View>
-          </View>
+          </ScrollView>
 
           {/* Actions Footer - Context-aware */}
           <View style={styles.actionsContainer}>

--- a/components/bible/VisualsPanel.tsx
+++ b/components/bible/VisualsPanel.tsx
@@ -26,8 +26,10 @@
  * embed restriction. When YouTube still refuses (e.g. age-gated content
  * in the future) `onError` falls back to opening the watch URL.
  *
- * The whole Visuals tab unlocks ScreenOrientation on mount so users can
- * rotate to landscape for wide diagrams — not just inside the lightbox.
+ * Orientation is owned by the reader screen
+ * (app/bible/[bookId]/[chapterNumber].tsx) — the whole reader is
+ * landscape-capable (MOBILE-1001 #2), so this tab no longer unlocks/locks
+ * orientation itself.
  */
 
 import { Ionicons } from '@expo/vector-icons';

--- a/components/bible/VisualsPanel.tsx
+++ b/components/bible/VisualsPanel.tsx
@@ -47,7 +47,6 @@ import {
 // the new `File.downloadFileAsync` API end-to-end.
 import * as FileSystem from 'expo-file-system/legacy';
 import { Image } from 'expo-image';
-import * as ScreenOrientation from 'expo-screen-orientation';
 import * as Sharing from 'expo-sharing';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
@@ -194,18 +193,11 @@ export function VisualsPanel({
     setVideoError(false);
   }, [bookId, chapter]);
 
-  // The whole Visuals tab is landscape-capable, not just the lightbox
-  // modal — wide diagrams (Genesis poster) are easier to read rotated.
-  // Unlock at mount and re-lock to portrait at unmount so other tabs /
-  // screens stay portrait. One mount/unmount effect (vs per-`openCard`)
-  // avoids rapid lock/unlock churn that previously crashed on background
-  // → resume of the PDF flow.
-  useEffect(() => {
-    ScreenOrientation.unlockAsync().catch(() => {});
-    return () => {
-      ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP).catch(() => {});
-    };
-  }, []);
+  // Orientation is owned by the reader screen (app/bible/[bookId]/[chapterNumber].tsx)
+  // as of MOBILE-1001 #2 — the entire reader is landscape-capable now, so the
+  // Visuals tab no longer unlocks on mount / re-locks PORTRAIT_UP on unmount.
+  // Re-locking on unmount here is exactly what snapped the Bible/Summary tabs
+  // back to portrait, and the per-tab churn fed the resume crash (#5).
 
   // ─── Bug #8 — pinch/zoom + pan SharedValues for the lightbox image ───
   // Held at module-scope-equivalent (component scope) so the same animated

--- a/components/settings/LexiconUnderlineToggle.tsx
+++ b/components/settings/LexiconUnderlineToggle.tsx
@@ -1,0 +1,94 @@
+/**
+ * Lexicon Underline Toggle
+ *
+ * Lets the reader turn the gold underline under definable (lexicon) words on
+ * or off (MOBILE-1001 #7). Words stay tappable for definitions either way —
+ * this only controls the visual hint.
+ *
+ * Follows the same section pattern as FontSizeSelector / ThemeSelector.
+ * Persists via the useLexiconUnderlines hook (AsyncStorage).
+ */
+
+import * as Haptics from 'expo-haptics';
+import { Platform, StyleSheet, Switch, Text, View } from 'react-native';
+import { useTheme } from '@/contexts/ThemeContext';
+import { useLexiconUnderlines } from '@/hooks/bible/use-lexicon-underlines';
+import { type getColors, spacing } from '@/theme/tokens';
+
+export function LexiconUnderlineToggle() {
+  const { colors } = useTheme();
+  const { showUnderlines, setShowUnderlines } = useLexiconUnderlines();
+  const styles = createStyles(colors);
+
+  const handleToggle = async (value: boolean) => {
+    if (Platform.OS !== 'web') {
+      await Haptics.selectionAsync();
+    }
+    await setShowUnderlines(value);
+  };
+
+  return (
+    <View style={styles.section}>
+      <Text style={styles.sectionTitle}>Reading</Text>
+      <View style={styles.container}>
+        <View style={styles.row}>
+          <View style={styles.textColumn}>
+            <Text style={styles.label}>Underline definable words</Text>
+            <Text style={styles.helpText}>
+              Show the gold underline under words with a dictionary entry. Words stay tappable
+              either way.
+            </Text>
+          </View>
+          <Switch
+            value={showUnderlines}
+            onValueChange={handleToggle}
+            trackColor={{ false: colors.divider, true: colors.gold }}
+            thumbColor={colors.background}
+            accessibilityLabel="Underline definable words"
+            testID="lexicon-underline-toggle"
+          />
+        </View>
+      </View>
+    </View>
+  );
+}
+
+const createStyles = (colors: ReturnType<typeof getColors>) =>
+  StyleSheet.create({
+    section: {
+      paddingHorizontal: spacing.lg,
+      marginBottom: spacing.xxxl,
+    },
+    sectionTitle: {
+      fontSize: 20,
+      fontWeight: '600',
+      color: colors.textPrimary,
+      marginBottom: spacing.lg,
+    },
+    container: {
+      backgroundColor: colors.backgroundElevated,
+      borderWidth: 1,
+      borderColor: colors.borderSecondary,
+      borderRadius: 8,
+      padding: spacing.xl,
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: spacing.lg,
+    },
+    textColumn: {
+      flex: 1,
+    },
+    label: {
+      fontSize: 14,
+      fontWeight: '500',
+      color: colors.textPrimary,
+    },
+    helpText: {
+      fontSize: 12,
+      color: colors.textSecondary,
+      marginTop: spacing.xs,
+    },
+  });

--- a/components/topics/TopicVerseTooltip.tsx
+++ b/components/topics/TopicVerseTooltip.tsx
@@ -396,8 +396,9 @@ export function TopicVerseTooltip({
   ).current;
 
   // Animated style for expansion (Reanimated — runs on UI thread)
+  // Fade in only — no maxHeight clamp. The old fixed-height inner ScrollView
+  // trapped the analysis scroll (#9); the modal body now scrolls as one region.
   const insightAnimatedStyle = useAnimatedStyle(() => ({
-    maxHeight: interpolate(expansionAnim.value, [0, 1], [0, 400]),
     opacity: interpolate(expansionAnim.value, [0, 0.5, 1], [0, 0, 1]),
   }));
 
@@ -437,10 +438,14 @@ export function TopicVerseTooltip({
           <Text style={styles.verseMateHeader}>Verse Insight</Text>
         </View>
 
-        {/* Content */}
+        {/* Content — single scroll region so the full analysis is reachable (#9). */}
         <View style={styles.contentContainer}>
-          <View style={styles.scrollContainer}>
-            <View {...panResponder.panHandlers}>
+          <ScrollView
+            style={styles.scrollContainer}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
+            <View>
               {/* Title */}
               <Text style={styles.title}>{verseReference}</Text>
 
@@ -458,13 +463,9 @@ export function TopicVerseTooltip({
                 ) : insightText ? (
                   <>
                     <Text style={styles.analysisTitle}>Analysis</Text>
-                    <ScrollView
-                      style={styles.insightScroll}
-                      contentContainerStyle={styles.insightScrollContent}
-                      showsVerticalScrollIndicator={false}
-                    >
+                    <View style={[styles.insightScroll, styles.insightScrollContent]}>
                       <Markdown style={markdownStyles}>{insightText}</Markdown>
-                    </ScrollView>
+                    </View>
                   </>
                 ) : (
                   <View style={styles.emptyInsightContainer}>
@@ -475,7 +476,7 @@ export function TopicVerseTooltip({
                 )}
               </Reanimated.View>
             </View>
-          </View>
+          </ScrollView>
 
           {/* Actions Footer */}
           <View style={styles.actionsContainer}>

--- a/hooks/bible/use-lexicon-underlines.ts
+++ b/hooks/bible/use-lexicon-underlines.ts
@@ -1,0 +1,110 @@
+/**
+ * useLexiconUnderlines Hook
+ *
+ * Manages the user's preference for showing the gold underline under
+ * lexicon-tappable words in the Bible reader, persisted to AsyncStorage.
+ *
+ * Andy (MOBILE-1001 #7) asked to be able to turn the underlines off (and for
+ * a thinner line — see HighlightedText's LEX_UNDERLINE note; RN can't set
+ * underline thickness cross-platform, so the line is lightened instead).
+ *
+ * Turning underlines OFF only removes the visual hint — the words stay
+ * tappable for definitions.
+ *
+ * Unlike useFontSize, this hook keeps a module-level subscriber set so a
+ * toggle in Settings updates an already-mounted reader live, without needing
+ * the reader screen to remount.
+ *
+ * @example
+ * ```tsx
+ * const { showUnderlines, setShowUnderlines } = useLexiconUnderlines();
+ * <Switch value={showUnderlines} onValueChange={setShowUnderlines} />
+ * ```
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = '@versemate:lexicon_underlines';
+const DEFAULT_SHOW_UNDERLINES = true;
+
+// Module-level cache + subscribers so every mounted consumer stays in sync
+// and remounts don't flicker.
+let inMemoryCache: boolean | null = null;
+const listeners = new Set<(value: boolean) => void>();
+
+function notify(value: boolean) {
+  inMemoryCache = value;
+  for (const listener of listeners) listener(value);
+}
+
+/** FOR TEST ENVIRONMENTS ONLY — resets the in-memory cache. */
+export function __TEST_ONLY_RESET_CACHE() {
+  inMemoryCache = null;
+  listeners.clear();
+}
+
+export interface UseLexiconUnderlinesResult {
+  /** Whether the lexicon underline hint is shown. */
+  showUnderlines: boolean;
+  /** Update the preference (persists to AsyncStorage, updates all consumers). */
+  setShowUnderlines: (value: boolean) => Promise<void>;
+  /** Whether the initial load from storage is in progress. */
+  isLoading: boolean;
+}
+
+export function useLexiconUnderlines(): UseLexiconUnderlinesResult {
+  const [showUnderlines, setState] = useState<boolean>(inMemoryCache ?? DEFAULT_SHOW_UNDERLINES);
+  const [isLoading, setIsLoading] = useState(inMemoryCache === null);
+
+  // Subscribe to cross-component updates.
+  useEffect(() => {
+    const listener = (value: boolean) => setState(value);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  // Load persisted value once.
+  useEffect(() => {
+    let isMounted = true;
+    if (inMemoryCache !== null) return;
+
+    (async () => {
+      try {
+        setIsLoading(true);
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        const value = stored === null ? DEFAULT_SHOW_UNDERLINES : stored === 'true';
+        if (isMounted) {
+          inMemoryCache = value;
+          setState(value);
+        }
+      } catch {
+        if (isMounted) {
+          inMemoryCache = DEFAULT_SHOW_UNDERLINES;
+          setState(DEFAULT_SHOW_UNDERLINES);
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const setShowUnderlines = async (value: boolean): Promise<void> => {
+    notify(value); // update all consumers immediately
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, String(value));
+    } catch (err) {
+      if (__DEV__) {
+        console.error('useLexiconUnderlines: failed to persist preference:', err);
+      }
+    }
+  };
+
+  return { showUnderlines, setShowUnderlines, isLoading };
+}


### PR DESCRIPTION
## MOBILE-1001 — Landscape & reader UX bug batch (reported by Andy via Slack)

Fixes a batch of iOS-reported bugs. Reproduced/verified against the **Expo Web target** with agent-browser where possible; native-only items are code-fixed and flagged for on-device verification.

### Fixed & web-verified
- **#1 Commentary pills scroll sideways when the panel narrows.** `ChapterContentTabs` (min-width + horizontal `ScrollView` + auto-center active) and `BibleExplanationsPanel` (horizontal `ScrollView`). Sliding-indicator math preserved.
- **#3 Dictionary popover no longer fills the screen in landscape.** `LexiconPopover` becomes a centered, width-constrained panel in landscape (`min(560, 62%w)`); portrait unchanged.
- **#7 Setting to turn off lexicon underlines + thinner line.** New `useLexiconUnderlines` hook (AsyncStorage + live pub/sub), Settings → "Reading" toggle, gated in `HighlightedText`. Words stay tappable when underlines are off. Underline color lightened as the cross-platform "thinner" approximation (RN can't set underline thickness; iOS honors `textDecorationColor`).

### Fixed, needs on-device verification
- **#9 Verse-insight analysis no longer trapped in a nested scroll.** All three insight modals (`VerseMateTooltip`, `AutoHighlightTooltip`, `TopicVerseTooltip`) now scroll as one region instead of a nested `ScrollView` inside an animated-maxHeight wrapper. *(Modal opens via a debounced verse-tap gesture that agent-browser can't trigger on web — please verify scroll-through on device.)*
- **#2 Whole reader is landscape-capable.** Orientation is owned by the reader screen (unlock on mount, lock `PORTRAIT_UP` only on leaving the reader) instead of the Visuals tab re-locking portrait on unmount. *(ScreenOrientation is a web no-op — verify rotation on device.)*
- **#5 Reconcile orientation on resume.** Re-assert orientation on `AppState` `active` so a stale landscape-in-portrait layout self-corrects; combined with #2's churn reduction. *(Crash needs on-device repro/profiling.)*

### Investigated — not reproducible (no code change)
- **#4 Menu fills landscape:** already capped at 340px (`min(windowWidth*0.85, 340)`) → measured ~36% width in landscape. Please confirm on the reporting device; the report may predate the cap.
- **#6 Expand/collapse-all "gone":** the control **exists and works** in the Study tab (toggles Expand All ↔ Collapse All). If the request is for the *By Line* tab (intentionally flat markdown), that's a feature request — needs product clarification.

### How to test
iOS device/sim: rotate to landscape in the reader (#2), open the dictionary (#3), open a verse insight with a long analysis and scroll to the buttons (#9), background+resume repeatedly while rotating (#5), Settings → Reading → toggle underlines (#7), narrow the split-view right pane (#1).

---
🔗 Backend companion PR for #8 (richer verse insights): **verse-mate/verse-mate#267**
