### PR TITLE
chore(lexicon): per-token Strong's homograph fix (21d63f5)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@tanstack/react-query": "^5.90.2",
         "@types/semver": "^7.7.1",
         "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#e1792e88d6af65a55cc51aacfe750ef5efad69e9",
+        "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#21d63f55e91f5756ce3179c9c21c5e7beeb681e4",
         "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
         "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
         "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",
@@ -846,7 +846,7 @@
 
     "@versemate/dotted-underline-text": ["@versemate/dotted-underline-text@file:modules/dotted-underline-text", {}],
 
-    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#e1792e8", {}, "verse-mate-verse-mate-lexicon-e1792e8"],
+    "@versemate/lexicon": ["@versemate/lexicon@github:verse-mate/verse-mate-lexicon#21d63f5", {}, "verse-mate-verse-mate-lexicon-21d63f5"],
 
     "@versemate/red-letter": ["@versemate/red-letter@github:verse-mate/verse-mate-red-letter#650d08c", {}, "verse-mate-verse-mate-red-letter-650d08c"],
 

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@tanstack/react-query": "^5.90.2",
     "@types/semver": "^7.7.1",
     "@versemate/dotted-underline-text": "file:./modules/dotted-underline-text",
-    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#e1792e88d6af65a55cc51aacfe750ef5efad69e9",
+    "@versemate/lexicon": "github:verse-mate/verse-mate-lexicon#21d63f55e91f5756ce3179c9c21c5e7beeb681e4",
     "@versemate/red-letter": "github:verse-mate/verse-mate-red-letter#650d08c",
     "@versemate/studies": "github:verse-mate/verse-mate-studies#b91fa3ca9bbdaf0ccf27d290ebba2b7ff68f593f",
     "@versemate/visuals": "github:verse-mate/verse-mate-visuals#6e8a427",


### PR DESCRIPTION
Bumps `@versemate/lexicon` to `21d63f5` — per-token Strong's disambiguation. Fixes Andy's definition bugs (Ps 31:15 "my times" plowshare→**time**; Lev 19:18 "your neighbor" shouting→**neighbor**) + the whole Hebrew-homograph class. Pure package bump, no app code change (fix is in `loadAlignmentFor`). Matches web verse-mate-web#234; depends on verse-mate-lexicon#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)