### PR TITLE
fix(lexicon): cross-translation underlines + correct definitions (Andy's Jul 11 bugs)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@tanstack/react-query": "^5.90.2",
         "@types/semver": "^7.7.1",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
+        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#e1792e88d6af65a55cc51aacfe750ef5efad69e9",
         "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
@@ -846,7 +846,7 @@
 
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
-    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#d16f2e0", {}, "verse-mate-verse-mate-lexicon-d16f2e0"],
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#e1792e8", {}, "verse-mate-verse-mate-lexicon-e1792e8"],
 
     "@versemate/red-letter": ["@versemate/red-letter@github:verse-mate/verse-mate-red-letter#650d08c", {}, "verse-mate-verse-mate-red-letter-650d08c"],
 

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -338,30 +338,40 @@ export function HighlightedText({
     for (const token of alignment.verses[verseNumber]) {
       const entry = alignment.lexicon[token.lemma];
       if (!entry) continue;
-      const rawSurface = token.surface;
-      // Split on whitespace and hyphens for multi-word detection.
-      const parts = rawSurface
-        .toLowerCase()
-        .split(/[\s-]+/)
-        .filter(Boolean);
-      if (parts.length <= 1) {
-        const normalized = rawSurface.toLowerCase();
-        // First-write-wins keeps the data file's ordering authoritative when
-        // the same surface maps to multiple lemmas in a verse.
-        if (!single.has(normalized)) {
-          single.set(normalized, { token, entry, isTheme: themeSet.has(token.lemma) });
+      // AlignedToken.surface is a single BSB-anchored string on legacy data,
+      // and a string[] of cross-translation surfaces (KJV/NASB/ESV/NIV/…) on
+      // newer @versemate/lexicon builds (via _aliases.json). Register every
+      // variant so a word underlines / looks up regardless of which
+      // translation the API is currently serving — otherwise BSB↔NASB wording
+      // drift silently drops the underline (e.g. BSB "Submit yourselves" vs
+      // NASB "Submit"). Mirror of web TokenizedVerse's `surfacesOf`.
+      const surfaces = Array.isArray(token.surface) ? token.surface : [token.surface];
+      for (const rawSurface of surfaces) {
+        if (!rawSurface) continue;
+        // Split on whitespace and hyphens for multi-word detection.
+        const parts = rawSurface
+          .toLowerCase()
+          .split(/[\s-]+/)
+          .filter(Boolean);
+        if (parts.length <= 1) {
+          const normalized = rawSurface.toLowerCase();
+          // First-write-wins keeps the data file's ordering authoritative when
+          // the same surface maps to multiple lemmas in a verse.
+          if (!single.has(normalized)) {
+            single.set(normalized, { token, entry, isTheme: themeSet.has(token.lemma) });
+          }
+        } else {
+          const head = parts[0];
+          const list = multi.get(head) ?? [];
+          list.push({
+            parts,
+            surface: rawSurface,
+            token,
+            entry,
+            isTheme: themeSet.has(token.lemma),
+          });
+          multi.set(head, list);
         }
-      } else {
-        const head = parts[0];
-        const list = multi.get(head) ?? [];
-        list.push({
-          parts,
-          surface: rawSurface,
-          token,
-          entry,
-          isTheme: themeSet.has(token.lemma),
-        });
-        multi.set(head, list);
       }
     }
     return { single, multi };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tanstack/react-query": "^5.90.2",
     "@types/semver": "^7.7.1",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#d16f2e0",
+    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#e1792e88d6af65a55cc51aacfe750ef5efad69e9",
     "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",


### PR DESCRIPTION
## What
Fixes the two lexicon bugs Andy reported (Jul 11, #versemate bugs):
- **Missing underlines** — words underlined/defined on web aren't on iOS (e.g. James 4:6 "Submit").
- **Wrong definitions** — e.g. Ps 31:15 "my times", Lev 19:18 "your neighbor".

## Root cause: version drift
Mobile pinned `@versemate/lexicon#d16f2e0`; **web is 10 commits ahead at `#e1792e88`**. Same package repo, different frozen commits — web got the fixes, mobile never did. The missing commits are exactly:
- `feat(aliases): cross-translation surface aliases` + `top-2000 map` + `KJV archaic forms` → underlines
- `fix(lemmas): promote content-word winners…` + `re-enrich 30 slug-collision swaps` → definitions

## Fix
1. **Bump the pin** to web's `#e1792e88` (exact parity with web).
2. **Handle the new token shape.** The new build changes `AlignedToken.surface` from `string` to `string | readonly string[]` (BSB surface unioned with cross-translation aliases). `HighlightedText`'s lookup builder called `.toLowerCase()` directly on it and would throw on the array — it now normalizes to an array and registers every surface variant, mirroring web's `TokenizedVerse.surfacesOf`. It is the only reader of `token.surface`; the popover receives the displayed tapped word (a string), unaffected.

## Testing
- `HighlightedText.test.tsx`: **13/13** pass (no regression).
- biome clean.
- Type-flow verified by hand (`token` is `AlignedToken` end-to-end; the union flows consistently). Pi can't run full `tsc` locally — CI is the type gate.
- ⚠️ On-device underline/definition parity pending the preview build.

## Honest caveat on "my times"
Ps 31:15 "my times" is aligned to lemma key `et`, a **3-way Hebrew homograph** (object-marker אֵת / plowshare אֵת / **time עֵת**). Neither the old nor new build resolves it to the ideal "time" — web shows "plowshare", old mobile showed "object-marker". This PR brings mobile to **parity with web**; making that specific token correct needs an upstream `_contextual.json` override in `verse-mate-lexicon` (separate — it fixes web + mobile at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
