### PR TITLE
CI-1: surface EAS build errors & decouple iOS/Android preview builds

### DIFF
--- a/.deployment/build-preview.sh
+++ b/.deployment/build-preview.sh
@@ -19,8 +19,21 @@ echo "=========================================="
 echo "Triggering $PLATFORM Preview Build"
 echo "=========================================="
 
-# Trigger build and capture output
+# Trigger build and capture output.
+# Disable `set -e` around the build so a non-zero exit doesn't abort the
+# script before we get a chance to surface EAS's error output. Without this,
+# the redirect below swallows the real failure reason (e.g. expired iOS
+# credentials) and CI only shows a bare "Process exit code 1".
+set +e
 eas build --platform "$PLATFORM" --profile preview --non-interactive --no-wait --json > build_output.json 2>&1
+EAS_EXIT=$?
+set -e
+
+if [ "$EAS_EXIT" -ne 0 ]; then
+  echo "❌ eas build failed for $PLATFORM (exit code $EAS_EXIT). EAS output:"
+  cat build_output.json
+  exit "$EAS_EXIT"
+fi
 
 # Extract JSON array from output
 BUILD_ID=$(grep -A 100 '^\[' build_output.json | jq -r '.[0].id')

--- a/.github/workflows/expo-preview-build.yml
+++ b/.github/workflows/expo-preview-build.yml
@@ -123,37 +123,44 @@ jobs:
         run: bun run lint
 
       - name: Run tests
+        id: tests
         if: steps.check_trigger.outputs.skip != 'true'
         run: npm test
 
+      # iOS and Android are independent deliverables. Each platform step uses
+      # `!cancelled()` so a failure on one platform (e.g. expired iOS signing
+      # credentials) does NOT skip the other — without this, GitHub implicitly
+      # ANDs `success()` into the condition and skips every following step once
+      # iOS fails. `steps.tests.outcome == 'success'` keeps the test gate intact
+      # (it is only 'success' when checkout/install/tsc/lint/tests all passed).
       - name: Build iOS Preview
         id: ios_build
-        if: ${{ steps.check_trigger.outputs.skip != 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/build-preview.sh ios
 
       - name: Build Android Preview
         id: android_build
-        if: ${{ steps.check_trigger.outputs.skip != 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'android') }}
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'android') }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/build-preview.sh android
 
       - name: Submit to TestFlight
-        if: ${{ steps.check_trigger.outputs.skip != 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
+        if: ${{ !cancelled() && steps.ios_build.outcome == 'success' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/submit-testflight.sh "${{ steps.ios_build.outputs.build_id }}"
 
       - name: Submit to Play Store
-        if: ${{ steps.check_trigger.outputs.skip != 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'android') }}
+        if: ${{ !cancelled() && steps.android_build.outcome == 'success' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'android') }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/submit-play-store.sh "${{ steps.android_build.outputs.build_id }}"
 
       - name: Build Summary
-        if: steps.check_trigger.outputs.skip != 'true'
+        if: ${{ !cancelled() && steps.check_trigger.outputs.skip != 'true' }}
         run: |
           echo "=========================================="
           echo "Preview Build Summary"

--- a/.github/workflows/expo-preview-build.yml
+++ b/.github/workflows/expo-preview-build.yml
@@ -133,9 +133,22 @@ jobs:
       # ANDs `success()` into the condition and skips every following step once
       # iOS fails. `steps.tests.outcome == 'success'` keeps the test gate intact
       # (it is only 'success' when checkout/install/tsc/lint/tests all passed).
+      #
+      # iOS builds are gated behind the `ENABLE_IOS_PREVIEW_BUILDS` repository
+      # variable. They are DISABLED unless that variable is set to 'true',
+      # because the VerseOfTheDay widget target lacks EAS credentials and fails
+      # non-interactive builds (see issue #347). Once those credentials are
+      # provisioned, set the repo variable to 'true' to re-enable iOS — no code
+      # change needed:
+      #   gh variable set ENABLE_IOS_PREVIEW_BUILDS --body true --repo <owner>/<repo>
+      - name: Skip iOS notice
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' && vars.ENABLE_IOS_PREVIEW_BUILDS != 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
+        run: |
+          echo "::notice title=iOS build skipped::iOS preview builds are disabled. Set the ENABLE_IOS_PREVIEW_BUILDS repository variable to 'true' to enable them (blocked on widget credentials — see issue #347)."
+
       - name: Build iOS Preview
         id: ios_build
-        if: ${{ !cancelled() && steps.tests.outcome == 'success' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
+        if: ${{ !cancelled() && steps.tests.outcome == 'success' && vars.ENABLE_IOS_PREVIEW_BUILDS == 'true' && (steps.check_trigger.outputs.platform == 'all' || steps.check_trigger.outputs.platform == 'ios') }}
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: bash .deployment/build-preview.sh ios


### PR DESCRIPTION
## Problem

The iOS preview build failed (run 27352487030) with only a bare `Process exit code 1` in the CI log, and because steps run sequentially in one job, the **iOS failure auto-skipped the Android build** and all following steps.

Two root causes:
1. `build-preview.sh` redirects all `eas build` output to `build_output.json` under `set -e`, so a non-zero exit aborts the script before the error is ever printed.
2. GitHub implicitly ANDs `success()` into each step's `if:`, so once the iOS step failed every later step (Android build, submits, summary) was skipped.

## Changes

**`.deployment/build-preview.sh`**
- Capture the `eas build` exit code instead of letting `set -e` abort silently.
- On failure, print `build_output.json` and exit with the real code — so the actual error (e.g. expired iOS signing credentials) shows in CI.

**`.github/workflows/expo-preview-build.yml`**
- Platform build steps gate on `!cancelled() && steps.tests.outcome == 'success'` → an iOS failure no longer skips Android (test/lint/tsc gate preserved).
- Each submit step gates on its own platform's build outcome.
- Build Summary always runs via `!cancelled()`.

A failed iOS build still fails the overall job — it just no longer blocks Android.

## Note

This is the resilience fix. The iOS step will still fail until the underlying credential issue is resolved, but the log will now show exactly why (likely an expired Apple distribution cert / provisioning profile).

Co-Authored-By: Claude <noreply@anthropic.com>

---

## Update: iOS builds gated behind a toggle

Since the widget credentials (#347) can't be provisioned right now, iOS preview builds are now **gated behind the `ENABLE_IOS_PREVIEW_BUILDS` repository variable** and are **disabled by default** (unless set to `true`). This stops the pipeline from failing on iOS while Android keeps building. A notice step explains the skip in the run log.

**Re-enable iOS once widget credentials are provisioned (#347):**
```
gh variable set ENABLE_IOS_PREVIEW_BUILDS --body true --repo verse-mate/verse-mate-mobile
```
No code change needed to flip it back on.
