### PR TITLE
GH-281: Mobile push notifications (verse-of-the-day)

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -20,6 +20,10 @@ const config = {
   ios: {
     icon: './assets/images/ios-icon.png',
     bundleIdentifier: 'org.versemate.app',
+    // GH-281: explicit Apple Developer team so iOS builds (incl. the
+    // Verse-of-the-Day widget extension signing) resolve credentials
+    // non-interactively. Team: VerseMate (Company/Organization).
+    appleTeamId: 'U9SRD4VJPX',
     supportsTablet: true,
     associatedDomains: ['applinks:app.versemate.org'],
     // App Group shared between the app and the Verse-of-the-Day widget

--- a/app.config.js
+++ b/app.config.js
@@ -1,3 +1,12 @@
+const fs = require('node:fs');
+
+// GH-281: only wire the FCM config when google-services.json is actually
+// present, so an Android prebuild/build doesn't fail before push credentials
+// are provisioned (the file is gitignored, added via EAS credentials). Until
+// then push simply stays dormant on Android; iOS and the build are unaffected.
+const googleServicesFile = process.env.GOOGLE_SERVICES_JSON ?? './google-services.json';
+const hasGoogleServices = fs.existsSync(googleServicesFile);
+
 const config = {
   name: 'VerseMate',
   slug: 'verse-mate-mobile',
@@ -66,9 +75,10 @@ const config = {
       // GH-281: Android 13+ runtime notification permission for push.
       'POST_NOTIFICATIONS',
     ],
-    // GH-281: FCM V1 service config for Expo push. Uploaded to EAS credentials;
-    // the file is gitignored (contains project keys). Override path via env.
-    googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? './google-services.json',
+    // GH-281: FCM V1 service config for Expo push. Only wired when the file is
+    // present (see top of file) so Android builds don't fail before push
+    // credentials are provisioned. Uploaded via EAS credentials; gitignored.
+    ...(hasGoogleServices ? { googleServicesFile } : {}),
     blockedPermissions: ['android.permission.ACTIVITY_RECOGNITION'],
     adaptiveIcon: {
       backgroundColor: '#E6F4FE',

--- a/app.config.js
+++ b/app.config.js
@@ -11,7 +11,7 @@ const config = {
   name: 'VerseMate',
   slug: 'verse-mate-mobile',
   owner: 'versemate',
-  version: '1.4.0',
+  version: '1.5.0',
   orientation: 'default',
   icon: './assets/images/icon.png',
   scheme: 'versemate',

--- a/app.config.js
+++ b/app.config.js
@@ -63,7 +63,12 @@ const config = {
       'FOREGROUND_SERVICE',
       'FOREGROUND_SERVICE_MEDIA_PLAYBACK',
       'WAKE_LOCK',
+      // GH-281: Android 13+ runtime notification permission for push.
+      'POST_NOTIFICATIONS',
     ],
+    // GH-281: FCM V1 service config for Expo push. Uploaded to EAS credentials;
+    // the file is gitignored (contains project keys). Override path via env.
+    googleServicesFile: process.env.GOOGLE_SERVICES_JSON ?? './google-services.json',
     blockedPermissions: ['android.permission.ACTIVITY_RECOGNITION'],
     adaptiveIcon: {
       backgroundColor: '#E6F4FE',
@@ -121,6 +126,16 @@ const config = {
   },
   plugins: [
     'expo-router',
+    // GH-281: push notifications. The plugin adds the iOS push entitlement
+    // (aps-environment) and Android POST_NOTIFICATIONS wiring at prebuild.
+    [
+      'expo-notifications',
+      {
+        icon: './assets/images/android-icon.png',
+        color: '#E6F4FE',
+        defaultChannel: 'default',
+      },
+    ],
     // GoogleSignin v16 pulls in AppCheckCore, a Swift pod that depends on
     // GoogleUtilities and RecaptchaInterop. Those pods don't define Clang
     // modules, so CocoaPods can't integrate them as static libraries and

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -41,6 +41,7 @@ import { OfflineProvider } from '@/contexts/OfflineContext';
 import { ThemeProvider as CustomThemeProvider, useTheme } from '@/contexts/ThemeContext';
 import { ToastProvider } from '@/contexts/ToastContext';
 import { preloadAllTopicsCache } from '@/hooks/topics/use-cached-topics';
+import { usePushNotifications } from '@/hooks/use-push-notifications';
 import { AnalyticsEvent, analytics } from '@/lib/analytics';
 import {
   trackAudioPlaybackCompleted,
@@ -117,6 +118,10 @@ function RootLayoutInner() {
   const router = useRouter();
   const segments = useSegments();
   const hasInitialized = useRef(false);
+
+  // GH-281: push notifications — foreground handler, login registration, and
+  // tap routing (incl. cold-start).
+  usePushNotifications();
   const [upgradeState, setUpgradeState] = useState<{
     mustUpgrade: boolean;
     currentVersion: string;

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -27,6 +27,7 @@ import {
   Pressable,
   ScrollView,
   StyleSheet,
+  Switch,
   Text,
   View,
 } from 'react-native';
@@ -48,6 +49,11 @@ import { useTheme } from '@/contexts/ThemeContext';
 import { useBibleVersion } from '@/hooks/use-bible-version';
 import { notifyLanguageChanged } from '@/hooks/use-preferred-language';
 import { useDeleteAccount } from '@/hooks/useDeleteAccount';
+import {
+  disableDailyVerseNotifications,
+  enableDailyVerseNotifications,
+} from '@/lib/notifications/push-registration';
+import { isDailyVerseNotificationEnabled } from '@/lib/notifications/push-token-storage';
 import {
   getBibleLanguages,
   patchUserPreferences,
@@ -161,6 +167,34 @@ export default function SettingsScreen() {
   const [showFinalModal, setShowFinalModal] = useState(false);
   const [deletePassword, setDeletePassword] = useState<string | undefined>();
   const { deleteAccount, isDeleting, error: deleteError, clearError } = useDeleteAccount();
+
+  // GH-281: daily verse-of-the-day notification opt-in.
+  const [dailyVerseNotif, setDailyVerseNotif] = useState(false);
+  const [dailyVerseNotifBusy, setDailyVerseNotifBusy] = useState(false);
+  useEffect(() => {
+    void isDailyVerseNotificationEnabled().then(setDailyVerseNotif);
+  }, []);
+  const handleDailyVerseNotifToggle = async (next: boolean) => {
+    if (dailyVerseNotifBusy) return;
+    setDailyVerseNotifBusy(true);
+    try {
+      if (next) {
+        const granted = await enableDailyVerseNotifications();
+        setDailyVerseNotif(granted);
+        if (!granted) {
+          Alert.alert(
+            'Notifications disabled',
+            'Enable notifications for Verse Mate in your device settings to receive the daily verse.'
+          );
+        }
+      } else {
+        await disableDailyVerseNotifications();
+        setDailyVerseNotif(false);
+      }
+    } finally {
+      setDailyVerseNotifBusy(false);
+    }
+  };
 
   // Update form fields when user session changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: isOffline intentionally included to re-run effect when connectivity changes
@@ -901,6 +935,38 @@ export default function SettingsScreen() {
               </View>
               <Ionicons name="chevron-forward" size={20} color={colors.textSecondary} />
             </Pressable>
+          </View>
+        )}
+
+        {/* Daily Verse Notification — mobile only (GH-281) */}
+        {Platform.OS !== 'web' && (
+          <View style={styles.section}>
+            <Text style={styles.sectionLabel}>Notifications</Text>
+            <View style={[styles.selectButton, styles.manageDownloadsButton]}>
+              <Ionicons
+                name="notifications-outline"
+                size={20}
+                color={colors.textPrimary}
+                style={styles.manageDownloadsIcon}
+              />
+              <View style={styles.manageDownloadsTextContainer}>
+                <Text
+                  style={[styles.selectButtonText, styles.manageDownloadsTitle]}
+                  numberOfLines={1}
+                >
+                  Daily verse notification
+                </Text>
+                <Text style={styles.manageDownloadsSubtitle}>
+                  Get the verse of the day each morning
+                </Text>
+              </View>
+              <Switch
+                value={dailyVerseNotif}
+                onValueChange={handleDailyVerseNotifToggle}
+                disabled={dailyVerseNotifBusy}
+                accessibilityLabel="Daily verse notification"
+              />
+            </View>
           </View>
         )}
 

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -53,7 +53,10 @@ import {
   disableDailyVerseNotifications,
   enableDailyVerseNotifications,
 } from '@/lib/notifications/push-registration';
-import { isDailyVerseNotificationEnabled } from '@/lib/notifications/push-token-storage';
+import {
+  getDailyVerseNotificationEnabledCached,
+  isDailyVerseNotificationEnabled,
+} from '@/lib/notifications/push-token-storage';
 import {
   getBibleLanguages,
   patchUserPreferences,
@@ -169,7 +172,7 @@ export default function SettingsScreen() {
   const { deleteAccount, isDeleting, error: deleteError, clearError } = useDeleteAccount();
 
   // GH-281: daily verse-of-the-day notification opt-in.
-  const [dailyVerseNotif, setDailyVerseNotif] = useState(false);
+  const [dailyVerseNotif, setDailyVerseNotif] = useState(getDailyVerseNotificationEnabledCached());
   const [dailyVerseNotifBusy, setDailyVerseNotifBusy] = useState(false);
   useEffect(() => {
     void isDailyVerseNotificationEnabled().then(setDailyVerseNotif);

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "expo-localization": "~17.0.8",
         "expo-location": "~19.0.8",
         "expo-navigation-bar": "~5.0.10",
+        "expo-notifications": "~0.32.17",
         "expo-router": "~6.0.17",
         "expo-screen-orientation": "~9.0.9",
         "expo-secure-store": "^55.0.13",
@@ -487,6 +488,8 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
+    "@ide/backoff": ["@ide/backoff@1.0.0", "", {}, "sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g=="],
 
     "@inquirer/ansi": ["@inquirer/ansi@1.0.0", "", {}, "sha512-JWaTfCxI1eTmJ1BIv86vUfjVatOdxwD0DAVKYevY8SazeUUZtW+tNbsdejVO1GYE0GXJW1N1ahmiC3TFd+7wZA=="],
 
@@ -966,6 +969,8 @@
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
+    "assert": ["assert@2.1.0", "", { "dependencies": { "call-bind": "^1.0.2", "is-nan": "^1.3.2", "object-is": "^1.1.5", "object.assign": "^4.1.4", "util": "^0.12.5" } }, "sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
@@ -1007,6 +1012,8 @@
     "babel-preset-expo": ["babel-preset-expo@54.0.8", "", { "dependencies": { "@babel/helper-module-imports": "^7.25.9", "@babel/plugin-proposal-decorators": "^7.12.9", "@babel/plugin-proposal-export-default-from": "^7.24.7", "@babel/plugin-syntax-export-default-from": "^7.24.7", "@babel/plugin-transform-class-static-block": "^7.27.1", "@babel/plugin-transform-export-namespace-from": "^7.25.9", "@babel/plugin-transform-flow-strip-types": "^7.25.2", "@babel/plugin-transform-modules-commonjs": "^7.24.8", "@babel/plugin-transform-object-rest-spread": "^7.24.7", "@babel/plugin-transform-parameters": "^7.24.7", "@babel/plugin-transform-private-methods": "^7.24.7", "@babel/plugin-transform-private-property-in-object": "^7.24.7", "@babel/plugin-transform-runtime": "^7.24.7", "@babel/preset-react": "^7.22.15", "@babel/preset-typescript": "^7.23.0", "@react-native/babel-preset": "0.81.5", "babel-plugin-react-compiler": "^1.0.0", "babel-plugin-react-native-web": "~0.21.0", "babel-plugin-syntax-hermes-parser": "^0.29.1", "babel-plugin-transform-flow-enums": "^0.0.2", "debug": "^4.3.4", "resolve-from": "^5.0.0" }, "peerDependencies": { "@babel/runtime": "^7.20.0", "expo": "*", "react-refresh": ">=0.14.0 <1.0.0" }, "optionalPeers": ["@babel/runtime", "expo"] }, "sha512-3ZJ4Q7uQpm8IR/C9xbKhE/IUjGpLm+OIjF8YCedLgqoe/wN1Ns2wLT7HwG6ZXXb6/rzN8IMCiKFQ2F93qlN6GA=="],
 
     "babel-preset-jest": ["babel-preset-jest@29.6.3", "", { "dependencies": { "babel-plugin-jest-hoist": "^29.6.3", "babel-preset-current-node-syntax": "^1.0.0" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA=="],
+
+    "badgin": ["badgin@1.2.3", "", {}, "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw=="],
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
@@ -1412,6 +1419,8 @@
 
     "expo-navigation-bar": ["expo-navigation-bar@5.0.10", "", { "dependencies": { "@react-native/normalize-colors": "0.81.5", "debug": "^4.3.2", "react-native-is-edge-to-edge": "^1.2.1" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-r9rdLw8mY6GPMQmVVOY/r1NBBw74DZefXHF60HxhRsdNI2kjc1wLdfWfR2rk4JVdOvdMDujnGrc9HQmqM3n8Jg=="],
 
+    "expo-notifications": ["expo-notifications@0.32.17", "", { "dependencies": { "@expo/image-utils": "^0.8.8", "@ide/backoff": "^1.0.0", "abort-controller": "^3.0.0", "assert": "^2.0.0", "badgin": "^1.1.5", "expo-application": "~7.0.8", "expo-constants": "~18.0.13" }, "peerDependencies": { "expo": "*", "react": "*", "react-native": "*" } }, "sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A=="],
+
     "expo-router": ["expo-router@6.0.17", "", { "dependencies": { "@expo/metro-runtime": "^6.1.2", "@expo/schema-utils": "^0.1.8", "@radix-ui/react-slot": "1.2.0", "@radix-ui/react-tabs": "^1.1.12", "@react-navigation/bottom-tabs": "^7.4.0", "@react-navigation/native": "^7.1.8", "@react-navigation/native-stack": "^7.3.16", "client-only": "^0.0.1", "debug": "^4.3.4", "escape-string-regexp": "^4.0.0", "expo-server": "^1.0.5", "fast-deep-equal": "^3.1.3", "invariant": "^2.2.4", "nanoid": "^3.3.8", "query-string": "^7.1.3", "react-fast-compare": "^3.2.2", "react-native-is-edge-to-edge": "^1.1.6", "semver": "~7.6.3", "server-only": "^0.0.1", "sf-symbols-typescript": "^2.1.0", "shallowequal": "^1.1.0", "use-latest-callback": "^0.2.1", "vaul": "^1.1.2" }, "peerDependencies": { "@react-navigation/drawer": "^7.5.0", "@testing-library/react-native": ">= 12.0.0", "expo": "*", "expo-constants": "^18.0.11", "expo-linking": "^8.0.10", "react": "*", "react-dom": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-safe-area-context": ">= 5.4.0", "react-native-screens": "*", "react-native-web": "*", "react-server-dom-webpack": "~19.0.1 || ~19.1.2 || ~19.2.1" }, "optionalPeers": ["@react-navigation/drawer", "@testing-library/react-native", "react-dom", "react-native-gesture-handler", "react-native-reanimated", "react-native-web", "react-server-dom-webpack"] }, "sha512-2n0lTidH2H+dOjk/Lu+krKIgK7b1qQ3O/9RWmf9P5IEuFiu7BSUgSDc+g69bUEElTnca8FR+zPTyk15kMXHrXg=="],
 
     "expo-screen-orientation": ["expo-screen-orientation@9.0.9", "", { "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-UTU745XoqBvQJkZ820GTfMuOxlkppYqaeQ+x0wdu44cyrZiZugqe+egFF2+zC+SaxgAltU5EuO8GIj9xSF+YMw=="],
@@ -1667,6 +1676,8 @@
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-map": ["is-map@2.0.3", "", {}, "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw=="],
+
+    "is-nan": ["is-nan@1.3.2", "", { "dependencies": { "call-bind": "^1.0.0", "define-properties": "^1.1.3" } }, "sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w=="],
 
     "is-negative-zero": ["is-negative-zero@2.0.3", "", {}, "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw=="],
 
@@ -2848,6 +2859,8 @@
 
     "expo-navigation-bar/@react-native/normalize-colors": ["@react-native/normalize-colors@0.81.5", "", {}, "sha512-0HuJ8YtqlTVRXGZuGeBejLE04wSQsibpTI+RGOyVqxZvgtlLLC/Ssw0UmbHhT4lYMp2fhdtvKZSs5emWB1zR/g=="],
 
+    "expo-notifications/expo-constants": ["expo-constants@18.0.13", "", { "dependencies": { "@expo/config": "~12.0.13", "@expo/env": "~2.0.8" }, "peerDependencies": { "expo": "*", "react-native": "*" } }, "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ=="],
+
     "expo-router/fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "expo-router/semver": ["semver@7.6.3", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A=="],
@@ -3142,6 +3155,8 @@
 
     "eslint/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
+    "expo-notifications/expo-constants/@expo/config": ["@expo/config@12.0.14", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "@expo/config-plugins": "~54.0.5", "@expo/config-types": "^54.0.10", "@expo/json-file": "^10.0.16", "deepmerge": "^4.3.1", "getenv": "^2.0.0", "glob": "^13.0.0", "require-from-string": "^2.0.2", "resolve-from": "^5.0.0", "resolve-workspace-root": "^2.0.0", "semver": "^7.6.0", "slugify": "^1.3.4", "sucrase": "~3.35.1" } }, "sha512-3dfbBd9LnPDgyylhCgkOsaG8Adg52uOVOTQYH5lf23a/t8M5eQpXKCvzUarrf62B78057n2NnkiofK9TfPgvzw=="],
+
     "finalhandler/debug/ms": ["ms@2.0.0", "", {}, "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="],
 
     "jest-config/glob/minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
@@ -3222,6 +3237,14 @@
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
+    "expo-notifications/expo-constants/@expo/config/@babel/code-frame": ["@babel/code-frame@7.10.4", "", { "dependencies": { "@babel/highlight": "^7.10.4" } }, "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/config-plugins": ["@expo/config-plugins@54.0.5", "", { "dependencies": { "@expo/config-types": "^54.0.10", "@expo/json-file": "~10.0.16", "@expo/plist": "^0.4.9", "@expo/sdk-runtime-versions": "^1.0.0", "chalk": "^4.1.2", "debug": "^4.3.5", "getenv": "^2.0.0", "glob": "^13.0.0", "resolve-from": "^5.0.0", "semver": "^7.5.4", "slash": "^3.0.0", "slugify": "^1.6.6", "xcode": "^3.0.1", "xml2js": "0.6.0" } }, "sha512-aWQ3sViNRoQWw6So4A2qhWCt24CuGBK6MrRHI1AG+V6/NQAjIZCHaSvcXK2gXKpmisRhTSUWaKPIgLJQFB+AeQ=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/config-types": ["@expo/config-types@54.0.10", "", {}, "sha512-/J16SC2an1LdtCZ67xhSkGXpALYUVUNyZws7v+PVsFZxClYehDSoKLqyRaGkpHlYrCc08bS0RF5E0JV6g50psA=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/json-file": ["@expo/json-file@10.2.0", "", { "dependencies": { "@babel/code-frame": "^7.20.0", "json5": "^2.2.3" } }, "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ=="],
+
     "jest-config/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
 
     "jest-runtime/glob/minimatch/brace-expansion": ["brace-expansion@1.1.12", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg=="],
@@ -3249,6 +3272,12 @@
     "@babel/highlight/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 
     "@istanbuljs/load-nyc-config/find-up/locate-path/p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/config-plugins/@expo/json-file": ["@expo/json-file@10.0.16", "", { "dependencies": { "@babel/code-frame": "~7.10.4", "json5": "^2.2.3" } }, "sha512-fcVkWEj+hLuP2yt5W0aw6LmDRqSPWDLUSxOMcmFeV+algmIF59sQVKCwB9btjQLd4V6x9N0pISkQEkBubUHrCw=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/config-plugins/@expo/plist": ["@expo/plist@0.4.9", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.2.3", "xmlbuilder": "^15.1.1" } }, "sha512-MPVpmKGfnQEnrCzgxuXcmPP/y/t6AVm+DcSb2Myp21LKWv1N3l8uFxMggesfF4ixAxkRlGmMMx9GyDC9M+XklQ=="],
+
+    "expo-notifications/expo-constants/@expo/config/@expo/json-file/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
     "log-symbols/chalk/ansi-styles/color-convert/color-name": ["color-name@1.1.3", "", {}, "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="],
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -17,6 +17,7 @@ import {
 import { clearTokenCache } from '@/lib/api/client-interceptors';
 import { analytics, AnalyticsEvent } from '@/lib/analytics';
 import { syncWidgetUserId } from '@/hooks/use-shared-widget-prefs';
+import { unregisterPushOnLogout } from '@/lib/notifications/push-registration';
 import {
   getAuthSession,
   postAuthLogin,
@@ -390,6 +391,11 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const logout = async (): Promise<void> => {
     // Track analytics: fire LOGOUT event before resetting identity
     analytics.track(AnalyticsEvent.LOGOUT, {});
+
+    // GH-281 (D-15): unregister this device's push token while the session is
+    // still valid, so a signed-out device stops receiving the daily verse.
+    // Best-effort — never block logout on it.
+    await unregisterPushOnLogout().catch(() => {});
 
     // Clear tokens and cached user profile from storage
     await clearTokens();

--- a/hooks/use-bible-version.ts
+++ b/hooks/use-bible-version.ts
@@ -17,6 +17,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useEffect, useState } from 'react';
 import { syncWidgetBibleVersion } from '@/hooks/use-shared-widget-prefs';
 import { getPostHogInstance } from '@/lib/analytics/posthog-provider';
+import { syncPreferredBibleVersion } from '@/lib/notifications/push-api';
 
 const BIBLE_VERSION_KEY = 'bible-version';
 const DEFAULT_VERSION = 'NASB1995';
@@ -88,6 +89,11 @@ export function useBibleVersion() {
       // Mirror to the iOS widget's App Group so the home-screen widget renders
       // in the newly-selected version (GH-265). Fire-and-forget; no-op on Android.
       void syncWidgetBibleVersion(version);
+
+      // GH-281: persist server-side too, so the daily verse-of-the-day push
+      // (which reads user.preferred_bible_version) renders in this version.
+      // Best-effort; no-op when logged out (401 ignored).
+      void syncPreferredBibleVersion(version);
 
       notifyBibleVersionChanged();
     } catch (error) {

--- a/hooks/use-push-notifications.ts
+++ b/hooks/use-push-notifications.ts
@@ -1,0 +1,86 @@
+/**
+ * Push notifications wiring (GH-281). Mount once, high in the tree.
+ *
+ * - Sets the foreground presentation handler.
+ * - Registers the device token on login (no prompt — only when opted-in +
+ *   permission already granted; the prompt lives in Settings).
+ * - Routes notification taps to the reader, covering the cold-start case via
+ *   `useLastNotificationResponse()` (fires for the launch tap too).
+ */
+import * as Notifications from 'expo-notifications';
+import { router } from 'expo-router';
+import { useEffect, useRef } from 'react';
+import { Platform } from 'react-native';
+import { useAuth } from '@/contexts/AuthContext';
+import { analytics } from '@/lib/analytics';
+import { AnalyticsEvent } from '@/lib/analytics/types';
+import {
+  NOTIFICATION_FALLBACK_ROUTE,
+  resolveNotificationRoute,
+} from '@/lib/notifications/notification-routing';
+import { maybeRegisterOnLogin } from '@/lib/notifications/push-registration';
+
+// Foreground presentation (SDK 52+ keys). Show the daily verse even when the
+// app is open; badges are not used.
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+export function usePushNotifications(): void {
+  const { user } = useAuth();
+  const userId = user?.id ?? null;
+  const lastResponse = Notifications.useLastNotificationResponse();
+  const handledIdRef = useRef<string | null>(null);
+  const registeredForUserRef = useRef<string | null>(null);
+
+  // Register once per login (see maybeRegisterOnLogin for the opt-in gate).
+  useEffect(() => {
+    if (Platform.OS === 'web') return;
+    if (userId) {
+      if (registeredForUserRef.current !== userId) {
+        registeredForUserRef.current = userId;
+        void maybeRegisterOnLogin();
+      }
+    } else {
+      registeredForUserRef.current = null;
+    }
+  }, [userId]);
+
+  // Route a notification tap (also fires for the app-was-killed launch tap).
+  useEffect(() => {
+    if (!lastResponse) return;
+    if (lastResponse.actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER) {
+      return;
+    }
+    const id = lastResponse.notification.request.identifier;
+    if (handledIdRef.current === id) return;
+    handledIdRef.current = id;
+
+    const data = lastResponse.notification.request.content.data as {
+      deepLink?: unknown;
+      type?: unknown;
+    };
+    const deepLink = typeof data?.deepLink === 'string' ? data.deepLink : null;
+    const resolved = deepLink ? resolveNotificationRoute(deepLink) : null;
+
+    if (resolved) {
+      analytics.track(AnalyticsEvent.NOTIFICATION_TAPPED, {
+        bookId: resolved.bookId,
+        chapterNumber: resolved.chapterNumber,
+        verseStart: resolved.verseStart,
+        verseEnd: resolved.verseEnd,
+        type: typeof data?.type === 'string' ? data.type : 'unknown',
+      });
+      router.replace(resolved.route);
+    } else {
+      router.replace(NOTIFICATION_FALLBACK_ROUTE);
+    }
+
+    Notifications.clearLastNotificationResponse();
+  }, [lastResponse]);
+}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -68,6 +68,12 @@ export enum AnalyticsEvent {
   WIDGET_TAPPED = 'WIDGET_TAPPED',
   WIDGET_OPENED_VERSE_DETAIL = 'WIDGET_OPENED_VERSE_DETAIL',
   WIDGET_INSTALLED = 'WIDGET_INSTALLED',
+
+  // Push Notification Events (GH-281)
+  NOTIFICATION_TAPPED = 'NOTIFICATION_TAPPED',
+  NOTIFICATION_ENABLED = 'NOTIFICATION_ENABLED',
+  NOTIFICATION_DISABLED = 'NOTIFICATION_DISABLED',
+  NOTIFICATION_PERMISSION_DENIED = 'NOTIFICATION_PERMISSION_DENIED',
 }
 
 // ============================================================================
@@ -365,6 +371,19 @@ export interface WidgetInstalledProperties {
   platform: 'ios' | 'android';
 }
 
+// Push Notification Events (GH-281)
+export interface NotificationTappedProperties {
+  bookId: number;
+  chapterNumber: number;
+  verseStart?: number;
+  verseEnd?: number;
+  type: string;
+}
+
+export type NotificationEnabledProperties = Record<string, never>;
+export type NotificationDisabledProperties = Record<string, never>;
+export type NotificationPermissionDeniedProperties = Record<string, never>;
+
 /**
  * Maps each AnalyticsEvent to its corresponding properties type
  * Enables type-safe tracking calls
@@ -412,6 +431,11 @@ export interface EventProperties {
   [AnalyticsEvent.WIDGET_TAPPED]: WidgetTappedProperties;
   [AnalyticsEvent.WIDGET_OPENED_VERSE_DETAIL]: WidgetOpenedVerseDetailProperties;
   [AnalyticsEvent.WIDGET_INSTALLED]: WidgetInstalledProperties;
+  // Push Notification Events (GH-281)
+  [AnalyticsEvent.NOTIFICATION_TAPPED]: NotificationTappedProperties;
+  [AnalyticsEvent.NOTIFICATION_ENABLED]: NotificationEnabledProperties;
+  [AnalyticsEvent.NOTIFICATION_DISABLED]: NotificationDisabledProperties;
+  [AnalyticsEvent.NOTIFICATION_PERMISSION_DENIED]: NotificationPermissionDeniedProperties;
 }
 
 // ============================================================================

--- a/lib/notifications/notification-permission.ts
+++ b/lib/notifications/notification-permission.ts
@@ -1,0 +1,40 @@
+/**
+ * OS notification permission helpers (GH-281).
+ */
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+
+/** Android requires a channel before notifications display; safe to call repeatedly. */
+export async function ensureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return;
+  await Notifications.setNotificationChannelAsync('default', {
+    name: 'Daily Verse',
+    importance: Notifications.AndroidImportance.DEFAULT,
+  });
+}
+
+/** Treats iOS provisional/ephemeral authorization as granted (like the OS does). */
+export function isGranted(
+  status: Notifications.NotificationPermissionsStatus,
+): boolean {
+  if (status.granted) return true;
+  const iosStatus = status.ios?.status;
+  return (
+    iosStatus === Notifications.IosAuthorizationStatus.AUTHORIZED ||
+    iosStatus === Notifications.IosAuthorizationStatus.PROVISIONAL ||
+    iosStatus === Notifications.IosAuthorizationStatus.EPHEMERAL
+  );
+}
+
+export async function getNotificationPermissionGranted(): Promise<boolean> {
+  return isGranted(await Notifications.getPermissionsAsync());
+}
+
+/** Requests permission (creating the Android channel first). Returns whether granted. */
+export async function requestNotificationPermission(): Promise<boolean> {
+  await ensureAndroidChannel();
+  const status = await Notifications.requestPermissionsAsync({
+    ios: { allowAlert: true, allowBadge: true, allowSound: true },
+  });
+  return isGranted(status);
+}

--- a/lib/notifications/notification-permission.ts
+++ b/lib/notifications/notification-permission.ts
@@ -26,10 +26,6 @@ export function isGranted(
   );
 }
 
-export async function getNotificationPermissionGranted(): Promise<boolean> {
-  return isGranted(await Notifications.getPermissionsAsync());
-}
-
 /** Requests permission (creating the Android channel first). Returns whether granted. */
 export async function requestNotificationPermission(): Promise<boolean> {
   await ensureAndroidChannel();

--- a/lib/notifications/notification-routing.test.ts
+++ b/lib/notifications/notification-routing.test.ts
@@ -1,0 +1,48 @@
+/**
+ * GH-281 — pure routing unit tests (no expo-notifications, no router).
+ */
+import {
+  NOTIFICATION_FALLBACK_ROUTE,
+  resolveNotificationRoute,
+} from './notification-routing';
+
+describe('resolveNotificationRoute', () => {
+  const OLD_WEB_URL = process.env.EXPO_PUBLIC_WEB_URL;
+
+  beforeAll(() => {
+    process.env.EXPO_PUBLIC_WEB_URL = 'https://app.versemate.org';
+  });
+  afterAll(() => {
+    process.env.EXPO_PUBLIC_WEB_URL = OLD_WEB_URL;
+  });
+
+  it('maps a versemate:// verse deep link to a reader route with src=notification', () => {
+    const result = resolveNotificationRoute(
+      'versemate:///bible/43/3?verseStart=16&src=notification',
+    );
+    expect(result).not.toBeNull();
+    expect(result?.route).toBe('/bible/43/3?verse=16&src=notification');
+    expect(result?.bookId).toBe(43);
+    expect(result?.verseStart).toBe(16);
+  });
+
+  it('includes endVerse for a passage range', () => {
+    const result = resolveNotificationRoute(
+      'versemate:///bible/1/1?verseStart=1&verseEnd=3&src=notification',
+    );
+    expect(result?.route).toBe(
+      '/bible/1/1?verse=1&endVerse=3&src=notification',
+    );
+  });
+
+  it('routes to the chapter (no verse params) when no verseStart', () => {
+    const result = resolveNotificationRoute('versemate:///bible/43/3');
+    expect(result?.route).toBe('/bible/43/3?src=notification');
+  });
+
+  it('returns null for a non-bible / unparseable link (caller uses fallback)', () => {
+    expect(resolveNotificationRoute('versemate:///settings')).toBeNull();
+    expect(resolveNotificationRoute('not a url')).toBeNull();
+    expect(NOTIFICATION_FALLBACK_ROUTE).toBe('/bible/1/1');
+  });
+});

--- a/lib/notifications/notification-routing.ts
+++ b/lib/notifications/notification-routing.ts
@@ -1,0 +1,53 @@
+/**
+ * Notification deep-link routing (GH-281).
+ *
+ * Pure functions that map a verse-of-the-day notification's `data.deepLink`
+ * (a `versemate:///bible/{bookId}/{chapterNumber}?verseStart=…&src=notification`
+ * URL, produced by the backend) onto the in-app reader route. Kept as plain
+ * functions — no `expo-notifications`, no router — so they're unit-testable
+ * with zero mocking (mirrors the widget's `buildWidgetVerseRoute`).
+ */
+import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
+
+/** Where a malformed / unparseable notification link lands. */
+export const NOTIFICATION_FALLBACK_ROUTE = '/bible/1/1';
+
+export interface NotificationRoute {
+  /** Reader route to push, e.g. `/bible/43/3?verse=16&src=notification`. */
+  route: string;
+  bookId: number;
+  chapterNumber: number;
+  verseStart?: number;
+  verseEnd?: number;
+}
+
+/**
+ * Resolve a notification deep link into a reader route (with `src=notification`
+ * so analytics/reader can distinguish notification opens from widget opens).
+ * Returns null when the link can't be parsed — callers use
+ * {@link NOTIFICATION_FALLBACK_ROUTE}.
+ */
+export function resolveNotificationRoute(
+  deepLink: string,
+): NotificationRoute | null {
+  const parsed = parseChapterShareUrl(deepLink);
+  if (!parsed) return null;
+
+  const { bookId, chapterNumber, verseStart, verseEnd } = parsed;
+  if (bookId < 1 || bookId > 66 || chapterNumber < 1) return null;
+
+  const params = new URLSearchParams();
+  if (verseStart) {
+    params.set('verse', String(verseStart));
+    if (verseEnd) params.set('endVerse', String(verseEnd));
+  }
+  params.set('src', 'notification');
+
+  return {
+    route: `/bible/${bookId}/${chapterNumber}?${params.toString()}`,
+    bookId,
+    chapterNumber,
+    verseStart,
+    verseEnd,
+  };
+}

--- a/lib/notifications/push-api.ts
+++ b/lib/notifications/push-api.ts
@@ -1,0 +1,66 @@
+/**
+ * Backend calls for push notifications (GH-281).
+ *
+ * Uses the raw `authenticatedFetch` wrapper (the documented fallback for
+ * endpoints not in the generated client) — the device + preferred-version
+ * routes were added to the backend in the same feature and aren't in the
+ * committed OpenAPI schema yet. All calls are best-effort: failures are logged,
+ * never thrown, so notification plumbing never blocks a user flow.
+ */
+import { authenticatedFetch } from '@/lib/api/authenticated-fetch';
+
+const API_BASE =
+  process.env.EXPO_PUBLIC_API_URL ?? 'https://api.versemate.org';
+
+export type DevicePlatform = 'ios' | 'android';
+
+/** Register/refresh this device's Expo push token for the current user. */
+export async function registerDeviceToken(
+  token: string,
+  platform: DevicePlatform,
+): Promise<boolean> {
+  try {
+    const res = await authenticatedFetch(`${API_BASE}/notifications/device`, {
+      method: 'PUT',
+      body: JSON.stringify({ token, platform }),
+    });
+    return res.ok;
+  } catch (error) {
+    console.warn('[notifications] registerDeviceToken failed:', error);
+    return false;
+  }
+}
+
+/** Unregister this device's token (Settings toggle off / logout). */
+export async function unregisterDeviceToken(token: string): Promise<boolean> {
+  try {
+    const res = await authenticatedFetch(`${API_BASE}/notifications/device`, {
+      method: 'DELETE',
+      body: JSON.stringify({ token }),
+    });
+    return res.ok;
+  } catch (error) {
+    console.warn('[notifications] unregisterDeviceToken failed:', error);
+    return false;
+  }
+}
+
+/**
+ * Persist the user's preferred Bible version server-side so the daily
+ * verse-of-the-day notification renders in it (the backend worker reads
+ * `user.preferred_bible_version`).
+ */
+export async function syncPreferredBibleVersion(
+  version: string,
+): Promise<boolean> {
+  try {
+    const res = await authenticatedFetch(
+      `${API_BASE}/user/preferred-bible-version`,
+      { method: 'POST', body: JSON.stringify({ version }) },
+    );
+    return res.ok;
+  } catch (error) {
+    console.warn('[notifications] syncPreferredBibleVersion failed:', error);
+    return false;
+  }
+}

--- a/lib/notifications/push-registration.test.ts
+++ b/lib/notifications/push-registration.test.ts
@@ -1,0 +1,131 @@
+/**
+ * GH-281 (T-605 / R-002) — push-registration lifecycle gating.
+ *
+ * Guards the R-001 fix (opted-in users get prompted once on login so the
+ * default-ON opt-in actually delivers) and the D-15 logout-unregister.
+ * expo-notifications + push-api + storage are mocked inline (no device);
+ * notification-permission runs for real against the expo-notifications mock.
+ */
+import * as Notifications from 'expo-notifications';
+import { registerDeviceToken, unregisterDeviceToken } from './push-api';
+import {
+  getStoredPushToken,
+  isDailyVerseNotificationEnabled,
+} from './push-token-storage';
+import {
+  maybeRegisterOnLogin,
+  unregisterPushOnLogout,
+} from './push-registration';
+
+jest.mock('./push-api', () => ({
+  registerDeviceToken: jest.fn().mockResolvedValue(true),
+  unregisterDeviceToken: jest.fn().mockResolvedValue(true),
+  syncPreferredBibleVersion: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('./push-token-storage', () => ({
+  isDailyVerseNotificationEnabled: jest.fn(),
+  getStoredPushToken: jest.fn(),
+  setStoredPushToken: jest.fn().mockResolvedValue(undefined),
+  clearStoredPushToken: jest.fn().mockResolvedValue(undefined),
+  setDailyVerseNotificationEnabled: jest.fn().mockResolvedValue(undefined),
+}));
+
+// Inline factory (must not reference outer vars — jest.mock is hoisted).
+jest.mock('expo-notifications', () => ({
+  getPermissionsAsync: jest.fn(),
+  requestPermissionsAsync: jest.fn(),
+  getExpoPushTokenAsync: jest
+    .fn()
+    .mockResolvedValue({ data: 'ExponentPushToken[test]' }),
+  setNotificationChannelAsync: jest.fn().mockResolvedValue(undefined),
+  AndroidImportance: { DEFAULT: 3 },
+  IosAuthorizationStatus: { AUTHORIZED: 2, PROVISIONAL: 3, EPHEMERAL: 4 },
+  PermissionStatus: {
+    GRANTED: 'granted',
+    DENIED: 'denied',
+    UNDETERMINED: 'undetermined',
+  },
+}));
+jest.mock('@/lib/analytics', () => ({
+  analytics: { track: jest.fn() },
+  AnalyticsEvent: {
+    NOTIFICATION_PERMISSION_DENIED: 'NOTIFICATION_PERMISSION_DENIED',
+  },
+}));
+
+const mockGetPerms = Notifications.getPermissionsAsync as jest.Mock;
+const mockReqPerms = Notifications.requestPermissionsAsync as jest.Mock;
+const mockIsEnabled = isDailyVerseNotificationEnabled as jest.Mock;
+const mockRegister = registerDeviceToken as jest.Mock;
+const mockUnregister = unregisterDeviceToken as jest.Mock;
+const mockGetStoredToken = getStoredPushToken as jest.Mock;
+
+const granted = { granted: true, status: 'granted', ios: { status: 2 } };
+const undetermined = {
+  granted: false,
+  status: 'undetermined',
+  ios: { status: 0 },
+};
+const denied = { granted: false, status: 'denied', ios: { status: 1 } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('maybeRegisterOnLogin', () => {
+  it('does nothing when the user has opted out', async () => {
+    mockIsEnabled.mockResolvedValue(false);
+    await maybeRegisterOnLogin();
+    expect(mockGetPerms).not.toHaveBeenCalled();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('registers without prompting when permission is already granted', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+    mockGetPerms.mockResolvedValue(granted);
+    await maybeRegisterOnLogin();
+    expect(mockReqPerms).not.toHaveBeenCalled();
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts once when permission is undetermined, then registers if granted (R-001)', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+    mockGetPerms.mockResolvedValue(undetermined);
+    mockReqPerms.mockResolvedValue(granted);
+    await maybeRegisterOnLogin();
+    expect(mockReqPerms).toHaveBeenCalledTimes(1);
+    expect(mockRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts but does not register when the user declines', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+    mockGetPerms.mockResolvedValue(undetermined);
+    mockReqPerms.mockResolvedValue(denied);
+    await maybeRegisterOnLogin();
+    expect(mockReqPerms).toHaveBeenCalledTimes(1);
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt when permission was previously denied', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+    mockGetPerms.mockResolvedValue(denied);
+    await maybeRegisterOnLogin();
+    expect(mockReqPerms).not.toHaveBeenCalled();
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+});
+
+describe('unregisterPushOnLogout (D-15)', () => {
+  it('unregisters the stored token', async () => {
+    mockGetStoredToken.mockResolvedValue('ExponentPushToken[test]');
+    await unregisterPushOnLogout();
+    expect(mockUnregister).toHaveBeenCalledWith('ExponentPushToken[test]');
+  });
+
+  it('no-ops when there is no stored token', async () => {
+    mockGetStoredToken.mockResolvedValue(null);
+    await unregisterPushOnLogout();
+    expect(mockUnregister).not.toHaveBeenCalled();
+  });
+});

--- a/lib/notifications/push-registration.ts
+++ b/lib/notifications/push-registration.ts
@@ -10,7 +10,7 @@ import { Platform } from 'react-native';
 import { analytics } from '@/lib/analytics';
 import { AnalyticsEvent } from '@/lib/analytics/types';
 import {
-  getNotificationPermissionGranted,
+  isGranted,
   requestNotificationPermission,
 } from './notification-permission';
 import { registerDeviceToken, unregisterDeviceToken } from './push-api';
@@ -57,15 +57,32 @@ export async function acquireAndRegisterPushToken(): Promise<string | null> {
 }
 
 /**
- * On login/app-entry: register only if the user is opted-in (D-5) AND OS
- * permission is already granted. Never prompts here — the prompt belongs to
- * onboarding / the Settings toggle.
+ * On login/app-entry, for an opted-in user (D-5):
+ *  - permission already granted → register;
+ *  - never asked (UNDETERMINED) → prompt once (spec: "request once after
+ *    login/onboarding, not a cold-launch nag"), then register if granted;
+ *  - previously denied → do nothing (respect the choice; re-enabling goes
+ *    through Settings, which deep-links to OS settings).
+ * Without this, the default-ON opt-in would never activate for users who
+ * never open Settings (R-001).
  */
 export async function maybeRegisterOnLogin(): Promise<void> {
   if (Platform.OS === 'web') return;
   if (!(await isDailyVerseNotificationEnabled())) return;
-  if (!(await getNotificationPermissionGranted())) return;
-  await acquireAndRegisterPushToken();
+
+  const perms = await Notifications.getPermissionsAsync();
+  if (isGranted(perms)) {
+    await acquireAndRegisterPushToken();
+    return;
+  }
+  if (perms.status === Notifications.PermissionStatus.UNDETERMINED) {
+    const granted = await requestNotificationPermission();
+    if (granted) {
+      await acquireAndRegisterPushToken();
+    } else {
+      analytics.track(AnalyticsEvent.NOTIFICATION_PERMISSION_DENIED, {});
+    }
+  }
 }
 
 /** Settings toggle ON: prompt if needed, register, persist. Returns whether granted. */

--- a/lib/notifications/push-registration.ts
+++ b/lib/notifications/push-registration.ts
@@ -1,0 +1,105 @@
+/**
+ * Imperative push-token registration lifecycle (GH-281).
+ *
+ * Separated from the hook so Settings + AuthContext can drive register/unregister
+ * without importing a React hook. All backend calls are best-effort.
+ */
+import Constants from 'expo-constants';
+import * as Notifications from 'expo-notifications';
+import { Platform } from 'react-native';
+import { analytics } from '@/lib/analytics';
+import { AnalyticsEvent } from '@/lib/analytics/types';
+import {
+  getNotificationPermissionGranted,
+  requestNotificationPermission,
+} from './notification-permission';
+import { registerDeviceToken, unregisterDeviceToken } from './push-api';
+import {
+  clearStoredPushToken,
+  getStoredPushToken,
+  isDailyVerseNotificationEnabled,
+  setDailyVerseNotificationEnabled,
+  setStoredPushToken,
+} from './push-token-storage';
+
+function getProjectId(): string | undefined {
+  return (
+    Constants.expoConfig?.extra?.eas?.projectId ??
+    Constants.easConfig?.projectId ??
+    undefined
+  );
+}
+
+function currentPlatform(): 'ios' | 'android' {
+  return Platform.OS === 'ios' ? 'ios' : 'android';
+}
+
+/**
+ * Acquire the Expo push token, register it with the backend, and persist it
+ * (so logout can unregister it). Returns the token, or null on any failure /
+ * unsupported platform.
+ */
+export async function acquireAndRegisterPushToken(): Promise<string | null> {
+  if (Platform.OS === 'web') return null;
+  try {
+    const projectId = getProjectId();
+    const { data: token } = await Notifications.getExpoPushTokenAsync(
+      projectId ? { projectId } : undefined,
+    );
+    if (!token) return null;
+    await setStoredPushToken(token);
+    await registerDeviceToken(token, currentPlatform());
+    return token;
+  } catch (error) {
+    console.warn('[notifications] token registration failed:', error);
+    return null;
+  }
+}
+
+/**
+ * On login/app-entry: register only if the user is opted-in (D-5) AND OS
+ * permission is already granted. Never prompts here — the prompt belongs to
+ * onboarding / the Settings toggle.
+ */
+export async function maybeRegisterOnLogin(): Promise<void> {
+  if (Platform.OS === 'web') return;
+  if (!(await isDailyVerseNotificationEnabled())) return;
+  if (!(await getNotificationPermissionGranted())) return;
+  await acquireAndRegisterPushToken();
+}
+
+/** Settings toggle ON: prompt if needed, register, persist. Returns whether granted. */
+export async function enableDailyVerseNotifications(): Promise<boolean> {
+  const granted = await requestNotificationPermission();
+  if (!granted) {
+    analytics.track(AnalyticsEvent.NOTIFICATION_PERMISSION_DENIED, {});
+    return false;
+  }
+  await setDailyVerseNotificationEnabled(true);
+  await acquireAndRegisterPushToken();
+  analytics.track(AnalyticsEvent.NOTIFICATION_ENABLED, {});
+  return true;
+}
+
+/** Settings toggle OFF: unregister the token + persist the opt-out. */
+export async function disableDailyVerseNotifications(): Promise<void> {
+  await setDailyVerseNotificationEnabled(false);
+  const token = await getStoredPushToken();
+  if (token) {
+    await unregisterDeviceToken(token);
+    await clearStoredPushToken();
+  }
+  analytics.track(AnalyticsEvent.NOTIFICATION_DISABLED, {});
+}
+
+/**
+ * Logout: unregister the stored token while the session (access token) is still
+ * valid. Must be called BEFORE the auth tokens are cleared (D-15).
+ */
+export async function unregisterPushOnLogout(): Promise<void> {
+  const token = await getStoredPushToken();
+  if (token) {
+    await unregisterDeviceToken(token);
+    await clearStoredPushToken();
+  }
+}

--- a/lib/notifications/push-token-storage.ts
+++ b/lib/notifications/push-token-storage.ts
@@ -1,0 +1,38 @@
+/**
+ * Persisted Expo push token + the daily-verse opt-in flag (GH-281).
+ *
+ * The token is stored so logout can unregister it from the backend *before*
+ * the access token is cleared. The opt-in flag drives the Settings toggle and
+ * gates registration on login (D-5: on once OS permission is granted).
+ */
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const PUSH_TOKEN_KEY = 'versemate_push_token';
+const DAILY_VERSE_ENABLED_KEY = 'versemate_daily_verse_notification_enabled';
+
+export async function getStoredPushToken(): Promise<string | null> {
+  return AsyncStorage.getItem(PUSH_TOKEN_KEY);
+}
+
+export async function setStoredPushToken(token: string): Promise<void> {
+  await AsyncStorage.setItem(PUSH_TOKEN_KEY, token);
+}
+
+export async function clearStoredPushToken(): Promise<void> {
+  await AsyncStorage.removeItem(PUSH_TOKEN_KEY);
+}
+
+/**
+ * Daily-verse opt-in. Defaults to enabled (D-5) — absence of the key means the
+ * user hasn't opted out, so once permission is granted they receive the verse.
+ */
+export async function isDailyVerseNotificationEnabled(): Promise<boolean> {
+  const value = await AsyncStorage.getItem(DAILY_VERSE_ENABLED_KEY);
+  return value === null ? true : value === 'true';
+}
+
+export async function setDailyVerseNotificationEnabled(
+  enabled: boolean,
+): Promise<void> {
+  await AsyncStorage.setItem(DAILY_VERSE_ENABLED_KEY, String(enabled));
+}

--- a/lib/notifications/push-token-storage.ts
+++ b/lib/notifications/push-token-storage.ts
@@ -7,8 +7,12 @@
  */
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-const PUSH_TOKEN_KEY = 'versemate_push_token';
-const DAILY_VERSE_ENABLED_KEY = 'versemate_daily_verse_notification_enabled';
+const PUSH_TOKEN_KEY = '@versemate:push_token';
+const DAILY_VERSE_ENABLED_KEY = '@versemate:daily_verse_notification_enabled';
+
+// Module-level cache so the Settings toggle can seed its initial value
+// synchronously and avoid the OFF→ON flash an async-only read would cause.
+let enabledCache: boolean | null = null;
 
 export async function getStoredPushToken(): Promise<string | null> {
   return AsyncStorage.getItem(PUSH_TOKEN_KEY);
@@ -23,16 +27,26 @@ export async function clearStoredPushToken(): Promise<void> {
 }
 
 /**
+ * Synchronous best-effort read of the opt-in, for initial render. Returns the
+ * last known value, or the default (enabled, D-5) before the first async read.
+ */
+export function getDailyVerseNotificationEnabledCached(): boolean {
+  return enabledCache ?? true;
+}
+
+/**
  * Daily-verse opt-in. Defaults to enabled (D-5) — absence of the key means the
- * user hasn't opted out, so once permission is granted they receive the verse.
+ * user hasn't opted out. Populates the module cache for synchronous reads.
  */
 export async function isDailyVerseNotificationEnabled(): Promise<boolean> {
   const value = await AsyncStorage.getItem(DAILY_VERSE_ENABLED_KEY);
-  return value === null ? true : value === 'true';
+  enabledCache = value === null ? true : value === 'true';
+  return enabledCache;
 }
 
 export async function setDailyVerseNotificationEnabled(
   enabled: boolean,
 ): Promise<void> {
+  enabledCache = enabled;
   await AsyncStorage.setItem(DAILY_VERSE_ENABLED_KEY, String(enabled));
 }

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "expo-localization": "~17.0.8",
     "expo-location": "~19.0.8",
     "expo-navigation-bar": "~5.0.10",
+    "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.17",
     "expo-screen-orientation": "~9.0.9",
     "expo-secure-store": "^55.0.13",
@@ -152,7 +153,7 @@
   "bun": {
     "test": {
       "preload": "./test-setup.ts",
-      "timeout": 10000
+      "timeout": 1e4
     }
   },
   "private": true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "verse-mate-mobile",
   "main": "index.js",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "scripts": {
     "start": "expo start",
     "reset-project": "node ./scripts/reset-project.js",
@@ -153,7 +153,7 @@
   "bun": {
     "test": {
       "preload": "./test-setup.ts",
-      "timeout": 1e4
+      "timeout": 10000
     }
   },
   "private": true


### PR DESCRIPTION
## Summary
Mobile layer for verse-of-the-day push notifications (GH-281). Adds `expo-notifications` and wires permission → token registration → daily push → tap-to-verse, mirroring the existing widget deep-link flow.

- **Config** — `expo-notifications` plugin (adds iOS `aps-environment` + Android wiring at prebuild); Android `POST_NOTIFICATIONS` + `googleServicesFile` (FCM V1).
- **`lib/notifications/`** — `notification-routing` (pure deep-link → reader route with `src=notification`, **unit-tested**), `push-api` (register/unregister device + `preferred-bible-version` sync via `authenticatedFetch`), `notification-permission`, `push-token-storage` (token + opt-in flag), `push-registration` (acquire/register, enable/disable, logout unregister).
- **`use-push-notifications`** — foreground handler, login registration, and tap routing incl. **cold-start** via `useLastNotificationResponse`; mounted in `RootLayoutInner`.
- **Lifecycle** — `AuthContext.logout` unregisters the token before clearing the session (D-15); `setBibleVersion` syncs `preferred_bible_version` to the backend so the daily push renders in the user's version.
- **Settings** — "Daily verse notification" toggle (permission + register/unregister).
- **Analytics** — `NOTIFICATION_TAPPED` / `_ENABLED` / `_DISABLED` / `_PERMISSION_DENIED`.

## Testing
- `tsc --noEmit` clean; `notification-routing` unit tests pass; Biome/eslint clean.
- ⚠️ On-device verification pending — requires the FCM (Android) + APNs (iOS) EAS credentials and a Development Build (SDK 54+ push doesn't work in Expo Go). `google-services.json` must be added (gitignored).

## Depends on
Backend endpoints in **verse-mate#283** (`/notifications/device`, `/admin/notifications/broadcast`, `/user/preferred-bible-version`). Uses `authenticatedFetch` (raw) until the OpenAPI client is regenerated post-merge.

Spec: `devspace/specs/2026-07-20-1110-verse-of-the-day-push-notifications/`