### PR TITLE
fix(visuals): fall back to BibleProject page when a video can't play in-app

### DIFF
--- a/components/bible/VisualsPanel.tsx
+++ b/components/bible/VisualsPanel.tsx
@@ -377,11 +377,20 @@ export function VisualsPanel({
   // Player API behind the scenes and exposes `onChangeState` / `onError`
   // for status. When the channel hard-blocks the embed, `onError` flips
   // `videoError` and we render an "Open in YouTube" fallback.
-  const youtubeWatchUrl = video ? `https://www.youtube.com/watch?v=${video.youtubeId}` : null;
+  // Fall back to the canonical BibleProject video page rather than a YouTube
+  // watch URL. Every VideoEntry carries a `page` that always resolves, whereas
+  // `youtube.com/watch?v=<youtubeId>` dead-ends when the bundled id is stale —
+  // several BibleProject overviews were re-released, leaving 403 ids (Matthew,
+  // Romans, 1 Corinthians, Titus, Hebrews), which made this very fallback
+  // button broken (Andy, 2026-07-12). The page also lets the user reach the
+  // video even when YouTube blocks the in-app embed.
+  const videoFallbackUrl = video
+    ? video.page || `https://www.youtube.com/watch?v=${video.youtubeId}`
+    : null;
   const handleVideoFallback = useCallback(() => {
-    if (!youtubeWatchUrl) return;
-    Linking.openURL(youtubeWatchUrl).catch(() => {});
-  }, [youtubeWatchUrl]);
+    if (!videoFallbackUrl) return;
+    Linking.openURL(videoFallbackUrl).catch(() => {});
+  }, [videoFallbackUrl]);
 
   // The youtube-iframe player needs an explicit `height`. The video card
   // itself is `aspectRatio: 16/9`, but RN measures children by absolute
@@ -427,10 +436,10 @@ export function VisualsPanel({
                 onPress={handleVideoFallback}
                 style={styles.videoErrorButton}
                 accessibilityRole="button"
-                accessibilityLabel="Open video in YouTube"
+                accessibilityLabel="Watch video on BibleProject"
                 testID={`${testID}-video-open-external`}
               >
-                <Text style={styles.videoErrorButtonText}>Open in YouTube</Text>
+                <Text style={styles.videoErrorButtonText}>Watch on BibleProject</Text>
               </Pressable>
             </View>
           ) : (


### PR DESCRIPTION
## Problem
The Visuals tab video card builds **both** the in-app YouTube embed and the "can't play in-app" fallback link from the same bundled `youtubeId`. Several BibleProject overview ids are now stale (YouTube 403 — re-released videos): **Matthew 1–13, Matthew 14–28, Romans 1–4, Romans 5–16, 1 Corinthians, Titus, Hebrews**. So the embed **and** the "Open in YouTube" link both dead-end (Andy, 2026-07-12, "important").

## Fix
Point the fallback at each `VideoEntry`'s canonical BibleProject `page` URL (always resolves) and relabel the button **"Watch on BibleProject"** — so the user can always reach the video regardless of a stale id or an embed block. Future-proofs against any bad id.

## Note
This is the client-robustness half. The stale ids themselves are corrected separately in `@versemate/visuals` (source: `verse-mate-web/scripts/visuals-ingest/bibleproject_videos.py`) + a pin bump.

## Testing
- Biome clean; `video.page` is a required field on every `VideoEntry`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)