### PR TITLE
fix(insight): scale Insight/commentary text with the reader font-size setting

### DIFF
--- a/components/bible/BibleExplanationsPanel.tsx
+++ b/components/bible/BibleExplanationsPanel.tsx
@@ -33,6 +33,7 @@ import { OfflineContentUnavailable } from '@/components/offline/OfflineContentUn
 import { useAuth } from '@/contexts/AuthContext';
 import { useTheme } from '@/contexts/ThemeContext';
 import { BOTTOM_THRESHOLD } from '@/hooks/bible/use-fab-visibility';
+import { useFontSize } from '@/hooks/bible/use-font-size';
 import { useOfflineStatus } from '@/hooks/bible/use-offline-status';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { useBibleByLine, useBibleSummary } from '@/src/api';
@@ -144,10 +145,11 @@ export function BibleExplanationsPanel({
   const { user } = useAuth();
   const { isOffline } = useOfflineStatus();
   const insets = useSafeAreaInsets();
+  const { fontSize: userFontSize } = useFontSize();
   const specs = useMemo(() => getSplitViewSpecs(mode), [mode]);
   const { styles, markdownStyles } = useMemo(
-    () => createStyles(specs, colors, insets),
-    [specs, colors, insets]
+    () => createStyles(specs, colors, insets, userFontSize),
+    [specs, colors, insets, userFontSize]
   );
   // Get current language from user preferences (default to 'en-US')
   // This ensures the query key changes when language changes
@@ -650,7 +652,8 @@ export function BibleExplanationsPanel({
 function createStyles(
   specs: ReturnType<typeof getSplitViewSpecs>,
   colors: ReturnType<typeof getColors>,
-  insets: ReturnType<typeof useSafeAreaInsets>
+  insets: ReturnType<typeof useSafeAreaInsets>,
+  userFontSize: number
 ) {
   const styles = StyleSheet.create({
     container: {
@@ -771,31 +774,41 @@ function createStyles(
     },
   });
 
+  // Scale the AI-explanation (Summary / By Line) reading text with the user's
+  // Bible font-size preference so Insight text grows alongside verse text
+  // (previously these were fixed tokens, so the font-size slider moved the
+  // Bible text but not the Insight — the bug Andy reported). bodyLarge (18) is
+  // the default reader size, so the scale is 1 at the default.
+  const contentScale = userFontSize / fontSizes.bodyLarge;
+  const bodyFont = fontSizes.bodyLarge * contentScale;
+  const heading1Font = fontSizes.heading1 * contentScale;
+  const heading2Font = fontSizes.heading2 * contentScale;
+
   const markdownStyles = StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * lineHeights.body,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: heading1Font,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: heading1Font * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: heading2Font,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: heading2Font * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xl,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * lineHeights.body,
       color: colors.textPrimary,
       marginBottom: spacing.md,
     },
@@ -808,8 +821,8 @@ function createStyles(
       marginBottom: spacing.lg,
     },
     blockquote_text: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * lineHeights.body,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * lineHeights.body,
       color: colors.textPrimary,
     },
   });

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -313,7 +313,10 @@ export function ChapterReader({
   const specs = getHeaderSpecs(mode);
   const { fontSize: userFontSize } = useFontSize();
   const styles = createStyles(colors, explanationsOnly, userFontSize);
-  const markdownStyles = useMemo(() => createMarkdownStyles(colors), [colors]);
+  const markdownStyles = useMemo(
+    () => createMarkdownStyles(colors, userFontSize),
+    [colors, userFontSize]
+  );
 
   // Use Bible Interaction Context for highlights and interactions
   const {
@@ -977,40 +980,53 @@ const createStyles = (
     },
   });
 
-const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
-  StyleSheet.create({
+const createMarkdownStyles = (
+  colors: ReturnType<typeof getColors>,
+  userFontSize: number = fontSizes.bodyLarge
+) => {
+  // Scale Insight (Summary / By Line / Detailed) markdown with the reader's
+  // font-size preference, mirroring the verse-text scaling above. Previously
+  // these were fixed tokens, so the slider moved verse text but not the
+  // Insight — the bug Andy reported. bodyLarge (18) is the default reader
+  // size, so the scale is 1 at the default.
+  const contentScale = userFontSize / fontSizes.bodyLarge;
+  const bodyFont = fontSizes.bodyLarge * contentScale;
+  const heading1Font = fontSizes.heading1 * contentScale;
+  const heading2Font = fontSizes.heading2 * contentScale;
+  const heading3Font = fontSizes.heading3 * contentScale;
+  return StyleSheet.create({
     body: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * 2.0,
       color: colors.textPrimary,
     },
     heading1: {
-      fontSize: fontSizes.heading1,
+      fontSize: heading1Font,
       fontWeight: fontWeights.bold,
-      lineHeight: fontSizes.heading1 * lineHeights.heading,
+      lineHeight: heading1Font * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: spacing.xxl,
       marginBottom: spacing.md,
     },
     heading2: {
-      fontSize: fontSizes.heading2,
+      fontSize: heading2Font,
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading2 * lineHeights.heading,
+      lineHeight: heading2Font * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     heading3: {
-      fontSize: fontSizes.heading3,
+      fontSize: heading3Font,
       fontWeight: fontWeights.semibold,
-      lineHeight: fontSizes.heading3 * lineHeights.heading,
+      lineHeight: heading3Font * lineHeights.heading,
       color: colors.textPrimary,
       marginTop: 64,
       marginBottom: spacing.sm,
     },
     paragraph: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.lg,
     },
@@ -1023,8 +1039,8 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
       color: colors.textPrimary,
     },
     list_item: {
-      fontSize: fontSizes.bodyLarge,
-      lineHeight: fontSizes.bodyLarge * 2.0,
+      fontSize: bodyFont,
+      lineHeight: bodyFont * 2.0,
       color: colors.textPrimary,
       marginBottom: spacing.sm,
     },
@@ -1070,3 +1086,4 @@ const createMarkdownStyles = (colors: ReturnType<typeof getColors>) =>
       marginVertical: spacing.xl,
     },
   });
+};


### PR DESCRIPTION
## Problem
Increasing the app font size scaled the Bible text but **not** the Insight / commentary text (reported by Andy, 2026-07-08). The font-size slider only fed verse rendering; every Insight surface used fixed `theme/tokens` sizes.

## Fix
Thread the user's `useFontSize` value into the markdown styles on **both** Insight render paths:
- **Phone** — `ChapterReader.createMarkdownStyles` (Summary / By Line / Detailed and `explanationsOnly` mode).
- **Tablet** — `BibleExplanationsPanel` split-view markdown styles.

Scale = `userFontSize / fontSizes.bodyLarge` (18), so it is exactly `1.0` at the default size — existing users see no change; other sizes scale the commentary body + headings proportionally, matching the verse text.

## Testing
- `tsc --noEmit`: clean (no errors in changed files).
- The change is a pure style-scale mirroring the existing verse-text scaling in `ChapterReader`.
- ⚠️ On-device visual confirmation still pending (the installed build predates this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
