### PR TITLE
fix(widget): never leave the Android widget blank (GH-265 follow-up)

### DIFF
--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -91,7 +91,7 @@ describe('widget-task-handler', () => {
       expect((global.fetch as unknown as jest.Mock).mock.calls[0][0]).toContain(
         'bible_version=KJV'
       );
-      expect(result.verseText).toBe('For God so loved the world');
+      expect(result.verses).toEqual([{ verseNumber: 16, text: 'For God so loved the world' }]);
       expect(result.reference).toBe('John 3:16');
       expect(parseChapterShareUrl(result.deepLink)).toEqual({
         bookId: 43,
@@ -125,8 +125,9 @@ describe('widget-task-handler', () => {
 
       const result = await fetchVerse();
 
-      expect(result.verseText).toBe('No verse today');
-      expect(result.reference).toBe('VerseMate');
+      expect(result.verses).toBeNull();
+      expect(result.fallbackText).toBe('No verse today');
+      expect(result.reference).toBe('');
       // No reference → Genesis 1 fallback link.
       expect(parseChapterShareUrl(result.deepLink)).toEqual({ bookId: 1, chapterNumber: 1 });
     });
@@ -138,8 +139,9 @@ describe('widget-task-handler', () => {
 
       const result = await fetchVerse();
 
-      expect(result.verseText).toBe("Open VerseMate to see today's verse");
-      expect(result.reference).toBe('VerseMate');
+      expect(result.verses).toBeNull();
+      expect(result.fallbackText).toBe("Open VerseMate to see today's verse");
+      expect(result.reference).toBe('');
       expect(parseChapterShareUrl(result.deepLink)).toEqual({ bookId: 1, chapterNumber: 1 });
     });
   });

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -25,6 +25,11 @@ export function VerseOfTheDayWidget({
   // no React dispatcher — `useMemoCache` reads from null and throws, leaving the
   // Android widget blank/transparent (GH-265). Opt this component out of the
   // compiler; it's a pure render-to-tree, so memoization buys nothing here.
+  // The eslint react-compiler rule flags this as an "unused" directive, but its
+  // static analysis disagrees with the actual babel build — on-device testing
+  // confirmed the directive IS what stops the crash (with it the widget renders,
+  // without it the useMemoCache TypeError above recurs). Suppress the false positive.
+  // eslint-disable-next-line react-compiler/react-compiler
   "use no memo";
 
   return (

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -19,6 +19,14 @@ export function VerseOfTheDayWidget({
   reference,
   deepLink,
 }: VerseOfTheDayWidgetProps) {
+  // React Compiler (app.config.js `experiments.reactCompiler`) instruments this
+  // component with a `useMemoCache` call. react-native-android-widget renders
+  // the tree via its own `buildWidgetTree`, NOT React's reconciler, so there is
+  // no React dispatcher — `useMemoCache` reads from null and throws, leaving the
+  // Android widget blank/transparent (GH-265). Opt this component out of the
+  // compiler; it's a pure render-to-tree, so memoization buys nothing here.
+  "use no memo";
+
   return (
     <FlexWidget
       style={{

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -2,22 +2,69 @@
  * Android Verse-of-the-Day widget UI (GH-265).
  *
  * react-native-android-widget renders this RN-like tree into a native
- * RemoteViews widget. Authored without an Android build — verify with
- * `expo prebuild -p android` + a device/emulator.
+ * RemoteViews widget. Styled to match the in-app reader: a gold accent rail,
+ * Unicode-superscript verse numbers, the verse text, and a gold reference with
+ * a small wordmark. Light + dark variants are rendered by the task handler.
  */
 import { FlexWidget, TextWidget } from "react-native-android-widget";
 
+export interface VerseData {
+  verseNumber: number;
+  text: string;
+}
+
 export interface VerseOfTheDayWidgetProps {
-  verseText: string;
+  /** Per-verse data from the API; null when rendering the fallback state. */
+  verses: VerseData[] | null;
+  /** Rendered reference, e.g. "Genesis 1:1-2". Empty in the fallback state. */
   reference: string;
   /** Universal-link deep link with verse range + src=widget. */
   deepLink: string;
+  /** Message shown when `verses` is null/empty (empty pool or fetch failure). */
+  fallbackText: string;
+  /** Which palette to paint; the handler renders one tree per system theme. */
+  theme: "light" | "dark";
+}
+
+// VerseMate brand palette (mobile theme/tokens.ts): gold accent #b09a6d.
+const PALETTES = {
+  light: {
+    background: "#ffffff",
+    accent: "#b09a6d",
+    verseText: "#1a1a1a",
+    reference: "#b09a6d",
+    wordmark: "#9b9b9b",
+  },
+  dark: {
+    background: "#121212",
+    accent: "#b09a6d",
+    verseText: "#e8e8e8",
+    reference: "#e0b890",
+    wordmark: "#8a8a8a",
+  },
+} as const;
+
+const SUPERSCRIPTS = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"];
+
+/** Render a verse number as Unicode superscript, matching the in-app reader. */
+function toSuperscript(n: number): string {
+  return String(n)
+    .split("")
+    .map((d) => SUPERSCRIPTS[Number(d)] ?? d)
+    .join("");
+}
+
+/** Inline the verse text with superscript verse numbers, e.g. "¹ In the…  ² The…". */
+function composeVerseText(verses: VerseData[]): string {
+  return verses.map((v) => `${toSuperscript(v.verseNumber)} ${v.text}`).join("  ");
 }
 
 export function VerseOfTheDayWidget({
-  verseText,
+  verses,
   reference,
   deepLink,
+  fallbackText,
+  theme,
 }: VerseOfTheDayWidgetProps) {
   // React Compiler (app.config.js `experiments.reactCompiler`) instruments this
   // component with a `useMemoCache` call. react-native-android-widget renders
@@ -32,40 +79,72 @@ export function VerseOfTheDayWidget({
   // eslint-disable-next-line react-compiler/react-compiler
   "use no memo";
 
+  const palette = PALETTES[theme];
+  const isFallback = !verses || verses.length === 0;
+  const bodyText = isFallback ? fallbackText : composeVerseText(verses);
+
   return (
     <FlexWidget
       style={{
         height: "match_parent",
         width: "match_parent",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        backgroundColor: "#ffffff",
+        flexDirection: "row",
+        backgroundColor: palette.background,
         borderRadius: 16,
-        padding: 14,
+        overflow: "hidden",
       }}
       clickAction="OPEN_VERSE"
       clickActionData={{ url: deepLink }}
     >
-      <TextWidget
-        text={verseText}
-        maxLines={6}
-        style={{ fontSize: 15, color: "#1a1a1a" }}
+      {/* Gold accent rail (matches the app's brand accent). */}
+      <FlexWidget
+        style={{ height: "match_parent", width: 5, backgroundColor: palette.accent }}
       />
+
       <FlexWidget
         style={{
-          flexDirection: "row",
-          justifyContent: "space-between",
-          width: "match_parent",
+          flex: 1,
+          height: "match_parent",
+          flexDirection: "column",
+          justifyContent: isFallback ? "center" : "space-between",
+          paddingTop: 14,
+          paddingBottom: 12,
+          paddingLeft: 14,
+          paddingRight: 14,
         }}
       >
         <TextWidget
-          text={reference}
-          style={{ fontSize: 12, color: "#6b6b6b", fontWeight: "600" }}
+          text={bodyText}
+          maxLines={6}
+          truncate="END"
+          style={{
+            fontSize: isFallback ? 14 : 15,
+            color: palette.verseText,
+            fontFamily: "serif",
+          }}
         />
-        <TextWidget
-          text="VerseMate"
-          style={{ fontSize: 11, color: "#9b9b9b" }}
-        />
+
+        <FlexWidget
+          style={{
+            flexDirection: "row",
+            justifyContent: "space-between",
+            alignItems: "center",
+            width: "match_parent",
+            ...(isFallback ? { marginTop: 12 } : {}),
+          }}
+        >
+          <TextWidget
+            text={isFallback ? "" : reference}
+            maxLines={1}
+            truncate="END"
+            style={{ fontSize: 12, color: palette.reference, fontWeight: "700" }}
+          />
+          <TextWidget
+            text="✦ VerseMate"
+            maxLines={1}
+            style={{ fontSize: 11, color: palette.wordmark, fontWeight: "600" }}
+          />
+        </FlexWidget>
       </FlexWidget>
     </FlexWidget>
   );

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -58,11 +58,17 @@ export function buildDeepLink(ref?: VerseResponse["reference"]): string {
   return `${url}&src=widget`;
 }
 
-export async function fetchVerse(): Promise<{
-  verseText: string;
+export interface WidgetVerseData {
+  /** Per-verse data; null when the pool is empty or the fetch failed. */
+  verses: { verseNumber: number; text: string }[] | null;
+  /** Rendered reference (e.g. "Genesis 1:1-2"); empty in the fallback state. */
   reference: string;
   deepLink: string;
-}> {
+  /** Message rendered when `verses` is null. */
+  fallbackText: string;
+}
+
+export async function fetchVerse(): Promise<WidgetVerseData> {
   const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
 
   try {
@@ -79,21 +85,24 @@ export async function fetchVerse(): Promise<{
     const data = (await res.json()) as VerseResponse;
     if (data.empty || !data.verses?.length) {
       return {
-        verseText: data.fallbackMessage ?? FALLBACK_MESSAGE,
-        reference: "VerseMate",
+        verses: null,
+        reference: "",
         deepLink: buildDeepLink(data.reference),
+        fallbackText: data.fallbackMessage ?? FALLBACK_MESSAGE,
       };
     }
     return {
-      verseText: data.verses.map((v) => v.text).join(" "),
-      reference: data.referenceText ?? "VerseMate",
+      verses: data.verses,
+      reference: data.referenceText ?? "",
       deepLink: buildDeepLink(data.reference),
+      fallbackText: FALLBACK_MESSAGE,
     };
   } catch {
     return {
-      verseText: FALLBACK_MESSAGE,
-      reference: "VerseMate",
+      verses: null,
+      reference: "",
       deepLink: `${WEB_BASE_URL}/bible/1/1?src=widget`,
+      fallbackText: FALLBACK_MESSAGE,
     };
   }
 }
@@ -105,24 +114,25 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
     case "WIDGET_RESIZED": {
       // Always render *something* — a blank/transparent widget is the worst
       // outcome. fetchVerse no longer rejects, but guard the whole render so
-      // any unexpected failure still paints a tap-to-open fallback.
+      // any unexpected failure still paints a tap-to-open fallback. Render a
+      // light + dark variant so the widget matches the launcher's theme.
       try {
-        const { verseText, reference, deepLink } = await fetchVerse();
-        props.renderWidget(
-          <VerseOfTheDayWidget
-            verseText={verseText}
-            reference={reference}
-            deepLink={deepLink}
-          />
-        );
+        const data = await fetchVerse();
+        props.renderWidget({
+          light: <VerseOfTheDayWidget {...data} theme="light" />,
+          dark: <VerseOfTheDayWidget {...data} theme="dark" />,
+        });
       } catch {
-        props.renderWidget(
-          <VerseOfTheDayWidget
-            verseText={FALLBACK_MESSAGE}
-            reference="VerseMate"
-            deepLink={`${WEB_BASE_URL}/bible/1/1?src=widget`}
-          />
-        );
+        const fallback: WidgetVerseData = {
+          verses: null,
+          reference: "",
+          deepLink: `${WEB_BASE_URL}/bible/1/1?src=widget`,
+          fallbackText: FALLBACK_MESSAGE,
+        };
+        props.renderWidget({
+          light: <VerseOfTheDayWidget {...fallback} theme="light" />,
+          dark: <VerseOfTheDayWidget {...fallback} theme="dark" />,
+        });
       }
       break;
     }

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -64,11 +64,15 @@ export async function fetchVerse(): Promise<{
   deepLink: string;
 }> {
   const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
-  const version =
-    (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
-  const pid = await AsyncStorage.getItem(USER_ID_KEY);
 
   try {
+    // Read inside the try: in the headless widget task AsyncStorage can throw
+    // if its native module isn't ready yet. A throw here must fall through to
+    // the rendered fallback below — never bubble out of fetchVerse, which would
+    // skip the widget render and leave a blank (transparent) widget.
+    const version =
+      (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
+    const pid = await AsyncStorage.getItem(USER_ID_KEY);
     let url = `${apiBase}/bible/verse-of-the-day?date=${localDate()}&bible_version=${version}`;
     if (pid) url += `&pid=${encodeURIComponent(pid)}`;
     const res = await fetch(url);
@@ -99,14 +103,27 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
     case "WIDGET_ADDED":
     case "WIDGET_UPDATE":
     case "WIDGET_RESIZED": {
-      const { verseText, reference, deepLink } = await fetchVerse();
-      props.renderWidget(
-        <VerseOfTheDayWidget
-          verseText={verseText}
-          reference={reference}
-          deepLink={deepLink}
-        />
-      );
+      // Always render *something* — a blank/transparent widget is the worst
+      // outcome. fetchVerse no longer rejects, but guard the whole render so
+      // any unexpected failure still paints a tap-to-open fallback.
+      try {
+        const { verseText, reference, deepLink } = await fetchVerse();
+        props.renderWidget(
+          <VerseOfTheDayWidget
+            verseText={verseText}
+            reference={reference}
+            deepLink={deepLink}
+          />
+        );
+      } catch {
+        props.renderWidget(
+          <VerseOfTheDayWidget
+            verseText={FALLBACK_MESSAGE}
+            reference="VerseMate"
+            deepLink={`${WEB_BASE_URL}/bible/1/1?src=widget`}
+          />
+        );
+      }
       break;
     }
     case "WIDGET_CLICK": {


### PR DESCRIPTION
## Problem
On device, the Android Verse-of-the-Day widget renders as a **blank/transparent cell** — the home-screen grid shows through, no content.

## Root-cause candidate
In `widgets/widget-task-handler.tsx`, `fetchVerse` read `AsyncStorage` **outside** its `try/catch`. In the headless widget task, if the AsyncStorage native module isn't ready, `fetchVerse` rejects → the handler's `await` throws → `props.renderWidget(...)` is **never called** → the widget stays blank.

## Fix
- Move the `AsyncStorage` reads **inside** the `try`, so `fetchVerse` always resolves to something renderable (branded fallback on any error).
- Wrap the `WIDGET_ADDED`/`WIDGET_UPDATE`/`WIDGET_RESIZED` render so a tap-to-open fallback widget is **always** painted, even on unexpected failure. A blank widget should be impossible after this.

## Verification
- ✅ ESLint clean; Jest `widget-task-handler` 7/7.
- ⚠️ **Needs on-device retest** — the native widget can't be built/run in CI (no `/dev/kvm`/SDK). If it's *still* blank after this, the cause is upstream (headless task not booting at all — e.g. `index.js` → `expo-router/entry` failing in the headless context), and the next step is `adb logcat` while adding the widget.

Follow-up to GH-265 (verse-mate-mobile#344).