### PR TITLE
chore(visuals): bump @versemate/visuals to corrected BibleProject video ids

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
-        "@versemate/visuals": "github:verse-mate/verse-mate-visuals#751d1a3",
+        "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
         "expo-apple-authentication": "~8.0.8",
@@ -849,7 +849,7 @@
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#b91fa3c", {}, "verse-mate-verse-mate-studies-b91fa3c"],
 
-    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#751d1a3", {}, "verse-mate-verse-mate-visuals-751d1a3"],
+    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#6e8a427", {}, "verse-mate-verse-mate-visuals-6e8a427"],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "verse-mate-mobile",
@@ -20,7 +21,7 @@
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
-        "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
+        "@versemate/visuals": "github:verse-mate/verse-mate-visuals#751d1a3",
         "axios": "^1.12.2",
         "expo": "~54.0.27",
         "expo-apple-authentication": "~8.0.8",
@@ -848,7 +849,7 @@
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#b91fa3c", {}, "verse-mate-verse-mate-studies-b91fa3c"],
 
-    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#fa6d815", {}, "verse-mate-verse-mate-visuals-fa6d815"],
+    "@versemate/visuals": ["@versemate/visuals@github:verse-mate/verse-mate-visuals#751d1a3", {}, "verse-mate-verse-mate-visuals-751d1a3"],
 
     "@vitest/expect": ["@vitest/expect@3.2.4", "", { "dependencies": { "@types/chai": "^5.2.2", "@vitest/spy": "3.2.4", "@vitest/utils": "3.2.4", "chai": "^5.2.0", "tinyrainbow": "^2.0.0" } }, "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig=="],
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
-    "@versemate/visuals": "github:verse-mate/verse-mate-visuals#751d1a3",
+    "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
     "axios": "^1.12.2",
     "expo": "~54.0.27",
     "expo-apple-authentication": "~8.0.8",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
-    "@versemate/visuals": "github:verse-mate/verse-mate-visuals#fa6d815",
+    "@versemate/visuals": "github:verse-mate/verse-mate-visuals#751d1a3",
     "axios": "^1.12.2",
     "expo": "~54.0.27",
     "expo-apple-authentication": "~8.0.8",


### PR DESCRIPTION
Bumps the `@versemate/visuals` pin to **verse-mate-visuals 751d1a3** (PR verse-mate/verse-mate-visuals#1), which replaces the **7 dead BibleProject overview video ids** (Matthew ×2, Romans ×2, 1 Corinthians, Titus, Hebrews — deleted/re-uploaded on YouTube) with the current ones. This **restores in-app playback** in the Visuals tab for those books (Andy, 2026-07-12, "important").

Verified after `bun install`: `node_modules/@versemate/visuals` now carries the 7 new ids and none of the dead ones.

**Depends on** verse-mate/verse-mate-visuals#1. Pin currently targets that PR's branch commit `751d1a3`; re-point to the main SHA once it merges. Complements #356 (which made the offline/embed-failure fallback open the BibleProject page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)