### PR TITLE
fix(reader): stuck skeleton on dropdown chapter jumps (deferred/urgent desync)

### DIFF
--- a/app/bible/[bookId]/[chapterNumber].tsx
+++ b/app/bible/[bookId]/[chapterNumber].tsx
@@ -553,7 +553,28 @@ export default function ChapterScreen() {
    */
   const renderChapterPage = useCallback(
     (pageBookId: number, pageChapterNumber: number) => {
-      const isCurrent = pageBookId === bookId && pageChapterNumber === chapterNumber;
+      // Is this page the reader's actual destination? `bookId`/`chapterNumber`
+      // are the URGENT values (set synchronously by navigateToChapter), so a
+      // swipe's destination lights up the instant the swipe fires. Deep-link
+      // scroll-to-verse must target the real destination only, so it stays
+      // gated on this.
+      const isUrgentCurrent = pageBookId === bookId && pageChapterNumber === chapterNumber;
+      // Content-visibility, however, must also accept the DEFERRED value the
+      // pager actually builds its 3-page window from (bookId/chapterNumber are
+      // passed to SimpleChapterPager via useDeferredValue). Gating purely on the
+      // urgent value broke DROPDOWN jumps: on a non-adjacent jump the urgent
+      // target isn't in the pager's (still-deferred) window yet, so NO rendered
+      // page matched `isCurrent` and all three showed the preloading skeleton
+      // until a swipe forced a re-sync (the "stuck skeleton, swipe to reveal"
+      // bug — regression from #328's useDeferredValue optimization, whose "the
+      // native swipe already moved to the content" premise doesn't hold for a
+      // programmatic jump that has no swipe animation). Accepting the deferred
+      // value keeps the current chapter's content on screen during the brief
+      // catch-up render instead of a skeleton; swipes are unaffected because
+      // their destination still matches the urgent value immediately.
+      const isCurrent =
+        isUrgentCurrent ||
+        (pageBookId === deferredBookId && pageChapterNumber === deferredChapterNumber);
       return (
         <ChapterPage
           bookId={pageBookId}
@@ -565,8 +586,8 @@ export default function ChapterScreen() {
           onScroll={handleScroll}
           onTap={handleTap}
           isPreloading={!isCurrent}
-          targetVerse={isCurrent ? targetVerse : undefined}
-          targetEndVerse={isCurrent ? targetEndVerse : undefined}
+          targetVerse={isUrgentCurrent ? targetVerse : undefined}
+          targetEndVerse={isUrgentCurrent ? targetEndVerse : undefined}
           fabVisible={fabVisible}
           onFABInteraction={showButtons}
         />
@@ -581,6 +602,8 @@ export default function ChapterScreen() {
       handleTap,
       bookId,
       chapterNumber,
+      deferredBookId,
+      deferredChapterNumber,
       targetVerse,
       targetEndVerse,
       fabVisible,


### PR DESCRIPTION
## Symptom
Navigating via the book/chapter **dropdown** to a non-adjacent chapter shows a **stuck loading skeleton**; swiping left then reveals the intended chapter. Consistent, and new (regression). Swiping to navigate is unaffected.

## Root cause — regression from #328's `useDeferredValue`
- `renderChapterPage` marks each page `isPreloading` unless `isCurrent`; `ChapterPage` renders its skeleton buffer while `isPreloading`.
- `isCurrent` compared the page to the **urgent** `bookId/chapterNumber`, but `SimpleChapterPager` builds its 3-page window from the **deferred** values (`useDeferredValue`).
- On a non-adjacent dropdown jump, the urgent target isn't in the pager's deferred window yet → **no** rendered page matches `isCurrent` → all three show the skeleton until a swipe forces re-sync.
- Swipes dodge it: the destination is the adjacent page, which the urgent value matches the instant `navigateToChapter` (a synchronous `useReducer`) fires. #328's comment assumed "the native swipe already moved to the content" — which never happens for a programmatic jump.

## Fix
A page shows content when it matches the urgent target **or** the deferred value the pager actually renders — keeping the current chapter visible during the brief deferred catch-up instead of a skeleton. Swipes are unchanged (urgent match still instant); deep-link scroll-to-verse stays gated on the true (urgent) destination.

## Verification
⚠️ **Diagnosed from the code; not yet verified on-device.** This is a React concurrent-rendering timing bug in the native pager (`react-native-pager-view`), which I can't drive from the Pi (the web build uses a different `PagerView.web.tsx`). Needs an on-device check on the next preview build. The change is minimal and strictly widens when content shows — it can't produce a worse state than today's all-skeleton, and preserves swipe behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
