### PR TITLE
fix(bible): highlighted verses no longer run two words together

### DIFF
--- a/__tests__/components/bible/HighlightedText.test.tsx
+++ b/__tests__/components/bible/HighlightedText.test.tsx
@@ -77,6 +77,74 @@ describe('HighlightedText', () => {
     expect(getByText('In the beginning God created the heavens and the earth.')).toBeTruthy();
   });
 
+  describe('whitespace preservation around highlight boundaries', () => {
+    const text = 'In the beginning God created the heavens and the earth.';
+
+    it('keeps the space after a highlight that ends on a word boundary', () => {
+      // Regression: tokenizeText matches /(\S+)(\s*)/g, capturing TRAILING
+      // whitespace only. A segment beginning with whitespace lost it on
+      // reassembly. Highlighting "beginning God" ends at char 20 — the space
+      // before "created" — so the verse rendered "Godcreated".
+      const { root } = render(
+        <HighlightedText
+          text={text}
+          verseNumber={1}
+          highlights={[{ ...mockHighlight, start_char: 7, end_char: 20 }]}
+          isVisible
+        />
+      );
+
+      expect(extractText(root.props.children)).toBe(text);
+    });
+
+    it('keeps whitespace for a highlight starting on a word boundary', () => {
+      // The mirror case: the highlighted segment itself starts with the space.
+      const { root } = render(
+        <HighlightedText
+          text={text}
+          verseNumber={1}
+          highlights={[{ ...mockHighlight, start_char: 16, end_char: 29 }]}
+          isVisible
+        />
+      );
+
+      expect(extractText(root.props.children)).toBe(text);
+    });
+
+    it('keeps whitespace across two highlights in one verse', () => {
+      const { root } = render(
+        <HighlightedText
+          text={text}
+          verseNumber={1}
+          highlights={[
+            { ...mockHighlight, highlight_id: 1, start_char: 7, end_char: 20 },
+            { ...mockHighlight, highlight_id: 2, start_char: 28, end_char: 40, color: 'green' },
+          ]}
+          isVisible
+        />
+      );
+
+      expect(extractText(root.props.children)).toBe(text);
+    });
+
+    it('keeps whitespace when the verse is not tokenized', () => {
+      // `isVisible` DEFAULTS TO TRUE, so omitting it does not reach this path —
+      // it has to be passed explicitly. The non-tokenized branch renders
+      // `segment.text` whole and was always correct; asserted so a future
+      // refactor cannot regress it silently.
+      const { root } = render(
+        <HighlightedText
+          text={text}
+          verseNumber={1}
+          highlights={[{ ...mockHighlight, start_char: 7, end_char: 20 }]}
+          isVisible={false}
+        />
+      );
+
+      expect(extractText(root.props.children)).toBe(text);
+    });
+  });
+
   it('should have selectable={true} on root Text for native text selection', () => {
     const { root } = render(
       <HighlightedText

--- a/components/bible/HighlightedText.tsx
+++ b/components/bible/HighlightedText.tsx
@@ -935,6 +935,26 @@ export function HighlightedText({
     };
 
     const elements: ReactNode[] = [];
+
+    // Re-emit any whitespace at the START of the segment.
+    //
+    // `tokenizeText` matches /(\S+)(\s*)/g, which captures each word plus its
+    // TRAILING whitespace — leading whitespace is matched by nothing and so was
+    // silently dropped when the tokens were reassembled.
+    //
+    // A segment only begins with whitespace when a highlight boundary lands
+    // there, and that is the NORMAL case: selecting whole words puts `end_char`
+    // immediately before a space. The visible result was two words running
+    // together — highlight "beginning God" in Genesis 1:1 and the verse rendered
+    // "Godcreated".
+    //
+    // Only affects the tokenized path (`isVisible`), i.e. verses actually on
+    // screen. The non-tokenized path renders `segment.text` whole and was always
+    // correct, which is why this survived: it is invisible until you highlight.
+    if (tokens.length > 0 && tokens[0].startChar > 0) {
+      elements.push(segment.text.slice(0, tokens[0].startChar));
+    }
+
     let idx = 0;
     while (idx < tokens.length) {
       const token = tokens[idx];


### PR DESCRIPTION
## Description

Highlight the words "beginning God" in Genesis 1:1 and the verse renders **"Godcreated"** — the space between "God" and "created" disappears.

`tokenizeText` matches `/(\S+)(\s*)/g`, which captures each word plus its **trailing** whitespace. Leading whitespace is matched by nothing, so when the tokens are reassembled a segment that *begins* with whitespace loses it:

```
verse:    "In the beginning God created the heavens and the earth."
highlight: start_char 7, end_char 20  ->  "beginning God"

segments: ["In the ", "beginning God", " created the heavens and the earth."]
                                        ^ this leading space is dropped
```

A segment only begins with whitespace when a highlight boundary lands there — and that is the **normal** case, because selecting whole words puts `end_char` immediately before a space. So it reproduces with any ordinary word-aligned highlight, in any verse.

Only the tokenized path is affected (`isVisible`, i.e. verses actually on screen). The non-tokenized branch renders `segment.text` whole and was always correct, which is why this survived unnoticed: the text is fine until you highlight it.

Found by a compiler/renderer differential harness being built on the native-text-rendering branch. Split out here because it is a live user-visible bug and shouldn't wait for that project to land.

## Testing Steps

**Verified by unit test (4 cases):**
- highlight ending on a word boundary (the reported case)
- highlight *starting* on a word boundary (the mirror case)
- two highlights in one verse
- the non-tokenized path, to pin that it stays correct

Each of the first three was confirmed to **fail without the fix** and pass with it, so none is vacuous. The fourth passes either way, which is the assertion that the non-tokenized path was never broken.

`npx jest __tests__/components/bible __tests__/lib` — 364 passed.

**On-device (not yet run):** open any chapter, highlight two or more whole words mid-verse, and confirm the text after the highlight still has its leading space. Worth a look on both light and dark themes since the highlight background makes the join more obvious.

## AI Contribution

- **Tool used:** Claude Code (Opus 5)
- **What was AI-generated:** the diagnosis, the one-line fix, and the four regression tests.
- **What was human-directed:** the operator asked for a native text-rendering project; this bug surfaced as a side effect of building a differential test harness for it, and splitting it into its own PR was a judgement call made to get the user-facing fix out early.
- **How it was verified:** the failure was reproduced from first principles against the tokenizer regex before any fix was written, then each regression test was run with the fix reverted to confirm it actually catches the bug.
- **Residual risk:** low. The change adds a string to the element list when a segment starts with whitespace and is otherwise inert — no behaviour change for segments that don't. Not yet exercised on a device.
