### PR TITLE
fix(ios): re-enable Verse-of-the-Day widget after provisioning credentials (#347)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -55,7 +55,6 @@
       },
       "env": {
         "APP_ENV": "preview",
-        "EXPO_EXCLUDE_IOS_WIDGET": "1",
         "EXPO_PUBLIC_API_URL": "https://api.versemate.org",
         "EXPO_PUBLIC_WEB_URL": "https://app.versemate.org",
         "EXPO_PUBLIC_POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",
@@ -80,7 +79,6 @@
       },
       "env": {
         "APP_ENV": "production",
-        "EXPO_EXCLUDE_IOS_WIDGET": "1",
         "EXPO_PUBLIC_API_URL": "https://api.versemate.org",
         "EXPO_PUBLIC_WEB_URL": "https://app.versemate.org",
         "EXPO_PUBLIC_POSTHOG_KEY": "phc_UhHXkLHgiD6916hYZgaKy9pjOOlZi9sTRic3RhWWLRC",


### PR DESCRIPTION
## What & why

Closes #347.

The Verse-of-the-Day widget added a second iOS target (`org.versemate.app.widget`) alongside the main app (`org.versemate.app`). That target had no signing credentials on EAS, so non-interactive iOS builds couldn't provision it — which is why `EXPO_EXCLUDE_IOS_WIDGET=1` was set in the `preview`/`production` profiles to drop the widget and keep iOS builds green.

The widget's credentials are now provisioned on EAS:

- **Distribution Certificate** — shared with the main app (serial `72AF4B…`, team `U9SRD4VJPX`).
- **Provisioning Profile** — a new App Store profile for `org.versemate.app.widget` (Developer Portal ID `ZDF7BQ6998`, active), created via the App Store Connect API key.
- **App Group** `group.org.versemate.app` — capability synced so the app and widget can share the selected Bible version.

Both `preview` and `production` use `distribution: store`, so they share the same App Store profile — no per-profile setup needed.

## Change

Remove `EXPO_EXCLUDE_IOS_WIDGET` from the `preview` and `production` env blocks in `eas.json`. With the flag gone, `app.config.js` re-enables the `@bacons/apple-targets` plugin and the App Group entitlement, bringing the iOS widget back into the build.

## Verification

A non-interactive iOS **preview** build with the widget target included compiled and signed both targets successfully:
https://expo.dev/accounts/versemate/projects/verse-mate-mobile/builds/9140767f-ab40-43d6-a234-bab1f0f47cf8

🤖 Generated with [Claude Code](https://claude.com/claude-code)
