### PR TITLE
fix(widget): open native app on tap via custom scheme (GH-265)

### DIFF
--- a/__tests__/utils/chapter-share-url.test.ts
+++ b/__tests__/utils/chapter-share-url.test.ts
@@ -97,6 +97,11 @@ describe('parseChapterShareUrl', () => {
     expect(result).toEqual({ bookId: 43, chapterNumber: 3 });
   });
 
+  it('parses the app custom scheme used by the widget (versemate:///bible/...)', () => {
+    const result = parseChapterShareUrl('versemate:///bible/43/3?verseStart=16&src=widget');
+    expect(result).toEqual({ bookId: 43, chapterNumber: 3, verseStart: 16 });
+  });
+
   it('returns null for malformed URL', () => {
     const result = parseChapterShareUrl('https://example.com/wrong/path');
     expect(result).toBeNull();

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -40,6 +40,9 @@ describe('widget-task-handler', () => {
       const ref = { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null };
       const url = buildDeepLink(ref);
 
+      // Custom scheme (not the https App Link host) so the tap always opens the
+      // native app without depending on App Links domain verification.
+      expect(url).toMatch(/^versemate:\/\/\/bible\//);
       // src=widget must survive for the layout to fire WIDGET_TAPPED.
       expect(url).toContain('src=widget');
       expect(url).toContain('verseStart=16');

--- a/utils/sharing/generate-chapter-share-url.ts
+++ b/utils/sharing/generate-chapter-share-url.ts
@@ -107,8 +107,13 @@ export function parseChapterShareUrl(url: string): {
     const urlObj = new URL(url);
     const baseUrlObj = new URL(baseUrl);
 
-    // Verify the URL matches our base URL (host must match)
-    if (urlObj.host !== baseUrlObj.host) {
+    // Accept either an https App Link on our web host, or the app's own custom
+    // scheme (versemate://) used by the home-screen widget — the latter always
+    // opens the native app without relying on App Links domain verification.
+    // Custom-scheme URLs are emitted as `versemate:///bible/...` (empty
+    // authority), so the path shape below is identical to the web host's.
+    const isAppScheme = urlObj.protocol === 'versemate:';
+    if (!isAppScheme && urlObj.host !== baseUrlObj.host) {
       return null;
     }
 

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -23,15 +23,20 @@ const USER_ID_KEY = "widget-user-id";
 const FALLBACK_MESSAGE = "Open VerseMate to see today's verse";
 
 /**
- * Base web host for the tap deep link.
+ * Base for the tap deep link — the app's custom scheme (versemate://), NOT the
+ * https App Link host.
  *
- * Must match the host the deep-link parser expects: parseChapterShareUrl
- * (utils/sharing/generate-chapter-share-url.ts) rejects any URL whose host
- * differs from `EXPO_PUBLIC_WEB_URL`. Deriving from the same env here keeps the
- * widget link and the parser in sync on every build (staging/preview/dev),
- * instead of hardcoding prod. Falls back to prod when the env is unset.
+ * A home-screen widget always has the app installed, and the custom scheme
+ * opens the native app directly. The https form (app.versemate.org) depends on
+ * Android App Links / iOS Universal Links domain verification
+ * (`.well-known/assetlinks.json` / `apple-app-site-association`); when that
+ * isn't verified the OS falls back to the browser — which is exactly what
+ * happened (the widget tap opened the web app). The triple slash yields an
+ * empty authority so the path is `/bible/...` — the shape parseChapterShareUrl
+ * (utils/sharing/generate-chapter-share-url.ts) parses; it accepts the
+ * `versemate:` scheme alongside the web host.
  */
-const WEB_BASE_URL = process.env.EXPO_PUBLIC_WEB_URL ?? "https://app.versemate.org";
+const DEEP_LINK_BASE = "versemate:///bible";
 
 interface VerseResponse {
   empty: boolean;
@@ -52,8 +57,8 @@ function localDate(): string {
 }
 
 export function buildDeepLink(ref?: VerseResponse["reference"]): string {
-  if (!ref) return `${WEB_BASE_URL}/bible/1/1?src=widget`;
-  let url = `${WEB_BASE_URL}/bible/${ref.bookId}/${ref.chapterNumber}?verseStart=${ref.verseStart}`;
+  if (!ref) return `${DEEP_LINK_BASE}/1/1?src=widget`;
+  let url = `${DEEP_LINK_BASE}/${ref.bookId}/${ref.chapterNumber}?verseStart=${ref.verseStart}`;
   if (ref.verseEnd) url += `&verseEnd=${ref.verseEnd}`;
   return `${url}&src=widget`;
 }
@@ -101,7 +106,7 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     return {
       verses: null,
       reference: "",
-      deepLink: `${WEB_BASE_URL}/bible/1/1?src=widget`,
+      deepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
       fallbackText: FALLBACK_MESSAGE,
     };
   }
@@ -126,7 +131,7 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
         const fallback: WidgetVerseData = {
           verses: null,
           reference: "",
-          deepLink: `${WEB_BASE_URL}/bible/1/1?src=widget`,
+          deepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
           fallbackText: FALLBACK_MESSAGE,
         };
         props.renderWidget({


### PR DESCRIPTION
## Problem
Tapping the Verse-of-the-Day widget opened the **web app**, not the native app.

The tap deep link used the https App Link host `app.versemate.org`. Android only routes an https link to the app if **App Links verification** passes (`/.well-known/assetlinks.json` must list the build's signing cert) — but that path on app.versemate.org serves the SPA `index.html`, so verification never passes and the OS opens the browser. (Same reason share links `/bible`,`/topic`,`/names-of-god` open web on Android.)

## Fix
A home-screen widget always has the app installed, so use the app's **custom scheme** for the tap:
- `buildDeepLink` emits `versemate:///bible/<book>/<chapter>?verseStart=…&src=widget` (triple slash = empty authority → path `/bible/…`, same shape the parser expects).
- `parseChapterShareUrl` accepts the `versemate:` scheme alongside the web host. The `_layout` handler's verse-range routing + `WIDGET_TAPPED` analytics are unchanged.

Custom scheme opens the native app directly — no domain verification.

## Verified on device (emulator)
`versemate:///bible/43/3?verseStart=16&src=widget` → opens `org.versemate.app` at **John 3:16** with the verse-detail sheet open. No browser, no chooser.

Tests: 44 pass — parser parses the custom scheme; `buildDeepLink` emits it.

## Follow-up (separate, broader)
Hosting `assetlinks.json` + `apple-app-site-association` at app.versemate.org would also fix **share links** opening web on Android + iOS Universal Links. Not done here (keeping this change simple).