### PR TITLE
GH-265: rebuild the Verse-of-the-Day widget to the design doc

### DIFF
--- a/__tests__/widgets/verse-of-the-day-widget.test.tsx
+++ b/__tests__/widgets/verse-of-the-day-widget.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * Android Verse-of-the-Day widget tree tests (GH-265).
+ *
+ * Renders the component through the library's own `buildWidgetTree` — the same
+ * renderer the headless widget task uses, and the one that blew up with
+ * `useMemoCache of null` when React Compiler instrumented this component. It
+ * also runs the library's `validateWidgetTree`, so an unsupported style prop or
+ * an illegal nesting fails here instead of on a home screen.
+ *
+ * Deep import: buildWidgetTree is not re-exported from the package index, and
+ * the index pulls in native-only modules that cannot load under jest.
+ */
+import { buildWidgetTree } from 'react-native-android-widget/src/api/build-widget-tree';
+import { VerseOfTheDayWidget } from '@/widgets/VerseOfTheDayWidget';
+
+const VERSES = [
+  { verseNumber: 14, text: 'I am fearfully and wonderfully made; wonderful are Your works.' },
+];
+
+const BASE = {
+  verses: VERSES,
+  reference: 'Psalm 139:14',
+  deepLink: 'versemate:///bible/19/139?verseStart=14&src=widget',
+  noteDeepLink: 'versemate:///bible/19/139?verseStart=14&src=widget&tab=summary',
+  fallbackText: "Open VerseMate to see today's verse",
+  versionLabel: 'NASB1995',
+} as const;
+
+/** Collect every node of a built tree, depth-first. */
+function flatten(tree: ReturnType<typeof buildWidgetTree>): ReturnType<typeof buildWidgetTree>[] {
+  return [tree, ...(tree.children ?? []).flatMap(flatten)];
+}
+
+function texts(tree: ReturnType<typeof buildWidgetTree>): string[] {
+  return flatten(tree)
+    .filter((n) => n.type === 'TextWidget')
+    .map((n) => (n.props as { text: string }).text);
+}
+
+function clickUrls(tree: ReturnType<typeof buildWidgetTree>): string[] {
+  return flatten(tree)
+    .map((n) => (n.props as { clickActionData?: { url?: string } }).clickActionData?.url)
+    .filter((url): url is string => typeof url === 'string');
+}
+
+describe('VerseOfTheDayWidget', () => {
+  // Every composition must survive the real renderer + validator.
+  it.each([
+    ['compact', 'light'],
+    ['compact', 'dark'],
+    ['expanded', 'light'],
+    ['expanded', 'dark'],
+  ] as const)('builds a valid %s / %s tree', (size, theme) => {
+    expect(() =>
+      buildWidgetTree(
+        <VerseOfTheDayWidget
+          {...BASE}
+          size={size}
+          theme={theme}
+          explanation="David pictures God weaving him together in the womb."
+        />
+      )
+    ).not.toThrow();
+  });
+
+  it('clamps the compact verse to 3 lines and pins the reference row', () => {
+    const tree = buildWidgetTree(<VerseOfTheDayWidget {...BASE} size="compact" theme="dark" />);
+
+    const verse = flatten(tree).find(
+      (n) => n.type === 'TextWidget' && (n.props as { maxLines?: number }).maxLines === 3
+    );
+    expect(verse).toBeDefined();
+    expect(texts(tree)).toEqual(expect.arrayContaining(['Psalm 139:14', '✦ VerseMate']));
+    // Design: progressive disclosure — no note copy at this size.
+    expect(texts(tree)).not.toContain('WHY IT MATTERS');
+  });
+
+  it('renders the note panel and its own tap zone when an explanation exists', () => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget
+        {...BASE}
+        size="expanded"
+        theme="dark"
+        explanation="David pictures God weaving him together in the womb."
+      />
+    );
+
+    expect(texts(tree)).toEqual(
+      expect.arrayContaining([
+        'VERSE OF THE DAY',
+        'NASB1995',
+        'WHY IT MATTERS',
+        'Read the full note →',
+      ])
+    );
+    // Two tap zones: the verse block → chapter, the note block → summary tab.
+    expect(clickUrls(tree)).toEqual(expect.arrayContaining([BASE.deepLink, BASE.noteDeepLink]));
+  });
+
+  it('falls back to a verse-only expanded layout when no explanation is served', () => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget {...BASE} size="expanded" theme="dark" explanation={null} />
+    );
+
+    // No empty panel, and the verse takes the freed rows.
+    expect(texts(tree)).not.toContain('WHY IT MATTERS');
+    expect(texts(tree)).not.toContain('Read the full note →');
+    const verse = flatten(tree).find(
+      (n) => n.type === 'TextWidget' && (n.props as { maxLines?: number }).maxLines === 9
+    );
+    expect(verse).toBeDefined();
+  });
+
+  it('shows the fallback message with no reference when the pool is empty', () => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget {...BASE} verses={null} reference="" size="compact" theme="light" />
+    );
+
+    expect(texts(tree)).toContain("Open VerseMate to see today's verse");
+    expect(texts(tree)).not.toContain('Psalm 139:14');
+  });
+});

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -13,6 +13,13 @@
 
 // Pin web/api hosts BEFORE importing the handler — both read process.env at
 // module load time.
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  buildWidgetVerseRoute,
+  parseChapterShareUrl,
+} from '@/utils/sharing/generate-chapter-share-url';
+import { buildDeepLink, fetchVerse, pickWidgetSize } from '@/widgets/widget-task-handler';
+
 process.env.EXPO_PUBLIC_WEB_URL = 'https://app.versemate.org';
 process.env.EXPO_PUBLIC_API_URL = 'https://api.versemate.org';
 
@@ -22,10 +29,6 @@ jest.mock('react-native-android-widget', () => ({
   FlexWidget: 'FlexWidget',
   TextWidget: 'TextWidget',
 }));
-
-import AsyncStorage from '@react-native-async-storage/async-storage';
-import { parseChapterShareUrl } from '@/utils/sharing/generate-chapter-share-url';
-import { buildDeepLink, fetchVerse } from '@/widgets/widget-task-handler';
 
 const originalFetch = global.fetch;
 
@@ -73,6 +76,60 @@ describe('widget-task-handler', () => {
       const parsed = parseChapterShareUrl(url);
       expect(parsed).toEqual({ bookId: 1, chapterNumber: 1 });
     });
+
+    // The expanded widget's "Why it matters" block is a second tap zone that must
+    // land on the reader's summary tab — the full chain the tap travels:
+    // buildDeepLink → parseChapterShareUrl → buildWidgetVerseRoute.
+    it('carries the note zone tab through to the reader route', () => {
+      const ref = { bookId: 19, chapterNumber: 139, verseStart: 14, verseEnd: null };
+      const url = buildDeepLink(ref, 'summary');
+
+      expect(url).toContain('src=widget');
+      expect(url).toContain('tab=summary');
+
+      const parsed = parseChapterShareUrl(url);
+      expect(parsed).toEqual({
+        bookId: 19,
+        chapterNumber: 139,
+        verseStart: 14,
+        tab: 'summary',
+      });
+
+      const route = buildWidgetVerseRoute(
+        // biome-ignore lint/style/noNonNullAssertion: asserted non-null above
+        parsed!.bookId,
+        // biome-ignore lint/style/noNonNullAssertion: asserted non-null above
+        parsed!.chapterNumber,
+        14,
+        undefined,
+        true,
+        parsed?.tab
+      );
+      expect(route).toBe('/bible/19/139?verse=14&src=widget&tab=summary');
+    });
+
+    it('drops an unknown tab rather than forwarding it', () => {
+      const ref = { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null };
+      const parsed = parseChapterShareUrl(buildDeepLink(ref, 'not-a-tab'));
+      expect(parsed).toEqual({ bookId: 43, chapterNumber: 3, verseStart: 16 });
+    });
+  });
+
+  // The design's two Android compositions ship as two providers, because the
+  // widget's own height is not discoverable (portrait reports the provider's max
+  // resize bound: a 4×2 and a 4×4 both read 358dp on the Pixel launcher).
+  describe('pickWidgetSize', () => {
+    it('selects the composition from the provider name, not a size', () => {
+      expect(pickWidgetSize('VerseOfTheDay')).toBe('compact');
+      expect(pickWidgetSize('VerseOfTheDayNote')).toBe('expanded');
+    });
+
+    it('falls back to compact for an unknown provider', () => {
+      // A stale widget from an older install must never paint a clipped note
+      // panel; verse-only is the safe composition at any size.
+      expect(pickWidgetSize('SomethingElse')).toBe('compact');
+      expect(pickWidgetSize('')).toBe('compact');
+    });
   });
 
   describe('fetchVerse', () => {
@@ -101,6 +158,33 @@ describe('widget-task-handler', () => {
         chapterNumber: 3,
         verseStart: 16,
       });
+    });
+
+    // The expanded composition's note panel is data-gated: it only paints when
+    // the API serves a summary, which it does not do yet.
+    it('plumbs the version label and an explanation when present, null when not', async () => {
+      const base = {
+        empty: false,
+        referenceText: 'Psalm 139:14',
+        verses: [{ verseNumber: 14, text: 'I am fearfully and wonderfully made' }],
+        reference: { bookId: 19, chapterNumber: 139, verseStart: 14, verseEnd: null },
+        versionKey: 'NASB1995',
+      };
+
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({ ...base, explanation: 'David pictures God weaving him together.' }),
+      }) as unknown as typeof fetch;
+      const withNote = await fetchVerse();
+      expect(withNote.versionLabel).toBe('NASB1995');
+      expect(withNote.explanation).toBe('David pictures God weaving him together.');
+      expect(withNote.noteDeepLink).toContain('tab=summary');
+
+      // Today's payload: no explanation field at all.
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => base,
+      }) as unknown as typeof fetch;
+      const withoutNote = await fetchVerse();
+      expect(withoutNote.explanation).toBeNull();
     });
 
     it('sends pid when a user id is stored, omits it otherwise (PD-7)', async () => {

--- a/app.config.js
+++ b/app.config.js
@@ -210,6 +210,17 @@ const config = {
     [
       'react-native-android-widget',
       {
+        // The design (panel 2B) draws two Android compositions: 4×2 verse-only
+        // and 4×4 verse + "Why it matters". They ship as two providers rather
+        // than one resizable widget because the widget's own size is NOT
+        // discoverable at render time: in portrait the library reports
+        // OPTION_APPWIDGET_MAX_HEIGHT, which is the provider's max resize bound,
+        // not the current height — a 4×2 and a 4×4 both report 358dp on the
+        // Pixel launcher (verified on an API 35 emulator). The widget *name* is
+        // reliable, so the task handler keys the composition off that instead.
+        // Vertical resize is disabled so each provider keeps the height its
+        // composition was drawn for (the design requires text to clamp, never
+        // overflow).
         widgets: [
           {
             name: 'VerseOfTheDay',
@@ -219,8 +230,19 @@ const config = {
             minHeight: '110dp',
             targetCellWidth: 4,
             targetCellHeight: 2,
-            resizeMode: 'horizontal|vertical',
+            resizeMode: 'horizontal',
             updatePeriodMillis: 86400000, // ~daily; OS-throttled periodic refresh
+          },
+          {
+            name: 'VerseOfTheDayNote',
+            label: 'Verse of the Day (with note)',
+            description: "Today's verse plus why it matters",
+            minWidth: '180dp',
+            minHeight: '250dp',
+            targetCellWidth: 4,
+            targetCellHeight: 4,
+            resizeMode: 'horizontal',
+            updatePeriodMillis: 86400000,
           },
         ],
       },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -265,7 +265,7 @@ function RootLayoutInner() {
           return;
         }
 
-        const { bookId, chapterNumber, verseStart, verseEnd } = chapterParsed;
+        const { bookId, chapterNumber, verseStart, verseEnd, tab } = chapterParsed;
 
         // Validate bookId (parser already validates 1-66 range)
         if (bookId < 1 || bookId > 66) {
@@ -284,7 +284,9 @@ function RootLayoutInner() {
 
         // Verse-of-the-day widget deep link carries ?verseStart (and ?src=widget).
         // Forward to the reader's existing `verse`/`endVerse` params (scroll +
-        // highlight) and emit the re-entry analytics event.
+        // highlight) and emit the re-entry analytics event. `tab` is forwarded
+        // too — the widget's "Why it matters" zone sends ?tab=summary so the
+        // reader opens straight on that insight.
         const isWidget = url.includes('src=widget');
         if (verseStart) {
           if (isWidget) {
@@ -297,13 +299,15 @@ function RootLayoutInner() {
             });
           }
           router.replace(
-            buildWidgetVerseRoute(bookId, chapterNumber, verseStart, verseEnd, isWidget)
+            buildWidgetVerseRoute(bookId, chapterNumber, verseStart, verseEnd, isWidget, tab)
           );
           return;
         }
 
-        // Navigate to the chapter
-        router.replace(`/bible/${bookId}/${chapterNumber}`);
+        // Navigate to the chapter (preserving a deep-linked insight tab)
+        router.replace(
+          tab ? `/bible/${bookId}/${chapterNumber}?tab=${tab}` : `/bible/${bookId}/${chapterNumber}`
+        );
       } catch (error) {
         // TODO: Track analytics - deep_link_failed with { url, error: error.message }
         console.error('Error handling deep link:', error);

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -1,7 +1,14 @@
 // Verse-of-the-Day iOS widget (GH-265).
 //
-// Authored without a local Apple toolchain — NOT compiled/run/device-tested.
-// Verify with `expo prebuild -p ios` + Xcode before release.
+// Verified on an iPhone 17 Pro simulator (iOS 26.5): all three families render
+// and were checked in light and dark appearance. Type-checks against the iOS
+// SDK with `xcrun -sdk iphoneos swiftc -typecheck -parse-as-library -target
+// arm64-apple-ios15.1 targets/widget/index.swift`.
+//
+// NOTE: a clean `expo prebuild -p ios` + simulator build currently fails in the
+// PostHog pod (`underlying Objective-C module 'PostHog' not found`, built from
+// its .swiftinterface). Pass BUILD_LIBRARY_FOR_DISTRIBUTION=NO to xcodebuild to
+// get through it — unrelated to this widget.
 //
 // Behavior:
 //  - Reads the user's preferred Bible version from the shared App Group
@@ -11,6 +18,24 @@
 //  - Tapping deep-links to the Universal Link form with the verse range so
 //    the app scrolls to the verse and emits WIDGET_TAPPED.
 //  - On error, shows the last cached entry (App Group) or a branded fallback.
+//
+// Layout follows the "Verse of the Day — home-screen widget" design doc
+// (turn 2, panel 2A — iOS): progressive disclosure by size, so each family
+// shows only what fits.
+//   - systemSmall  (170×170): reference first, verse clamped to 5 lines, no note.
+//   - systemMedium (364×170): gold rail, eyebrow + version, verse clamped to 3.
+//   - systemLarge  (364×382): verse zone + a "Why it matters" zone, each its own
+//     tap target (verse → the chapter, note → the reader's summary tab).
+// Type is clamped, never scaled (design rule: "clamp lines, never shrink the
+// type"), so every day's verse occupies the same slots.
+//
+// Two deliberate deviations from the design doc, both noted there as open:
+//  - Typeface: the design calls for bundled Literata. Nothing is bundled in this
+//    repo, so this uses the system serif (New York) via `design: .serif` — the
+//    same reasoning the design applies to Android's `fontFamily="serif"`.
+//    Bundling Literata is an asset + Info.plist (UIAppFonts) change.
+//  - The note zone needs a short summary the API does not serve yet; when it is
+//    absent, systemLarge falls back to a verse-only composition.
 
 import WidgetKit
 import SwiftUI
@@ -44,6 +69,11 @@ struct VerseOfTheDay: Codable {
   let date: String?
   let reference: Reference?
   let fallbackMessage: String?
+  let versionKey: String?
+  /// Short "why it matters" summary for systemLarge (design: ≤220 chars).
+  /// NOT served by /bible/verse-of-the-day yet — decoded optionally so the note
+  /// zone lights up the day the API starts returning it.
+  let explanation: String?
 
   struct Verse: Codable {
     let verseNumber: Int
@@ -118,10 +148,15 @@ private func fetchVerseOfTheDay(completion: @escaping (VerseOfTheDay?) -> Void) 
   task.resume()
 }
 
-private func deepLinkURL(_ ref: VerseOfTheDay.Reference) -> URL? {
+/// Insight tab the note zone opens — the reader's short overview, the in-app
+/// counterpart of the widget's "Why it matters" panel.
+private let noteTab = "summary"
+
+private func deepLinkURL(_ ref: VerseOfTheDay.Reference, tab: String? = nil) -> URL? {
   var s = "\(webBaseURL)/bible/\(ref.bookId)/\(ref.chapterNumber)?verseStart=\(ref.verseStart)"
   if let end = ref.verseEnd { s += "&verseEnd=\(end)" }
   s += "&src=widget"
+  if let tab = tab { s += "&tab=\(tab)" }
   return URL(string: s)
 }
 
@@ -158,40 +193,352 @@ struct Provider: TimelineProvider {
 
 // MARK: - View
 
+/// Design 2A palette. Dark values are the design's verbatim; light is the same
+/// structure resolved against the app's light tokens — gold drops to #b09a6d
+/// there, the only gold that clears WCAG AA on white.
+private struct Palette {
+  let surface: Color
+  let verseText: Color
+  let gold: Color
+  let eyebrow: Color
+  let version: Color
+  let wordmark: Color
+  let explanation: Color
+  let hairline: Color
+  let footerHairline: Color
+  let largeHeaderTop: Color
+  let largeHeaderBottom: Color
+  let largeEyebrow: Color
+
+  static let dark = Palette(
+    surface: Color(hex: 0x16_16_18),
+    verseText: Color(hex: 0xF4_F2_EE),
+    gold: Color(hex: 0xD8_A8_5F),
+    eyebrow: Color(hex: 0x8A_8A_93),
+    version: Color(hex: 0x6E_6E_77),
+    wordmark: Color(hex: 0x7D_7D_86),
+    explanation: Color(hex: 0xC1_BF_B9),
+    hairline: Color(hex: 0x26_26_2A),
+    footerHairline: Color(hex: 0x21_21_25),
+    largeHeaderTop: Color(hex: 0x1D_1C_1A),
+    largeHeaderBottom: Color(hex: 0x16_16_18),
+    largeEyebrow: Color(hex: 0x9C_7F_4E)
+  )
+
+  static let light = Palette(
+    surface: Color(hex: 0xFF_FF_FF),
+    verseText: Color(hex: 0x1A_1A_1A),
+    gold: Color(hex: 0xB0_9A_6D),
+    eyebrow: Color(hex: 0x6E_6E_77),
+    version: Color(hex: 0x8A_8A_8A),
+    wordmark: Color(hex: 0x9B_9B_9B),
+    explanation: Color(hex: 0x4A_4A_4A),
+    hairline: Color(hex: 0xE8_E4_DC),
+    footerHairline: Color(hex: 0xEE_EA_E2),
+    largeHeaderTop: Color(hex: 0xFA_F8_F4),
+    largeHeaderBottom: Color(hex: 0xFF_FF_FF),
+    largeEyebrow: Color(hex: 0x8A_73_45)
+  )
+}
+
+extension Color {
+  /// 0xRRGGBB literal → Color, so the design's hex values stay readable.
+  init(hex: UInt32) {
+    self.init(
+      .sRGB,
+      red: Double((hex >> 16) & 0xFF) / 255,
+      green: Double((hex >> 8) & 0xFF) / 255,
+      blue: Double(hex & 0xFF) / 255,
+      opacity: 1
+    )
+  }
+}
+
+extension View {
+  /// Paint the widget surface. From iOS 17 WidgetKit requires the background to
+  /// come from `containerBackground` (it also draws edge-to-edge, which the
+  /// design's full-bleed large header needs); earlier versions take a plain
+  /// background. @ViewBuilder keeps the two branch types legal.
+  @ViewBuilder
+  func widgetSurface(_ color: Color) -> some View {
+    if #available(iOS 17.0, *) {
+      self.containerBackground(color, for: .widget)
+    } else {
+      self.background(color)
+    }
+  }
+}
+
+/// Serif body face — see the header note on Literata.
+private func serif(_ size: CGFloat, _ weight: Font.Weight = .regular) -> Font {
+  .system(size: size, weight: weight, design: .serif)
+}
+
+/// Uppercase eyebrow label ("VERSE OF THE DAY" / "WHY IT MATTERS").
+private struct Eyebrow: View {
+  let text: String
+  let color: Color
+
+  var body: some View {
+    Text(text)
+      .font(.system(size: 9, weight: .bold))
+      .tracking(1.26)  // design: .14em at 9pt
+      .foregroundColor(color)
+      .lineLimit(1)
+  }
+}
+
+/// "✦ VerseMate" wordmark.
+private struct Wordmark: View {
+  let palette: Palette
+
+  var body: some View {
+    HStack(spacing: 4) {
+      Text("✦").foregroundColor(palette.gold)
+      Text("VerseMate").foregroundColor(palette.wordmark)
+    }
+    .font(.system(size: 10, weight: .medium))
+  }
+}
+
 struct VerseOfTheDayWidgetView: View {
   @Environment(\.widgetFamily) var family
+  @Environment(\.colorScheme) var colorScheme
   let entry: VerseEntry
 
+  private var palette: Palette { colorScheme == .dark ? .dark : .light }
+
+  private var isFallback: Bool {
+    guard let v = entry.verse, v.empty == false, let verses = v.verses else { return true }
+    return verses.isEmpty
+  }
+
   private var verseText: String {
-    guard let v = entry.verse, v.empty == false, let verses = v.verses else {
+    guard let v = entry.verse, v.empty == false, let verses = v.verses, !verses.isEmpty else {
       return entry.verse?.fallbackMessage ?? "Open VerseMate to see today's verse"
     }
     return verses.map { $0.text }.joined(separator: " ")
   }
 
-  private var reference: String {
-    entry.verse?.referenceText ?? "VerseMate"
+  private var reference: String { entry.verse?.referenceText ?? "" }
+
+  private var versionLabel: String { entry.verse?.versionKey ?? "" }
+
+  /// "Jul 27 · NASB1995" for the large header; version alone if the date is unset.
+  private var dateAndVersion: String {
+    guard let raw = entry.verse?.date else { return versionLabel }
+    let parser = DateFormatter()
+    parser.dateFormat = "yyyy-MM-dd"
+    guard let parsed = parser.date(from: raw) else { return versionLabel }
+    let out = DateFormatter()
+    out.dateFormat = "MMM d"
+    let day = out.string(from: parsed)
+    return versionLabel.isEmpty ? day : "\(day) · \(versionLabel)"
   }
 
+  /// The note zone needs both room and copy; without a summary systemLarge
+  /// paints a verse-only composition rather than an empty zone.
+  private var explanation: String? {
+    guard !isFallback, let text = entry.verse?.explanation, !text.isEmpty else { return nil }
+    return text
+  }
+
+  private var chapterURL: URL? { entry.verse?.reference.flatMap { deepLinkURL($0) } }
+  private var noteURL: URL? { entry.verse?.reference.flatMap { deepLinkURL($0, tab: noteTab) } }
+
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text(verseText)
-        .font(family == .systemSmall ? .caption : .body)
-        .lineLimit(family == .systemSmall ? 4 : 6)
-        .minimumScaleFactor(0.8)
-      Spacer(minLength: 2)
-      HStack {
+    content
+      .widgetSurface(palette.surface)
+      // Whole-surface tap → the chapter. systemLarge's note zone overrides this
+      // for its own region with a Link (design: "Android allows a few regions,
+      // iOS uses Link").
+      .widgetURL(chapterURL)
+  }
+
+  @ViewBuilder
+  private var content: some View {
+    switch family {
+    case .systemSmall: small
+    case .systemLarge: large
+    default: medium
+    }
+  }
+
+  // MARK: Small — reference first, verse trimmed to its core clause.
+
+  private var small: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      if !isFallback {
         Text(reference)
-          .font(.caption2.weight(.semibold))
-          .foregroundColor(.secondary)
+          .font(serif(12, .semibold))
+          .tracking(0.24)
+          .foregroundColor(palette.gold)
+          .lineLimit(1)
+      }
+      Spacer(minLength: 8)
+      Text(verseText)
+        .font(serif(14))
+        .lineLimit(5)
+        .truncationMode(.tail)
+        .foregroundColor(palette.verseText)
+      Spacer(minLength: 8)
+      HStack {
+        Text(versionLabel)
+          .font(.system(size: 10))
+          .foregroundColor(palette.version)
+          .lineLimit(1)
         Spacer()
-        Text("VerseMate")
-          .font(.caption2)
-          .foregroundColor(.secondary.opacity(0.7))
+        Text("✦")
+          .font(.system(size: 10))
+          .foregroundColor(palette.gold)
       }
     }
-    .padding(12)
-    .widgetURL(entry.verse?.reference.flatMap(deepLinkURL))
+    .padding(16)
+  }
+
+  // MARK: Medium — the current widget, tightened.
+
+  private var medium: some View {
+    HStack(spacing: 0) {
+      LinearGradient(
+        gradient: Gradient(colors: [Color(hex: 0xE4_BE_7C), Color(hex: 0x8A_6B_36)]),
+        startPoint: .top,
+        endPoint: .bottom
+      )
+      .frame(width: 3)
+
+      VStack(alignment: .leading, spacing: 0) {
+        HStack {
+          Eyebrow(text: "VERSE OF THE DAY", color: palette.eyebrow)
+          Spacer()
+          Text(versionLabel)
+            .font(.system(size: 10))
+            .foregroundColor(palette.version)
+            .lineLimit(1)
+        }
+        Spacer(minLength: 8)
+        Text(verseText)
+          .font(serif(15))
+          .lineLimit(3)
+          .truncationMode(.tail)
+          .foregroundColor(palette.verseText)
+        Spacer(minLength: 8)
+        HStack {
+          Text(reference)
+            .font(serif(12, .semibold))
+            .foregroundColor(palette.gold)
+            .lineLimit(1)
+          Spacer()
+          Wordmark(palette: palette)
+        }
+      }
+      .padding(.vertical, 16)
+      .padding(.horizontal, 18)
+    }
+  }
+
+  // MARK: Large — verse + explanation, one tap target each.
+
+  private var large: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      verseZone
+
+      if let explanation = explanation {
+        Rectangle()
+          .fill(palette.hairline)
+          .frame(height: 1)
+
+        if let noteURL = noteURL {
+          Link(destination: noteURL) { noteZone(explanation) }
+        } else {
+          noteZone(explanation)
+        }
+      }
+    }
+  }
+
+  private var verseZone: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack {
+        Eyebrow(text: "VERSE OF THE DAY", color: palette.largeEyebrow)
+        Spacer()
+        Text(dateAndVersion)
+          .font(.system(size: 10))
+          .foregroundColor(palette.version)
+          .lineLimit(1)
+      }
+      Text(verseText)
+        // Without the note zone the verse owns the freed rows.
+        .lineLimit(explanation == nil ? 12 : 4)
+        .font(serif(17))
+        .truncationMode(.tail)
+        .foregroundColor(palette.verseText)
+      if !isFallback {
+        Text(reference)
+          .font(serif(13, .semibold))
+          .foregroundColor(palette.gold)
+          .lineLimit(1)
+      }
+      if explanation == nil { Spacer(minLength: 0) }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(.top, 18)
+    .padding(.horizontal, 20)
+    .padding(.bottom, 16)
+    .background(
+      LinearGradient(
+        gradient: Gradient(colors: [palette.largeHeaderTop, palette.largeHeaderBottom]),
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+    )
+  }
+
+  private func noteZone(_ explanation: String) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Eyebrow(text: "WHY IT MATTERS", color: palette.eyebrow)
+      Text(explanation)
+        .font(serif(13, .light))
+        .lineLimit(6)
+        .truncationMode(.tail)
+        .foregroundColor(palette.explanation)
+      Spacer(minLength: 0)
+      VStack(spacing: 0) {
+        Rectangle()
+          .fill(palette.footerHairline)
+          .frame(height: 1)
+        HStack {
+          Text("Read the full note →")
+            .font(.system(size: 11, weight: .medium))
+            .foregroundColor(palette.gold)
+            .lineLimit(1)
+          Spacer()
+          Wordmark(palette: palette)
+        }
+        .padding(.top, 10)
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+    .padding(.top, 16)
+    .padding(.horizontal, 20)
+    .padding(.bottom, 14)
+  }
+}
+
+extension WidgetConfiguration {
+  /// From iOS 17 WidgetKit insets widget content with its own default margins.
+  /// The design's large family is drawn edge-to-edge — a full-bleed gradient
+  /// header and a divider spanning the full width — and the view already supplies
+  /// the design's own paddings (16/18/20), so the OS margins both double them and
+  /// float the divider away from the edges. Confirmed on a simulator: with the
+  /// margins left on, the header and divider are visibly inset from the rounded
+  /// corners and the verse loses a line to the narrower text column.
+  func edgeToEdgeIfAvailable() -> some WidgetConfiguration {
+    if #available(iOS 17.0, *) {
+      return self.contentMarginsDisabled()
+    } else {
+      return self
+    }
   }
 }
 
@@ -208,5 +555,6 @@ struct VerseOfTheDayWidget: Widget {
     .configurationDisplayName("Verse of the Day")
     .description("Today's Bible verse from VerseMate.")
     .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    .edgeToEdgeIfAvailable()
   }
 }

--- a/utils/sharing/generate-chapter-share-url.ts
+++ b/utils/sharing/generate-chapter-share-url.ts
@@ -10,7 +10,7 @@
  * Example: https://app.versemate.org/bible/john/3?tab=summary (John 3 Summary insight)
  */
 
-import type { ContentTabType } from '@/types/bible';
+import { type ContentTabType, isContentTabType } from '@/types/bible';
 import { getBookSlug, parseBookParam } from '../bookSlugs';
 
 /**
@@ -95,6 +95,7 @@ export function parseChapterShareUrl(url: string): {
   chapterNumber: number;
   verseStart?: number;
   verseEnd?: number;
+  tab?: ContentTabType;
 } | null {
   const baseUrl = process.env.EXPO_PUBLIC_WEB_URL;
 
@@ -152,11 +153,18 @@ export function parseChapterShareUrl(url: string): {
     const verseStart = parsePositiveInt(urlObj.searchParams.get('verseStart'));
     const verseEnd = parsePositiveInt(urlObj.searchParams.get('verseEnd'));
 
+    // Optional insight tab (?tab=summary) — set by share links and by the
+    // widget's "Why it matters" tap zone. Unknown values are dropped so a
+    // malformed link still opens the chapter on the default tab.
+    const rawTab = urlObj.searchParams.get('tab');
+    const tab = isContentTabType(rawTab) ? rawTab : undefined;
+
     return {
       bookId,
       chapterNumber,
       ...(verseStart !== undefined ? { verseStart } : {}),
       ...(verseEnd !== undefined ? { verseEnd } : {}),
+      ...(tab !== undefined ? { tab } : {}),
     };
   } catch (error) {
     console.warn('Failed to parse chapter share URL:', error);
@@ -180,6 +188,8 @@ export function parseChapterShareUrl(url: string): {
  * @param verseStart - First verse to scroll to / highlight
  * @param verseEnd - Optional last verse of the passage
  * @param isWidget - Whether the originating link carried `?src=widget`
+ * @param tab - Optional insight tab to open (the widget's note zone sends
+ *   `summary`); forwarded verbatim so the reader's deep-link effect picks it up
  * @returns Reader route, e.g. `/bible/43/3?verse=16&endVerse=18&src=widget`
  */
 export function buildWidgetVerseRoute(
@@ -187,11 +197,13 @@ export function buildWidgetVerseRoute(
   chapterNumber: number,
   verseStart: number,
   verseEnd: number | undefined,
-  isWidget: boolean
+  isWidget: boolean,
+  tab?: ContentTabType
 ): string {
   const verseParams = new URLSearchParams();
   verseParams.set('verse', String(verseStart));
   if (verseEnd) verseParams.set('endVerse', String(verseEnd));
   if (isWidget) verseParams.set('src', 'widget');
+  if (tab) verseParams.set('tab', tab);
   return `/bible/${bookId}/${chapterNumber}?${verseParams.toString()}`;
 }

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -2,9 +2,19 @@
  * Android Verse-of-the-Day widget UI (GH-265).
  *
  * react-native-android-widget renders this RN-like tree into a native
- * RemoteViews widget. Styled to match the in-app reader: a gold accent rail,
- * Unicode-superscript verse numbers, the verse text, and a gold reference with
- * a small wordmark. Light + dark variants are rendered by the task handler.
+ * RemoteViews widget. Layout follows the "Verse of the Day — home-screen
+ * widget" design doc (turn 2, panel 2B — Android):
+ *
+ *  - `compact`  (4×2, 336×148dp): verse clamped to 3 lines, reference + wordmark
+ *    pinned to the bottom baseline. No header, no accent rail — at this size the
+ *    design reads the widget as a plain rounded Material surface.
+ *  - `expanded` (4×4, 336×336dp): eyebrow + version, verse clamped to 4 lines,
+ *    gold reference, then a nested rounded "Why it matters" panel. The design
+ *    uses an inset surface instead of a hairline divider, and each block is its
+ *    own tap target (verse → chapter, note → the explanation tab).
+ *
+ * Type never shrinks to fit (design rule: "clamp lines, never shrink the type"),
+ * so every day's verse occupies the same slots regardless of length.
  */
 import { FlexWidget, TextWidget } from "react-native-android-widget";
 
@@ -12,6 +22,9 @@ export interface VerseData {
   verseNumber: number;
   text: string;
 }
+
+/** Which of the design's two Android compositions to paint. */
+export type WidgetSize = "compact" | "expanded";
 
 export interface VerseOfTheDayWidgetProps {
   /** Per-verse data from the API; null when rendering the fallback state. */
@@ -24,25 +37,53 @@ export interface VerseOfTheDayWidgetProps {
   fallbackText: string;
   /** Which palette to paint; the handler renders one tree per system theme. */
   theme: "light" | "dark";
+  /** Which composition to paint, derived from the host cell size. */
+  size?: WidgetSize;
+  /**
+   * Short "why it matters" summary (≤220 chars per the design). Only the
+   * `expanded` size has room for it; when absent that size paints a verse-only
+   * composition rather than an empty panel.
+   */
+  explanation?: string | null;
+  /** Deep link for the explanation tab; used by the note block's tap zone. */
+  noteDeepLink?: string;
+  /** Translation label shown in the expanded header, e.g. "NASB1995". */
+  versionLabel?: string;
 }
 
-// VerseMate brand palette (mobile theme/tokens.ts): gold accent #b09a6d.
+// Palette from the design doc (2B). The dark values are the design's verbatim;
+// light is the same structure resolved against the app's light tokens — gold
+// drops to #b09a6d there, the only gold that clears WCAG AA on white.
 const PALETTES = {
   light: {
     background: "#ffffff",
-    accent: "#b09a6d",
+    border: "#e8e4dc",
     verseText: "#1a1a1a",
     reference: "#b09a6d",
+    eyebrow: "#6e6e77",
+    version: "#8a8a8a",
     wordmark: "#9b9b9b",
+    panel: "#f7f5f1",
+    panelLabel: "#8a7345",
+    explanation: "#4a4a4a",
+    link: "#8a7345",
   },
   dark: {
-    background: "#121212",
-    accent: "#b09a6d",
-    verseText: "#e8e8e8",
-    reference: "#e0b890",
+    background: "#1b1b1b",
+    border: "#2a2a2a",
+    verseText: "#ededed",
+    reference: "#e0b872",
+    eyebrow: "#8a8a8a",
+    version: "#6e6e6e",
     wordmark: "#8a8a8a",
+    panel: "#141414",
+    panelLabel: "#e0b872",
+    explanation: "#bdbdbd",
+    link: "#e0b872",
   },
 } as const;
+
+type Palette = (typeof PALETTES)[keyof typeof PALETTES];
 
 const SUPERSCRIPTS = ["⁰", "¹", "²", "³", "⁴", "⁵", "⁶", "⁷", "⁸", "⁹"];
 
@@ -59,12 +100,53 @@ function composeVerseText(verses: VerseData[]): string {
   return verses.map((v) => `${toSuperscript(v.verseNumber)} ${v.text}`).join("  ");
 }
 
+/**
+ * Reference + wordmark row that closes every composition. Pinned so the widget's
+ * silhouette is identical whatever the verse length (design 2B, stress test).
+ */
+function FooterRow({
+  reference,
+  palette,
+  referenceSize,
+}: {
+  reference: string;
+  palette: Palette;
+  referenceSize: number;
+}) {
+  return (
+    <FlexWidget
+      style={{
+        flexDirection: "row",
+        justifyContent: "space-between",
+        alignItems: "center",
+        width: "match_parent",
+      }}
+    >
+      <TextWidget
+        text={reference}
+        maxLines={1}
+        truncate="END"
+        style={{ fontSize: referenceSize, color: palette.reference, fontWeight: "600" }}
+      />
+      <TextWidget
+        text="✦ VerseMate"
+        maxLines={1}
+        style={{ fontSize: 10, color: palette.wordmark, fontWeight: "500" }}
+      />
+    </FlexWidget>
+  );
+}
+
 export function VerseOfTheDayWidget({
   verses,
   reference,
   deepLink,
   fallbackText,
   theme,
+  size = "compact",
+  explanation,
+  noteDeepLink,
+  versionLabel,
 }: VerseOfTheDayWidgetProps) {
   // React Compiler (app.config.js `experiments.reactCompiler`) instruments this
   // component with a `useMemoCache` call. react-native-android-widget renders
@@ -82,70 +164,143 @@ export function VerseOfTheDayWidget({
   const palette = PALETTES[theme];
   const isFallback = !verses || verses.length === 0;
   const bodyText = isFallback ? fallbackText : composeVerseText(verses);
+  // The note panel needs both room and copy; without a summary the expanded
+  // size paints a verse-only composition instead of an empty surface.
+  const showNote = size === "expanded" && !isFallback && !!explanation;
 
-  return (
-    <FlexWidget
-      style={{
-        height: "match_parent",
-        width: "match_parent",
-        flexDirection: "row",
-        backgroundColor: palette.background,
-        borderRadius: 16,
-        overflow: "hidden",
-      }}
-      clickAction="OPEN_VERSE"
-      clickActionData={{ url: deepLink }}
-    >
-      {/* Gold accent rail (matches the app's brand accent). */}
-      <FlexWidget
-        style={{ height: "match_parent", width: 5, backgroundColor: palette.accent }}
-      />
+  const surface = {
+    height: "match_parent",
+    width: "match_parent",
+    flexDirection: "column",
+    backgroundColor: palette.background,
+    borderRadius: 28,
+    borderWidth: 1,
+    borderColor: palette.border,
+    overflow: "hidden",
+  } as const;
 
+  if (size === "compact") {
+    return (
       <FlexWidget
         style={{
-          flex: 1,
-          height: "match_parent",
-          flexDirection: "column",
+          ...surface,
           justifyContent: isFallback ? "center" : "space-between",
-          paddingTop: 14,
-          paddingBottom: 12,
-          paddingLeft: 14,
-          paddingRight: 14,
+          paddingVertical: 16,
+          paddingHorizontal: 18,
         }}
+        clickAction="OPEN_VERSE"
+        clickActionData={{ url: deepLink }}
       >
         <TextWidget
           text={bodyText}
-          maxLines={6}
+          maxLines={3}
           truncate="END"
-          style={{
-            fontSize: isFallback ? 14 : 15,
-            color: palette.verseText,
-            fontFamily: "serif",
-          }}
+          style={{ fontSize: 15, color: palette.verseText, fontFamily: "serif" }}
         />
+        {isFallback ? null : (
+          <FooterRow reference={reference} palette={palette} referenceSize={12} />
+        )}
+      </FlexWidget>
+    );
+  }
 
+  return (
+    <FlexWidget style={surface}>
+      {/* Verse block — its own tap zone, deep-links to the chapter. */}
+      <FlexWidget
+        style={{
+          width: "match_parent",
+          flexDirection: "column",
+          flexGap: 10,
+          paddingTop: 18,
+          paddingHorizontal: 18,
+          paddingBottom: 14,
+          // Without the note panel this block owns the whole surface.
+          ...(showNote ? {} : { flex: 1 }),
+        }}
+        clickAction="OPEN_VERSE"
+        clickActionData={{ url: deepLink }}
+      >
         <FlexWidget
           style={{
             flexDirection: "row",
             justifyContent: "space-between",
             alignItems: "center",
             width: "match_parent",
-            ...(isFallback ? { marginTop: 12 } : {}),
           }}
         >
           <TextWidget
-            text={isFallback ? "" : reference}
+            text="VERSE OF THE DAY"
             maxLines={1}
-            truncate="END"
-            style={{ fontSize: 12, color: palette.reference, fontWeight: "700" }}
+            style={{
+              fontSize: 9,
+              fontWeight: "700",
+              letterSpacing: 0.14,
+              color: palette.eyebrow,
+            }}
           />
           <TextWidget
-            text="✦ VerseMate"
+            text={versionLabel ?? ""}
             maxLines={1}
-            style={{ fontSize: 11, color: palette.wordmark, fontWeight: "600" }}
+            style={{ fontSize: 10, color: palette.version }}
           />
         </FlexWidget>
+
+        <TextWidget
+          text={bodyText}
+          // Without the note panel the verse takes the freed rows.
+          maxLines={showNote ? 4 : 9}
+          truncate="END"
+          style={{ fontSize: 16, color: palette.verseText, fontFamily: "serif" }}
+        />
+
+        {isFallback ? null : (
+          <FooterRow reference={reference} palette={palette} referenceSize={13} />
+        )}
       </FlexWidget>
+
+      {/* Note block — nested rounded surface, deep-links to the explanation tab. */}
+      {showNote ? (
+        <FlexWidget
+          style={{
+            flex: 1,
+            width: "match_parent",
+            flexDirection: "column",
+            justifyContent: "space-between",
+            marginHorizontal: 12,
+            marginBottom: 12,
+            padding: 14,
+            backgroundColor: palette.panel,
+            borderRadius: 20,
+          }}
+          clickAction="OPEN_VERSE"
+          clickActionData={{ url: noteDeepLink ?? deepLink }}
+        >
+          <FlexWidget style={{ width: "match_parent", flexDirection: "column", flexGap: 8 }}>
+            <TextWidget
+              text="WHY IT MATTERS"
+              maxLines={1}
+              style={{
+                fontSize: 9,
+                fontWeight: "700",
+                letterSpacing: 0.14,
+                color: palette.panelLabel,
+              }}
+            />
+            <TextWidget
+              text={explanation ?? ""}
+              maxLines={5}
+              truncate="END"
+              style={{ fontSize: 13, color: palette.explanation, fontFamily: "serif" }}
+            />
+          </FlexWidget>
+          <TextWidget
+            text="Read the full note →"
+            maxLines={1}
+            style={{ fontSize: 11, fontWeight: "500", color: palette.link }}
+          />
+        </FlexWidget>
+      ) : null}
     </FlexWidget>
   );
 }

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -12,7 +12,7 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Linking } from "react-native";
 import type { WidgetTaskHandlerProps } from "react-native-android-widget";
-import { VerseOfTheDayWidget } from "./VerseOfTheDayWidget";
+import { VerseOfTheDayWidget, type WidgetSize } from "./VerseOfTheDayWidget";
 
 const BIBLE_VERSION_KEY = "bible-version";
 const DEFAULT_VERSION = "NASB1995";
@@ -49,6 +49,38 @@ interface VerseResponse {
     verseEnd: number | null;
   };
   fallbackMessage?: string;
+  versionKey?: string;
+  /**
+   * Short "why it matters" summary for the expanded widget (design: ≤220 chars).
+   * NOT served by /bible/verse-of-the-day yet — the field is read optionally so
+   * the note panel lights up the day the API starts returning it, and the
+   * expanded size falls back to a verse-only composition until then.
+   */
+  explanation?: string | null;
+}
+
+/**
+ * Insight tab the note block opens. `summary` is the reader's short overview
+ * tab — the in-app counterpart of the widget's "Why it matters" panel.
+ */
+const NOTE_TAB = "summary";
+
+/** Provider that paints the 4×4 "verse + why it matters" composition. */
+const NOTE_WIDGET_NAME = "VerseOfTheDayNote";
+
+/**
+ * Which composition to paint, from the widget's provider name (app.config.js).
+ *
+ * Deliberately NOT derived from `widgetInfo.height`: in portrait the library
+ * reports OPTION_APPWIDGET_MAX_HEIGHT — the provider's maximum resize bound, not
+ * the widget's current height — so a 4×2 and a 4×4 both report 358dp on the
+ * Pixel launcher (measured on an API 35 emulator, confirmed against the
+ * launcher's own `getMinMaxSizes: Rect(360, 210 - 676, 358)`). Thresholding that
+ * value silently painted the expanded layout inside a 4×2 cell. The name is the
+ * one signal that actually distinguishes them.
+ */
+export function pickWidgetSize(widgetName: string): WidgetSize {
+  return widgetName === NOTE_WIDGET_NAME ? "expanded" : "compact";
 }
 
 function localDate(): string {
@@ -56,11 +88,16 @@ function localDate(): string {
   return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
 }
 
-export function buildDeepLink(ref?: VerseResponse["reference"]): string {
-  if (!ref) return `${DEEP_LINK_BASE}/1/1?src=widget`;
+/**
+ * Build the widget's tap deep link. Pass `tab` for the note block's zone so the
+ * reader opens on that insight tab (design 2B: two tap zones, one per block).
+ */
+export function buildDeepLink(ref?: VerseResponse["reference"], tab?: string): string {
+  const suffix = tab ? `&src=widget&tab=${tab}` : "&src=widget";
+  if (!ref) return `${DEEP_LINK_BASE}/1/1?src=widget${tab ? `&tab=${tab}` : ""}`;
   let url = `${DEEP_LINK_BASE}/${ref.bookId}/${ref.chapterNumber}?verseStart=${ref.verseStart}`;
   if (ref.verseEnd) url += `&verseEnd=${ref.verseEnd}`;
-  return `${url}&src=widget`;
+  return `${url}${suffix}`;
 }
 
 export interface WidgetVerseData {
@@ -71,6 +108,12 @@ export interface WidgetVerseData {
   deepLink: string;
   /** Message rendered when `verses` is null. */
   fallbackText: string;
+  /** Same target as `deepLink`, but opens the reader's insight tab. */
+  noteDeepLink: string;
+  /** Translation label for the expanded header; empty when unknown. */
+  versionLabel: string;
+  /** "Why it matters" summary; null until the API serves one. */
+  explanation: string | null;
 }
 
 export async function fetchVerse(): Promise<WidgetVerseData> {
@@ -90,26 +133,36 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     const data = (await res.json()) as VerseResponse;
     if (data.empty || !data.verses?.length) {
       return {
-        verses: null,
-        reference: "",
+        ...emptyState(data.fallbackMessage ?? FALLBACK_MESSAGE),
         deepLink: buildDeepLink(data.reference),
-        fallbackText: data.fallbackMessage ?? FALLBACK_MESSAGE,
+        noteDeepLink: buildDeepLink(data.reference, NOTE_TAB),
       };
     }
     return {
       verses: data.verses,
       reference: data.referenceText ?? "",
       deepLink: buildDeepLink(data.reference),
+      noteDeepLink: buildDeepLink(data.reference, NOTE_TAB),
       fallbackText: FALLBACK_MESSAGE,
+      versionLabel: data.versionKey ?? "",
+      explanation: data.explanation ?? null,
     };
   } catch {
-    return {
-      verses: null,
-      reference: "",
-      deepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
-      fallbackText: FALLBACK_MESSAGE,
-    };
+    return emptyState(FALLBACK_MESSAGE);
   }
+}
+
+/** Verse-less state: a tap-to-open fallback pointing at Genesis 1. */
+function emptyState(fallbackText: string): WidgetVerseData {
+  return {
+    verses: null,
+    reference: "",
+    deepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
+    noteDeepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
+    fallbackText,
+    versionLabel: "",
+    explanation: null,
+  };
 }
 
 export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
@@ -121,22 +174,19 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
       // outcome. fetchVerse no longer rejects, but guard the whole render so
       // any unexpected failure still paints a tap-to-open fallback. Render a
       // light + dark variant so the widget matches the launcher's theme.
+      // Which provider was placed picks the composition (design 2B: 4×2 vs 4×4).
+      const size = pickWidgetSize(props.widgetInfo.widgetName);
       try {
         const data = await fetchVerse();
         props.renderWidget({
-          light: <VerseOfTheDayWidget {...data} theme="light" />,
-          dark: <VerseOfTheDayWidget {...data} theme="dark" />,
+          light: <VerseOfTheDayWidget {...data} size={size} theme="light" />,
+          dark: <VerseOfTheDayWidget {...data} size={size} theme="dark" />,
         });
       } catch {
-        const fallback: WidgetVerseData = {
-          verses: null,
-          reference: "",
-          deepLink: `${DEEP_LINK_BASE}/1/1?src=widget`,
-          fallbackText: FALLBACK_MESSAGE,
-        };
+        const fallback = emptyState(FALLBACK_MESSAGE);
         props.renderWidget({
-          light: <VerseOfTheDayWidget {...fallback} theme="light" />,
-          dark: <VerseOfTheDayWidget {...fallback} theme="dark" />,
+          light: <VerseOfTheDayWidget {...fallback} size={size} theme="light" />,
+          dark: <VerseOfTheDayWidget {...fallback} size={size} theme="dark" />,
         });
       }
       break;


### PR DESCRIPTION
Implements the design doc "Verse of the Day — home-screen widget" (turn 2, panels 2A/2B) on both platforms. Text is clamped and never scaled, per the design's own rule, so every day's verse occupies the same slots regardless of length.

## iOS — progressive disclosure by family

| Family | Composition |
|---|---|
| small | reference first, verse clamped to 5 lines, no note |
| medium | gold gradient rail, eyebrow + version, verse clamped to 3 |
| large | verse zone + "Why it matters" zone, **each its own tap target** — verse deep-links to the chapter, note to the reader's summary tab |

Verified on an iPhone 17 Pro simulator (iOS 26.5), all three families in light and dark.

That verification caught something no unit test would: **iOS 17+ default content margins** were insetting the design's full-bleed gradient header and divider, and stealing enough width to ellipsize the verse at `"and m…"`. Fixed with an availability-gated `contentMarginsDisabled()` (`edgeToEdgeIfAvailable()`), which restores the edge-to-edge treatment and lets all four verse lines fit.

## Android — two providers, not one resizable widget

The design draws two compositions (4×2 verse-only, 4×4 verse + note). They ship as **two providers** because a widget's own size is not discoverable at render time:

- in portrait `react-native-android-widget` returns `OPTION_APPWIDGET_MAX_HEIGHT` — the provider's *max resize bound*, not the current height
- measured on an API 35 emulator: a 4×2 and a 4×4 **both report 358dp**, corroborated by the launcher's own `getMinMaxSizes: Rect(360, 210 - 676, 358)`
- the library renders one bitmap per theme with no `SizeF` support, so Android 12+ per-size layouts aren't reachable either

Thresholding that value silently painted the expanded layout (with its eyebrow) inside a 4×2 cell. `pickWidgetSize()` now keys off `widgetInfo.widgetName`, and falls back to the verse-only composition for an unknown provider so a stale widget from an older install can never paint a clipped note panel. Vertical resize is disabled on both providers so each keeps the height its composition was drawn for.

## Deep links

`parseChapterShareUrl` now extracts a `tab` validated through the existing `isContentTabType`, and `buildWidgetVerseRoute` forwards it, so the note zone lands on the reader's summary tab. This also fixes a pre-existing gap: `?tab=` on a plain chapter share link was parsed and then discarded.

## Data dependency

The note copy comes from the new `explanation` field on `/bible/verse-of-the-day` (verse-mate/verse-mate#304). It's read optionally — until that ships, the large / 4×4 layouts render a verse-only composition rather than an empty panel, so these can land in either order.

## Tests

1685 pass. New widget tests render **both** compositions through the library's own `buildWidgetTree` + `validateWidgetTree` — the renderer that caused the original GH-265 blank widget — plus the full deep-link chain and the provider-name selection.

## Not verified

A pixel screenshot of the final Android compositions with live data. The build installs, both providers appear in the picker with the right labels/sizes, the widget renders (not blank), and logcat confirmed the data chain end-to-end (`explanation=yes` from a local backend) — but launcher drag-and-drop automation proved unreliable and the emulator's single home page lacks 4 free rows for the 4×4. Worth a human eye on Android before merge.

## Incidental findings (not addressed here)

- **iOS simulator builds fail from a clean prebuild** — the PostHog pod fails module-interface verification (`underlying Objective-C module 'PostHog' not found`, built from its `.swiftinterface`). Workaround: `BUILD_LIBRARY_FOR_DISTRIBUTION=NO`. Deserves a Podfile `post_install` fix.
- **`targets/widget/Info.plist` and `generated.entitlements`** are generated by prebuild into a tracked directory and show up untracked every time — candidates for `.gitignore`.