### PR TITLE
feat(highlights): red-letter 'Jesus's Words' toggle + rendering

### DIFF
--- a/__tests__/red-letter.test.ts
+++ b/__tests__/red-letter.test.ts
@@ -1,0 +1,20 @@
+import { bookHasRedLetter, getRedLetterVerses, isRedLetterVerse } from '@versemate/red-letter';
+
+describe('@versemate/red-letter integration', () => {
+  it('returns the words-of-Jesus verses for a Gospel chapter', () => {
+    const mark10 = getRedLetterVerses(41, 10);
+    expect(mark10.length).toBeGreaterThan(0);
+    expect(mark10).toContain(29); // Jesus speaks in Mark 10:29
+    expect(mark10).not.toContain(1); // v1 is narration
+  });
+
+  it('isRedLetterVerse membership check', () => {
+    expect(isRedLetterVerse(41, 10, 29)).toBe(true);
+    expect(isRedLetterVerse(41, 10, 1)).toBe(false);
+  });
+
+  it('books with no words of Jesus resolve to empty / false', () => {
+    expect(bookHasRedLetter(1)).toBe(false); // Genesis
+    expect(getRedLetterVerses(1, 1)).toEqual([]);
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -20,6 +20,7 @@
         "@types/semver": "^7.7.1",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
         "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
+        "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
         "axios": "^1.12.2",
@@ -846,6 +847,8 @@
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
     "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0"],
+
+    "@versemate/red-letter": ["@versemate/red-letter@github:verse-mate/verse-mate-red-letter#650d08c", {}, "verse-mate-verse-mate-red-letter-650d08c"],
 
     "@versemate/studies": ["@versemate/studies@github:verse-mate/verse-mate-studies#b91fa3c", {}, "verse-mate-verse-mate-studies-b91fa3c"],
 

--- a/components/bible/ChapterReader.tsx
+++ b/components/bible/ChapterReader.tsx
@@ -22,6 +22,7 @@
  */
 
 import type { AlignedToken, LexEntry } from '@versemate/lexicon';
+import { getRedLetterVerses } from '@versemate/red-letter';
 import { Fragment, useEffect, useMemo, useRef, useState } from 'react';
 import {
   type NativeSyntheticEvent,
@@ -44,6 +45,7 @@ import { isElementVisible, useTextVisibility } from '@/contexts/TextVisibilityCo
 import { useTheme } from '@/contexts/ThemeContext';
 import { useFontSize } from '@/hooks/bible/use-font-size';
 import type { Highlight } from '@/hooks/bible/use-highlights';
+import { useRedLetterEnabled } from '@/hooks/bible/use-red-letter-enabled';
 import { isEnglishVersion, useChapterAlignment } from '@/hooks/use-chapter-alignment';
 import {
   fontSizes,
@@ -313,6 +315,24 @@ export function ChapterReader({
   const specs = getHeaderSpecs(mode);
   const { fontSize: userFontSize } = useFontSize();
   const styles = createStyles(colors, explanationsOnly, userFontSize);
+
+  // Red-letter (words of Jesus): render whole verses Jesus speaks in red when
+  // the "Jesus's Words" toggle is on. Local, translation-independent dataset
+  // (@versemate/red-letter) — no API, works offline / for guests. Mirrors
+  // verse-mate-web's `.red-letter` class; the color cascades into the verse's
+  // lexicon/highlight child spans (they set no text color of their own).
+  const { isEnabled: redLetterEnabled } = useRedLetterEnabled();
+  const redLetterVerses = useMemo(
+    () =>
+      new Set<number>(
+        redLetterEnabled ? getRedLetterVerses(chapter.bookId, chapter.chapterNumber) : []
+      ),
+    [redLetterEnabled, chapter.bookId, chapter.chapterNumber]
+  );
+  const redLetterStyle = useMemo(
+    () => ({ color: mode === 'dark' ? '#ff6b6b' : '#c1121f' }),
+    [mode]
+  );
   const markdownStyles = useMemo(
     () => createMarkdownStyles(colors, userFontSize),
     [colors, userFontSize]
@@ -703,7 +723,11 @@ export function ChapterReader({
                                 onVerseTap={handleVerseTap}
                                 alignment={alignment}
                                 onLexiconWordPress={handleLexiconWordPress}
-                                style={styles.verseTextInline}
+                                style={
+                                  redLetterVerses.has(verse.verseNumber)
+                                    ? [styles.verseTextInline, redLetterStyle]
+                                    : styles.verseTextInline
+                                }
                                 isVisible={isVerseVisible(group[0].verseNumber)}
                               />
                             </Text>
@@ -735,7 +759,11 @@ export function ChapterReader({
                       onVerseTap={handleVerseTap}
                       alignment={alignment}
                       onLexiconWordPress={handleLexiconWordPress}
-                      style={styles.verseText}
+                      style={
+                        redLetterVerses.has(verse.verseNumber)
+                          ? [styles.verseText, redLetterStyle]
+                          : styles.verseText
+                      }
                       isVisible={true}
                     />
                   </View>

--- a/components/settings/AutoHighlightSettings.tsx
+++ b/components/settings/AutoHighlightSettings.tsx
@@ -11,6 +11,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { Alert, Pressable, StyleSheet, Switch, Text, View } from 'react-native';
 import { useTheme } from '@/contexts/ThemeContext';
+import { useRedLetterEnabled } from '@/hooks/bible/use-red-letter-enabled';
 import { useAutoHighlightsEnabled } from '@/hooks/use-auto-highlights-enabled';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
@@ -58,6 +59,7 @@ export function AutoHighlightSettings({
   const styles = createStyles(colors);
   const queryClient = useQueryClient();
   const { isEnabled: localEnabled, setEnabled: setLocalEnabled } = useAutoHighlightsEnabled();
+  const { isEnabled: redLetterEnabled, setEnabled: setRedLetterEnabled } = useRedLetterEnabled();
   const [themes, setThemes] = useState<HighlightTheme[]>([]);
   const [publicThemes, setPublicThemes] = useState<
     { theme_id: number; name: string; color: string; description: string | null }[]
@@ -224,6 +226,29 @@ export function AutoHighlightSettings({
                 Toggle themes on or off to customize which highlights you see.
               </Text>
             )}
+          </View>
+
+          {/* Jesus's Words (red-letter). Always shown + purely client-side, so
+              it works for signed-out users too — backed by the shared
+              @versemate/red-letter dataset, independent of the sign-in-gated API
+              themes below. Mirrors verse-mate-web's "Jesus's Words" toggle. */}
+          <View style={styles.themeItem} testID="red-letter-row">
+            <View style={styles.themeHeader}>
+              <View style={styles.themeHeaderLeft}>
+                <View style={[styles.colorBadge, { backgroundColor: '#c1121f' }]} />
+                <Text style={styles.themeName}>{"Jesus's Words"}</Text>
+              </View>
+              <Switch
+                value={redLetterEnabled}
+                onValueChange={setRedLetterEnabled}
+                trackColor={{ false: colors.border, true: colors.gold }}
+                thumbColor={colors.background}
+                testID="toggle-red-letter"
+              />
+            </View>
+            <Text style={styles.themeDescription}>
+              Show every verse spoken by Jesus in red (red-letter)
+            </Text>
           </View>
 
           {error && <Text style={styles.errorText}>{error}</Text>}

--- a/hooks/bible/use-red-letter-enabled.ts
+++ b/hooks/bible/use-red-letter-enabled.ts
@@ -1,0 +1,104 @@
+/**
+ * useRedLetterEnabled Hook
+ *
+ * Master on/off toggle for red-letter (words of Jesus) rendering, persisted to
+ * AsyncStorage. Works for logged-in and logged-out users as a local preference,
+ * default OFF — mirroring verse-mate-web's `redLetter` setting (PR #226).
+ *
+ * Like useLexiconUnderlines, it keeps a module-level subscriber set so toggling
+ * "Jesus's Words" on the Highlights screen updates an already-mounted reader
+ * live, without needing the reader screen to remount.
+ *
+ * @example
+ * ```tsx
+ * const { isEnabled, setEnabled } = useRedLetterEnabled();
+ * <Switch value={isEnabled} onValueChange={setEnabled} />
+ * ```
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useEffect, useState } from 'react';
+
+const STORAGE_KEY = '@versemate:red_letter_enabled';
+const DEFAULT_ENABLED = false;
+
+// Module-level cache + subscribers so every mounted consumer stays in sync
+// and remounts don't flicker.
+let inMemoryCache: boolean | null = null;
+const listeners = new Set<(value: boolean) => void>();
+
+function notify(value: boolean) {
+  inMemoryCache = value;
+  for (const listener of listeners) listener(value);
+}
+
+/** FOR TEST ENVIRONMENTS ONLY — resets the in-memory cache. */
+export function __TEST_ONLY_RESET_CACHE() {
+  inMemoryCache = null;
+  listeners.clear();
+}
+
+export interface UseRedLetterEnabledResult {
+  /** Whether the words of Jesus are shown in red. */
+  isEnabled: boolean;
+  /** Update the preference (persists to AsyncStorage, updates all consumers). */
+  setEnabled: (value: boolean) => Promise<void>;
+  /** Whether the initial load from storage is in progress. */
+  isLoading: boolean;
+}
+
+export function useRedLetterEnabled(): UseRedLetterEnabledResult {
+  const [isEnabled, setState] = useState<boolean>(inMemoryCache ?? DEFAULT_ENABLED);
+  const [isLoading, setIsLoading] = useState(inMemoryCache === null);
+
+  // Subscribe to cross-component updates.
+  useEffect(() => {
+    const listener = (value: boolean) => setState(value);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  // Load persisted value once.
+  useEffect(() => {
+    let isMounted = true;
+    if (inMemoryCache !== null) return;
+
+    (async () => {
+      try {
+        setIsLoading(true);
+        const stored = await AsyncStorage.getItem(STORAGE_KEY);
+        const value = stored === null ? DEFAULT_ENABLED : stored === 'true';
+        if (isMounted) {
+          inMemoryCache = value;
+          setState(value);
+        }
+      } catch {
+        if (isMounted) {
+          inMemoryCache = DEFAULT_ENABLED;
+          setState(DEFAULT_ENABLED);
+        }
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    })();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const setEnabled = async (value: boolean): Promise<void> => {
+    notify(value); // update all consumers immediately
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, String(value));
+    } catch (err) {
+      if (__DEV__) {
+        console.error('useRedLetterEnabled: failed to persist preference:', err);
+      }
+    }
+  };
+
+  return { isEnabled, setEnabled, isLoading };
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,7 @@ module.exports = {
     // Whitelist @versemate/studies + @versemate/visuals — both ship .ts
     // source via a github:/file: dep, so Jest needs to run them through
     // babel-jest like any project file.
-    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|msw|@mswjs/.*|@bundled-es-modules/.*|until-async|@versemate/(studies|visuals)))',
+    'node_modules/(?!((jest-)?react-native|@react-native(-community)?|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|@unimodules/.*|unimodules|sentry-expo|native-base|react-native-svg|msw|@mswjs/.*|@bundled-es-modules/.*|until-async|@versemate/(studies|visuals|red-letter)))',
   ],
 
   // Ignore flow type files

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/semver": "^7.7.1",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
     "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
+    "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
     "axios": "^1.12.2",


### PR DESCRIPTION
## What
Adds **red-letter ("Jesus's Words")** to mobile — every verse Jesus speaks renders in red when the toggle is on — matching what Andy shipped on web (verse-mate-web #226). Requested in the #versemate bugs channel ("the data source of red letter bible should be avail for mobile").

## How — via a new shared package, not the backend
The red-letter data is **translation-independent** (which verses Jesus speaks is the same in NASB, KJV, WEB, any language — it's derived from the public-domain World English Bible `\wj` markers at the *verse* level). So it's pure static reference data, exactly like `@versemate/visuals` / `@versemate/lexicon` — **not** the DB-backed treatment `@versemate/studies` needs (studies are *translated*, so they're server-side).

So Andy's inline `redLetterVerses.json` is extracted into a new shared package **[`@versemate/red-letter`](https://github.com/verse-mate/verse-mate-red-letter)** — a single source of truth for web + mobile (no per-client duplication). This PR consumes it:

- **`@versemate/red-letter`** dep (pinned `650d08c`) + jest transform whitelist.
- **`use-red-letter-enabled`** hook — persisted (AsyncStorage), default off, module-level subscribers so toggling live-updates an already-mounted reader (mirrors `use-lexicon-underlines`). Purely client-side → **works for signed-out guests**, like Andy's web version.
- **"Jesus's Words" toggle** in `AutoHighlightSettings` (Highlights screen) — red dot + "Show every verse spoken by Jesus in red (red-letter)".
- **`ChapterReader`** merges a red text color (`#c1121f` light / `#ff6b6b` dark) into the verse text style for red-letter verses. The color cascades into the verse's lexicon/highlight child spans (they set no text color), so backgrounds/underlines still work — same approach as web's `.red-letter` class. **Zero changes to `HighlightedText`.**

## Testing
- `__tests__/red-letter.test.ts`: **3/3** (accessor integration — Mark 10:29 is red, narration isn't, Genesis empty).
- Biome ci clean; eslint 0 errors.
- ⚠️ On-device visual (does the toggle redden the text?) pending the preview build.

## Depends on
`@versemate/red-letter` (public repo). Pin `650d08c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
