### PR TITLE
GH-265: fix the Android widget losing content, wasting space, and disagreeing with the daily push

### DIFF
--- a/__tests__/hooks/use-bible-version.test.ts
+++ b/__tests__/hooks/use-bible-version.test.ts
@@ -7,7 +7,18 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { renderHook, waitFor } from '@testing-library/react-native';
 import { act } from 'react-test-renderer';
-import { resetCachedVersion, useBibleVersion } from '@/hooks/use-bible-version';
+import {
+  backfillPreferredBibleVersion,
+  resetCachedVersion,
+  useBibleVersion,
+} from '@/hooks/use-bible-version';
+import { syncPreferredBibleVersion } from '@/lib/notifications/push-api';
+
+jest.mock('@/lib/notifications/push-api', () => ({
+  syncPreferredBibleVersion: jest.fn().mockResolvedValue(true),
+}));
+
+const mockSync = syncPreferredBibleVersion as jest.MockedFunction<typeof syncPreferredBibleVersion>;
 
 describe('useBibleVersion', () => {
   beforeEach(async () => {
@@ -125,5 +136,50 @@ describe('useBibleVersion', () => {
     });
 
     expect(result2.current.bibleVersion).toBe('NKJV');
+  });
+});
+
+// The daily verse-of-the-day push renders in `user.preferred_bible_version`,
+// which setBibleVersion only writes on change — so a translation chosen before
+// that sync existed never reached the server, and the push arrives in NASB1995
+// while the widget (which sends bible_version explicitly) shows the real one.
+describe('backfillPreferredBibleVersion', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+    resetCachedVersion();
+    jest.clearAllMocks();
+  });
+
+  it('pushes the stored translation to the server once per install', async () => {
+    mockSync.mockResolvedValue(true);
+    await AsyncStorage.setItem('bible-version', 'KJV');
+
+    await backfillPreferredBibleVersion();
+    await backfillPreferredBibleVersion();
+
+    expect(mockSync).toHaveBeenCalledTimes(1);
+    expect(mockSync).toHaveBeenCalledWith('KJV');
+  });
+
+  it('retries on the next launch when the sync fails', async () => {
+    mockSync.mockResolvedValue(false);
+    await AsyncStorage.setItem('bible-version', 'KJV');
+
+    await backfillPreferredBibleVersion();
+    await backfillPreferredBibleVersion();
+
+    // Flag stays unset on failure, so a flaky launch doesn't strand the user
+    // on a translation the server never heard about.
+    expect(mockSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('stays silent when the user never chose a translation', async () => {
+    mockSync.mockResolvedValue(true);
+
+    await backfillPreferredBibleVersion();
+
+    // The server default already matches; writing would claim a preference
+    // the user never expressed.
+    expect(mockSync).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/widgets/verse-of-the-day-widget.test.tsx
+++ b/__tests__/widgets/verse-of-the-day-widget.test.tsx
@@ -95,6 +95,20 @@ describe('VerseOfTheDayWidget', () => {
     );
     // Two tap zones: the verse block → chapter, the note block → summary tab.
     expect(clickUrls(tree)).toEqual(expect.arrayContaining([BASE.deepLink, BASE.noteDeepLink]));
+
+    // The explanation must sit inside a weighted box so it grows into whatever
+    // height the launcher actually gave the widget instead of clamping to a
+    // constant. `flex` becomes `weight` only on a FlexWidget — TextWidget styles
+    // drop it silently — so a "simplification" that moves the text back out
+    // reintroduces the reported blank rows with every test still green.
+    const box = flatten(tree).find(
+      (n) =>
+        (n.props as { weight?: number }).weight === 1 &&
+        (n.children ?? []).some((c) =>
+          (c.props as { text?: string }).text?.startsWith('David pictures')
+        )
+    );
+    expect(box).toBeDefined();
   });
 
   it('falls back to a verse-only expanded layout when no explanation is served', () => {

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -211,6 +211,23 @@ describe('widget-task-handler', () => {
       await AsyncStorage.removeItem('widget-user-id');
     });
 
+    // The widget and the daily push must land on the same verse. The pick is
+    // seeded (date, userId) and persisted, so they agree only while both use
+    // the SAME date — and the push worker uses the server's. Omitting the param
+    // makes the endpoint default to that same server-local today. Sending the
+    // device's date instead also 400s outright ("date must be today or
+    // yesterday") for any device in a UTC+ zone, which renders an empty widget.
+    it('never sends a date, so the server clock decides — same as the daily push', async () => {
+      const fetchMock = jest.fn().mockResolvedValue({
+        json: async () => ({ empty: true, fallbackMessage: 'x' }),
+      }) as unknown as typeof fetch;
+      global.fetch = fetchMock;
+
+      await fetchVerse();
+
+      expect((fetchMock as unknown as jest.Mock).mock.calls[0][0]).not.toContain('date=');
+    });
+
     it('returns the fallback message when the verse pool is empty', async () => {
       global.fetch = jest.fn().mockResolvedValue({
         json: async () => ({ empty: true, fallbackMessage: 'No verse today' }),

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -283,6 +283,42 @@ describe('widget-task-handler', () => {
       expect(result.reference).toBe('John 3:16');
     });
 
+    // The cached payload is only reusable for the identity it was fetched
+    // under: the backend seeds its pick `${date}:${userId}` and renders it in
+    // the requested translation. Without this the failure path resurrects
+    // another identity's verse — the same mismatch this widget was fixed to
+    // stop, one layer down (add the widget logged out, then log in).
+    it.each([
+      ['the user logged in since', { pid: 'user-123', version: 'NASB1995' }],
+      ['the translation changed since', { pid: null, version: 'KJV' }],
+    ])('does not serve a cached verse when %s', async (_label, now) => {
+      // Cached while logged out, in NASB1995.
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({
+          empty: false,
+          referenceText: 'John 3:16',
+          verses: [{ verseNumber: 16, text: 'For God so loved the world' }],
+          reference: { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null },
+          versionKey: 'NASB1995',
+        }),
+      }) as unknown as typeof fetch;
+      await fetchVerse();
+
+      if (now.pid) await AsyncStorage.setItem('widget-user-id', now.pid);
+      await AsyncStorage.setItem('bible-version', now.version);
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+      const result = await fetchVerse();
+
+      expect(result.verses).toBeNull();
+      expect(result.fallbackText).toBe("Open VerseMate to see today's verse");
+
+      await AsyncStorage.removeItem('widget-user-id');
+      await AsyncStorage.removeItem('bible-version');
+    });
+
     // A device offline for days should show the honest "open the app" state
     // rather than last week's verse under a "VERSE OF THE DAY" header.
     it('ignores a cached verse older than yesterday', async () => {

--- a/__tests__/widgets/widget-task-handler.test.ts
+++ b/__tests__/widgets/widget-task-handler.test.ts
@@ -33,6 +33,12 @@ jest.mock('react-native-android-widget', () => ({
 const originalFetch = global.fetch;
 
 describe('widget-task-handler', () => {
+  // fetchVerse persists every successful payload; drop it between tests so the
+  // fallback assertions below exercise the no-cache path.
+  beforeEach(async () => {
+    await AsyncStorage.removeItem('widget-verse-cache');
+  });
+
   afterEach(() => {
     global.fetch = originalFetch;
     jest.clearAllMocks();
@@ -230,6 +236,54 @@ describe('widget-task-handler', () => {
       expect(result.fallbackText).toBe("Open VerseMate to see today's verse");
       expect(result.reference).toBe('');
       expect(parseChapterShareUrl(result.deepLink)).toEqual({ bookId: 1, chapterNumber: 1 });
+    });
+
+    // The reported "sometimes it doesn't load any content": the OS reruns the
+    // widget task only every few hours, so before this a single failed fetch
+    // left the widget empty until the next tick.
+    it.each([
+      ['fetch throws', () => jest.fn().mockRejectedValue(new Error('network down'))],
+      [
+        'the API errors out (e.g. invalid_date)',
+        () => jest.fn().mockResolvedValue({ json: async () => ({ error: 'invalid_date' }) }),
+      ],
+    ])('serves the last good verse when %s', async (_label, makeFetch) => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({
+          empty: false,
+          referenceText: 'John 3:16',
+          verses: [{ verseNumber: 16, text: 'For God so loved the world' }],
+          reference: { bookId: 43, chapterNumber: 3, verseStart: 16, verseEnd: null },
+          versionKey: 'NASB1995',
+        }),
+      }) as unknown as typeof fetch;
+      await fetchVerse();
+
+      global.fetch = makeFetch() as unknown as typeof fetch;
+      const result = await fetchVerse();
+
+      expect(result.verses).toEqual([{ verseNumber: 16, text: 'For God so loved the world' }]);
+      expect(result.reference).toBe('John 3:16');
+    });
+
+    // A device offline for days should show the honest "open the app" state
+    // rather than last week's verse under a "VERSE OF THE DAY" header.
+    it('ignores a cached verse older than yesterday', async () => {
+      await AsyncStorage.setItem(
+        'widget-verse-cache',
+        JSON.stringify({
+          date: '2020-01-01',
+          data: { verses: [{ verseNumber: 1, text: 'stale' }], reference: 'Gen 1:1' },
+        })
+      );
+      global.fetch = jest
+        .fn()
+        .mockRejectedValue(new Error('network down')) as unknown as typeof fetch;
+
+      const result = await fetchVerse();
+
+      expect(result.verses).toBeNull();
+      expect(result.fallbackText).toBe("Open VerseMate to see today's verse");
     });
   });
 });

--- a/app.config.js
+++ b/app.config.js
@@ -237,7 +237,7 @@ const config = {
             targetCellWidth: 4,
             targetCellHeight: 2,
             resizeMode: 'horizontal',
-            updatePeriodMillis: 86400000, // ~daily; OS-throttled periodic refresh
+            updatePeriodMillis: 21600000, // 6h: rolls the verse over near midnight, and retries a failed fetch within hours instead of a day
           },
           {
             name: 'VerseOfTheDayNote',
@@ -248,7 +248,7 @@ const config = {
             targetCellWidth: 4,
             targetCellHeight: 4,
             resizeMode: 'horizontal',
-            updatePeriodMillis: 86400000,
+            updatePeriodMillis: 21600000,
           },
         ],
       },

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -411,10 +411,23 @@ function RootLayoutInner() {
       }
     };
 
+    // Repaint a widget left empty by a failed background fetch. The fallback
+    // tells the user to open the app, so opening it must actually fix it — the
+    // OS runs the widget's own update task only every few hours. No-ops when
+    // today's verse is already cached or no widget is placed.
+    const refreshWidgets = async () => {
+      const widgets = await import('@/widgets/widget-task-handler');
+      await widgets.refreshWidgets();
+    };
+
     // Run on mount (covers cold start) and on each foreground transition.
     checkWidgetInstalled();
+    refreshWidgets();
     const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {
-      if (state === 'active') checkWidgetInstalled();
+      if (state === 'active') {
+        checkWidgetInstalled();
+        refreshWidgets();
+      }
     });
 
     return () => subscription.remove();

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -416,8 +416,13 @@ function RootLayoutInner() {
     // OS runs the widget's own update task only every few hours. No-ops when
     // today's verse is already cached or no widget is placed.
     const refreshWidgets = async () => {
-      const widgets = await import('@/widgets/widget-task-handler');
-      await widgets.refreshWidgets();
+      try {
+        const widgets = await import('@/widgets/widget-task-handler');
+        await widgets.refreshWidgets();
+      } catch {
+        // Best-effort, matching checkWidgetInstalled above: refreshWidgets
+        // swallows its own failures, so only the dynamic import can reject.
+      }
     };
 
     // Run on mount (covers cold start) and on each foreground transition.

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/auth/token-storage';
 import { clearTokenCache } from '@/lib/api/client-interceptors';
 import { analytics, AnalyticsEvent } from '@/lib/analytics';
+import { backfillPreferredBibleVersion } from '@/hooks/use-bible-version';
 import { syncWidgetUserId } from '@/hooks/use-shared-widget-prefs';
 import { unregisterPushOnLogout } from '@/lib/notifications/push-registration';
 import {
@@ -221,10 +222,24 @@ export function AuthProvider({ children }: AuthProviderProps) {
   // Mirror the user's id into the widget container so the home-screen widget
   // shows this user's personal verse (PD-7); cleared on logout. Memoize the id
   // so the effect deps are a primitive (Biome react-hooks rule).
+  //
+  // Gated on `isLoading`: `user` is null on mount too, and writing that through
+  // would clear the stored id on EVERY cold start, before restoreSession has
+  // had a chance to resolve. The widget runs in its own headless process and
+  // reads this key directly — a fetch landing in that window sends no `pid`, so
+  // the backend serves the anonymous GLOBAL verse while the daily push (which
+  // always has a real user id) serves the PERSONAL one. The pick is seeded
+  // `${date}:${userId}`, so those are different verses by construction, not a
+  // rounding error. Only a settled null — a genuinely logged-out user — clears.
   const widgetUserId = user?.id ?? null;
   useEffect(() => {
+    if (isLoading) return;
     void syncWidgetUserId(widgetUserId);
-  }, [widgetUserId]);
+    // Same alignment problem one layer over: the daily push renders in
+    // `user.preferred_bible_version`, which is only written on change, so a
+    // translation chosen before that sync existed never reached the server.
+    if (widgetUserId) void backfillPreferredBibleVersion();
+  }, [widgetUserId, isLoading]);
 
   /**
    * Fetch user session from backend and cache the result for offline use.

--- a/hooks/use-bible-version.ts
+++ b/hooks/use-bible-version.ts
@@ -31,6 +31,38 @@ function notifyBibleVersionChanged(): void {
   for (const fn of listeners) fn();
 }
 
+/** Set once the server has been told this install's stored translation. */
+const VERSION_BACKFILL_KEY = 'preferred-bible-version-backfilled';
+
+/**
+ * Push this install's stored translation to the server once, for users who
+ * chose it before GH-281 added the server-side sync.
+ *
+ * `setBibleVersion` only syncs *on change*, so anyone who picked a translation
+ * earlier and never touched it again still has the column default (NASB1995)
+ * server-side. The daily verse-of-the-day push reads that column, so they get
+ * the right verse rendered in the wrong translation — the widget sends
+ * `bible_version` explicitly and is unaffected, which is what makes the
+ * mismatch look arbitrary.
+ *
+ * Called when a session settles as logged in. Flag-guarded so it costs one
+ * request per install rather than one per launch; best-effort, never surfaced.
+ */
+export async function backfillPreferredBibleVersion(): Promise<void> {
+  try {
+    if (await AsyncStorage.getItem(VERSION_BACKFILL_KEY)) return;
+    const version = await AsyncStorage.getItem(BIBLE_VERSION_KEY);
+    // Nothing stored means the user never chose one — the server default
+    // already matches, and writing it would claim a preference they never set.
+    if (!version) return;
+    if (await syncPreferredBibleVersion(version)) {
+      await AsyncStorage.setItem(VERSION_BACKFILL_KEY, 'true');
+    }
+  } catch {
+    // Best-effort; retried next launch since the flag stays unset.
+  }
+}
+
 /**
  * Reset the module-level cache. Test-only — Jest's AsyncStorage.clear()
  * doesn't touch this module's state, so without an explicit reset the

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -311,7 +311,14 @@ export function VerseOfTheDayWidget({
           <FlexWidget style={{ flex: 1, width: "match_parent", marginTop: 8 }}>
             <TextWidget
               text={explanation ?? ""}
-              maxLines={14}
+              // Deliberately far beyond any panel: a measured 4×4 cell came in
+              // at 483dp, where ~14 lines of 13sp copy is about the whole
+              // panel — so a 14 ceiling was close enough to bind again on the
+              // tallest launchers and bring the blank rows back at a rarer
+              // size. The weighted box does the clipping; this only has to be
+              // high enough never to be the constraint, and costs nothing when
+              // the copy is shorter (the API's summaries run ~6 lines).
+              maxLines={40}
               truncate="END"
               style={{
                 fontSize: 13,

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -263,12 +263,12 @@ export function VerseOfTheDayWidget({
       </FlexWidget>
 
       {/* Note block — nested rounded surface, deep-links to the explanation tab.
-          Deliberately FLAT: label, copy and link are direct siblings spaced with
-          margins. An earlier version wrapped them in an inner column and used
-          `flex: 1` + `justifyContent: "space-between"` + `flexGap`; RemoteViews
-          did not resolve that nesting, and on-device it clipped the explanation
-          mid-sentence and dropped the link entirely. Margins are predictable
-          where nested flex weights are not. */}
+          Label, copy and link are direct siblings spaced with explicit margins;
+          an earlier version used `justifyContent: "space-between"` + `flexGap`
+          here, which the library implements by injecting invisible weighted
+          spacers — on-device that clipped the explanation mid-sentence and
+          dropped the link entirely. Margins for spacing, one weighted child
+          (below) for the growth. */}
       {showNote ? (
         <FlexWidget
           style={{
@@ -294,17 +294,32 @@ export function VerseOfTheDayWidget({
               color: palette.panelLabel,
             }}
           />
-          <TextWidget
-            text={explanation ?? ""}
-            maxLines={5}
-            truncate="END"
-            style={{
-              fontSize: 13,
-              color: palette.explanation,
-              fontFamily: "serif",
-              marginTop: 8,
-            }}
-          />
+          {/* The explanation sits in its own weighted box so it uses ALL the
+              room the panel has left instead of a fixed line count. A 4×4 cell
+              is far taller on One UI than on the Pixel launcher, so any constant
+              clamps the copy while the panel still has blank rows — the reported
+              "description cutoff but more space avail." `maxLines` is a ceiling
+              now, not the binding constraint.
+
+              The weight has to sit on a FlexWidget: `flex` maps to LinearLayout
+              weight in this library and is silently dropped from TextWidget
+              styles. `height: "match_parent"` on the text is NOT a substitute —
+              a vertical LinearLayout gives a MATCH_PARENT child every remaining
+              pixel before it measures later siblings, which is what dropped the
+              link in the earlier nested-flex attempt. Weight is resolved after
+              all children are measured, so the link keeps its row. */}
+          <FlexWidget style={{ flex: 1, width: "match_parent", marginTop: 8 }}>
+            <TextWidget
+              text={explanation ?? ""}
+              maxLines={14}
+              truncate="END"
+              style={{
+                fontSize: 13,
+                color: palette.explanation,
+                fontFamily: "serif",
+              }}
+            />
+          </FlexWidget>
           <TextWidget
             text="Read the full note →"
             maxLines={1}

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -21,6 +21,13 @@ const DEFAULT_VERSION = "NASB1995";
 // (PD-7). Absent when logged out → the endpoint serves the global verse.
 const USER_ID_KEY = "widget-user-id";
 const FALLBACK_MESSAGE = "Open VerseMate to see today's verse";
+/**
+ * Last successfully fetched verse. The OS only runs the widget's update task
+ * every few hours, so without this a single failed fetch (offline at boot, API
+ * hiccup, a `date` the API rejects) left the widget showing FALLBACK_MESSAGE
+ * until the next tick — the reported "sometimes it doesn't load any content".
+ */
+const VERSE_CACHE_KEY = "widget-verse-cache";
 
 /**
  * Base for the tap deep link — the app's custom scheme (versemate://), NOT the
@@ -116,6 +123,36 @@ export interface WidgetVerseData {
   explanation: string | null;
 }
 
+interface VerseCache {
+  /** Local date the verse was fetched for, `YYYY-MM-DD`. */
+  date: string;
+  data: WidgetVerseData;
+}
+
+/** Cached verse, or null when absent, unreadable, or older than yesterday. */
+async function readCache(): Promise<VerseCache | null> {
+  try {
+    const raw = await AsyncStorage.getItem(VERSE_CACHE_KEY);
+    if (!raw) return null;
+    const cache = JSON.parse(raw) as VerseCache;
+    // Same window the API itself serves ("date must be today or yesterday"),
+    // so a device that has been offline for days shows the honest "open the
+    // app" state rather than a stale verse under a "VERSE OF THE DAY" header.
+    const ageDays = (Date.parse(localDate()) - Date.parse(cache.date)) / 86_400_000;
+    return ageDays >= 0 && ageDays <= 1 ? cache : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeCache(date: string, data: WidgetVerseData): Promise<void> {
+  try {
+    await AsyncStorage.setItem(VERSE_CACHE_KEY, JSON.stringify({ date, data }));
+  } catch {
+    // Best-effort: a failed cache write must never fail the render.
+  }
+}
+
 export async function fetchVerse(): Promise<WidgetVerseData> {
   const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
 
@@ -124,21 +161,27 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     // if its native module isn't ready yet. A throw here must fall through to
     // the rendered fallback below — never bubble out of fetchVerse, which would
     // skip the widget render and leave a blank (transparent) widget.
+    const today = localDate();
     const version =
       (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
     const pid = await AsyncStorage.getItem(USER_ID_KEY);
-    let url = `${apiBase}/bible/verse-of-the-day?date=${localDate()}&bible_version=${version}`;
+    let url = `${apiBase}/bible/verse-of-the-day?date=${today}&bible_version=${version}`;
     if (pid) url += `&pid=${encodeURIComponent(pid)}`;
     const res = await fetch(url);
     const data = (await res.json()) as VerseResponse;
     if (data.empty || !data.verses?.length) {
-      return {
-        ...emptyState(data.fallbackMessage ?? FALLBACK_MESSAGE),
-        deepLink: buildDeepLink(data.reference),
-        noteDeepLink: buildDeepLink(data.reference, NOTE_TAB),
-      };
+      // Covers a genuinely empty pool AND every error shape (e.g. the API's
+      // `invalid_date` when the device's local date runs ahead of the server's).
+      // Yesterday's verse beats an empty widget; the message is the last resort.
+      return (
+        (await readCache())?.data ?? {
+          ...emptyState(data.fallbackMessage ?? FALLBACK_MESSAGE),
+          deepLink: buildDeepLink(data.reference),
+          noteDeepLink: buildDeepLink(data.reference, NOTE_TAB),
+        }
+      );
     }
-    return {
+    const verse: WidgetVerseData = {
       verses: data.verses,
       reference: data.referenceText ?? "",
       deepLink: buildDeepLink(data.reference),
@@ -147,8 +190,10 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
       versionLabel: data.versionKey ?? "",
       explanation: data.explanation ?? null,
     };
+    await writeCache(today, verse);
+    return verse;
   } catch {
-    return emptyState(FALLBACK_MESSAGE);
+    return (await readCache())?.data ?? emptyState(FALLBACK_MESSAGE);
   }
 }
 
@@ -163,6 +208,49 @@ function emptyState(fallbackText: string): WidgetVerseData {
     versionLabel: "",
     explanation: null,
   };
+}
+
+/** Both providers the app registers (app.config.js `react-native-android-widget`). */
+const WIDGET_NAMES = ["VerseOfTheDay", NOTE_WIDGET_NAME];
+
+/**
+ * Repaint every placed widget from the app process. Called on foreground so the
+ * fallback's own instruction — "Open VerseMate to see today's verse" — is true:
+ * the OS runs the widget's own update task only every few hours, so a widget
+ * left empty by a failed fetch had no way to recover on demand.
+ *
+ * No-ops once today's verse is already cached (so a normal launch costs one
+ * AsyncStorage read, not a network call) and when no widget is on the home
+ * screen. Best-effort throughout — never let a widget failure surface in the app.
+ */
+export async function refreshWidgets(): Promise<void> {
+  try {
+    if ((await readCache())?.date === localDate()) return;
+
+    const { getWidgetInfo, requestWidgetUpdate } = await import(
+      "react-native-android-widget"
+    );
+    const placed = await Promise.all(WIDGET_NAMES.map((name) => getWidgetInfo(name)));
+    if (placed.every((widgets) => widgets.length === 0)) return;
+
+    const data = await fetchVerse();
+    await Promise.all(
+      WIDGET_NAMES.map((widgetName) =>
+        requestWidgetUpdate({
+          widgetName,
+          renderWidget: (info) => {
+            const size = pickWidgetSize(info.widgetName);
+            return {
+              light: <VerseOfTheDayWidget {...data} size={size} theme="light" />,
+              dark: <VerseOfTheDayWidget {...data} size={size} theme="dark" />,
+            };
+          },
+        }),
+      ),
+    );
+  } catch {
+    // Best-effort: widget module unavailable, no widgets placed, or draw failed.
+  }
 }
 
 export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -127,10 +127,34 @@ export interface WidgetVerseData {
   explanation: string | null;
 }
 
+/**
+ * The full identity of a cached verse, not just when it was fetched.
+ *
+ * The backend seeds its pick `${date}:${userId}` and renders it in the
+ * requested translation, so a payload is only reusable for the SAME
+ * (date, pid, version). Keying on the date alone let a verse fetched under one
+ * identity be served under another — the exact mismatch this widget was fixed
+ * to stop, one layer down: add the widget logged out (global verse cached),
+ * then log in, and the widget kept serving the global verse while the daily
+ * push carried the personal one.
+ */
 interface VerseCache {
-  /** Local date the verse was fetched for, `YYYY-MM-DD`. */
+  /** Local date the verse was fetched on, `YYYY-MM-DD`. */
   date: string;
+  /** `widget-user-id` at fetch time; null when logged out (global verse). */
+  pid: string | null;
+  /** `bible_version` the payload was rendered in. */
+  version: string;
   data: WidgetVerseData;
+}
+
+/** Whether a cached payload was fetched under the identity in effect now. */
+function matchesIdentity(
+  cache: VerseCache,
+  pid: string | null,
+  version: string,
+): boolean {
+  return cache.pid === pid && cache.version === version;
 }
 
 /** Cached verse, or null when absent, unreadable, or older than yesterday. */
@@ -149,9 +173,9 @@ async function readCache(): Promise<VerseCache | null> {
   }
 }
 
-async function writeCache(date: string, data: WidgetVerseData): Promise<void> {
+async function writeCache(cache: VerseCache): Promise<void> {
   try {
-    await AsyncStorage.setItem(VERSE_CACHE_KEY, JSON.stringify({ date, data }));
+    await AsyncStorage.setItem(VERSE_CACHE_KEY, JSON.stringify(cache));
   } catch {
     // Best-effort: a failed cache write must never fail the render.
   }
@@ -159,6 +183,12 @@ async function writeCache(date: string, data: WidgetVerseData): Promise<void> {
 
 export async function fetchVerse(): Promise<WidgetVerseData> {
   const apiBase = process.env.EXPO_PUBLIC_API_URL ?? "https://api.versemate.org";
+  // Declared out here so the catch can check the cache against the identity we
+  // were fetching for. If the throw beat the AsyncStorage reads these stay at
+  // their defaults, which simply fails the identity check — the conservative
+  // direction, since serving another user's verse is worse than the fallback.
+  let version = DEFAULT_VERSION;
+  let pid: string | null = null;
 
   try {
     // Read inside the try: in the headless widget task AsyncStorage can throw
@@ -166,9 +196,8 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     // the rendered fallback below — never bubble out of fetchVerse, which would
     // skip the widget render and leave a blank (transparent) widget.
     const today = localDate();
-    const version =
-      (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
-    const pid = await AsyncStorage.getItem(USER_ID_KEY);
+    version = (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
+    pid = await AsyncStorage.getItem(USER_ID_KEY);
     // No `date` param — deliberately. The endpoint defaults to its own
     // server-local today, which is exactly what the daily verse-of-the-day
     // push worker passes (`sendDailyVerse` → `todayServerLocal()`), and the
@@ -189,10 +218,13 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     const data = (await res.json()) as VerseResponse;
     if (data.empty || !data.verses?.length) {
       // Covers a genuinely empty pool AND every error shape (e.g. the API's
-      // `invalid_date` when the device's local date runs ahead of the server's).
-      // Yesterday's verse beats an empty widget; the message is the last resort.
+      // `invalid_date` when a client's date runs ahead of the server's).
+      // Yesterday's verse beats an empty widget — but only if it was fetched
+      // for the same user and translation, or the fallback would quietly
+      // resurrect another identity's verse. The message is the last resort.
+      const cache = await readCache();
       return (
-        (await readCache())?.data ?? {
+        (cache && matchesIdentity(cache, pid, version) ? cache.data : null) ?? {
           ...emptyState(data.fallbackMessage ?? FALLBACK_MESSAGE),
           deepLink: buildDeepLink(data.reference),
           noteDeepLink: buildDeepLink(data.reference, NOTE_TAB),
@@ -208,10 +240,14 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
       versionLabel: data.versionKey ?? "",
       explanation: data.explanation ?? null,
     };
-    await writeCache(today, verse);
+    await writeCache({ date: today, pid, version, data: verse });
     return verse;
   } catch {
-    return (await readCache())?.data ?? emptyState(FALLBACK_MESSAGE);
+    const cache = await readCache();
+    return (
+      (cache && matchesIdentity(cache, pid, version) ? cache.data : null) ??
+      emptyState(FALLBACK_MESSAGE)
+    );
   }
 }
 
@@ -237,13 +273,25 @@ const WIDGET_NAMES = ["VerseOfTheDay", NOTE_WIDGET_NAME];
  * the OS runs the widget's own update task only every few hours, so a widget
  * left empty by a failed fetch had no way to recover on demand.
  *
- * No-ops once today's verse is already cached (so a normal launch costs one
- * AsyncStorage read, not a network call) and when no widget is on the home
- * screen. Best-effort throughout — never let a widget failure surface in the app.
+ * No-ops when no widget is on the home screen, and when today's cached verse
+ * was fetched for the identity in effect right now — so a normal launch costs a
+ * couple of AsyncStorage reads rather than a network call. The identity half of
+ * that check is what makes the refresh useful rather than decorative: logging
+ * in, or switching translation, changes which verse the backend would return
+ * (it seeds its pick `${date}:${userId}`), and a date-only check would return
+ * early and leave the widget on the old one until the next OS tick.
+ *
+ * Best-effort throughout — never let a widget failure surface in the app.
  */
 export async function refreshWidgets(): Promise<void> {
   try {
-    if ((await readCache())?.date === localDate()) return;
+    const cache = await readCache();
+    if (cache?.date === localDate()) {
+      const version =
+        (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
+      const pid = await AsyncStorage.getItem(USER_ID_KEY);
+      if (matchesIdentity(cache, pid, version)) return;
+    }
 
     const { getWidgetInfo, requestWidgetUpdate } = await import(
       "react-native-android-widget"

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -90,6 +90,10 @@ export function pickWidgetSize(widgetName: string): WidgetSize {
   return widgetName === NOTE_WIDGET_NAME ? "expanded" : "compact";
 }
 
+/**
+ * Device-local date, used ONLY as the cache's freshness clock — never sent to
+ * the API. See the request in `fetchVerse` for why the `date` param is omitted.
+ */
 function localDate(): string {
   const n = new Date();
   return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(n.getDate()).padStart(2, "0")}`;
@@ -165,7 +169,21 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
     const version =
       (await AsyncStorage.getItem(BIBLE_VERSION_KEY)) ?? DEFAULT_VERSION;
     const pid = await AsyncStorage.getItem(USER_ID_KEY);
-    let url = `${apiBase}/bible/verse-of-the-day?date=${today}&bible_version=${version}`;
+    // No `date` param — deliberately. The endpoint defaults to its own
+    // server-local today, which is exactly what the daily verse-of-the-day
+    // push worker passes (`sendDailyVerse` → `todayServerLocal()`), and the
+    // pick is persisted per (date, userId) — so widget and notification
+    // resolve to the same row instead of two clocks racing.
+    //
+    // Sending the DEVICE's local date (the old behavior) broke both ways: the
+    // API only accepts today or yesterday server-local, so a device in a UTC+
+    // zone requests a date that is still tomorrow to the server and gets a
+    // 400 back — the widget then renders empty. It also meant a device whose
+    // date lagged the server's showed yesterday's verse while the push carried
+    // today's. Local-midnight rollover is the thing given up here; matching the
+    // notification is worth more, and closing the gap the other way needs
+    // per-user timezones in the push worker (a documented backend limitation).
+    let url = `${apiBase}/bible/verse-of-the-day?bible_version=${version}`;
     if (pid) url += `&pid=${encodeURIComponent(pid)}`;
     const res = await fetch(url);
     const data = (await res.json()) as VerseResponse;


### PR DESCRIPTION
Two reported Android widget bugs.

## 1 — "Sometimes it does not load any content"


`fetchVerse` caught every failure and returned the "Open VerseMate to see today's verse" fallback **with no cache**, so a single failed fetch — offline at boot, an API hiccup, a rejected date — left the widget empty until the next OS update tick, **24h away**. Nothing could heal it in between: the app never called `requestWidgetUpdate`, so the fallback's own instruction to open the app did nothing.

- Cache the last successful payload, serve it on any failure. Capped at yesterday — the same window the API serves — so a device offline for days shows the honest empty state rather than a stale verse under a "VERSE OF THE DAY" header.
- `refreshWidgets()` on app foreground, so opening the app really does repaint an empty widget. No-ops once today's verse is cached and when no widget is placed, so a normal launch costs one AsyncStorage read, not a network call.
- `updatePeriodMillis` 24h → 6h. Also fixes the verse rolling over at whatever time of day the widget last updated instead of near midnight.

### Related bug this masks but does not fix

The API answers `{"error":"invalid_date","message":"date must be today or yesterday"}` for any date outside its window, and the widget sends the **device's** local date. A device in a UTC+ zone near midnight gets that error every time. The cache now hides the symptom; the request is still wrong for those users and wants its own fix.

## 2 — "It does not use whole space even having it"

The explanation was clamped to `maxLines={5}` while its panel stretched to fill the widget, leaving blank rows below. No constant works here — a 4×4 cell is far taller on One UI than on the Pixel launcher.

The explanation now sits in its own **weighted** `FlexWidget`, with `maxLines` as a ceiling (14) rather than the binding constraint.

Two library details that rule out the simpler shapes:
- `flex` maps to LinearLayout weight **only on `FlexWidget`** — `TextWidget.convertProps` never reads it, so `flex` on the text is silently dropped.
- `height: "match_parent"` on the text is not a substitute: a vertical LinearLayout hands a MATCH_PARENT child every remaining pixel *before* measuring later siblings. That is what dropped the "Read the full note →" link in the earlier nested-flex attempt.

## Verification

Driven on an API 35 emulator through the library's own `WidgetPreview`, which renders via the same native path as the launcher (`createPreview` → `buildWidgetFromRoot` → measure `EXACTLY(w,h)` → bitmap), at 336dp wide with a long explanation:

| height | before | after |
|---|---|---|
| 420dp | 5 lines + `…`, ~7 blank rows | **all 11 lines**, link intact |
| 336dp | 5 lines + `…` | 7 lines, link intact |
| 300dp | 5 lines + `…` | 7 lines, link intact — the weighted child does not starve later siblings |

**Cosmetic tradeoff** at the smallest sizes: when the copy genuinely overflows, the final line is now cut mid-glyph rather than ellipsized, because the box fills the panel exactly and its height is not a whole number of lines. Ellipsizing cleanly would need line-height arithmetic against `widgetInfo.height`, which breaks under the user's font-scale setting.

**Heal path, verified end-to-end on an API 35 emulator:** airplane mode on → placed the 4×4 → it painted the exact reported empty state ("Open VerseMate to see today's verse"). Airplane mode off → foregrounded the app → the widget repainted with Romans 8:28 and its note. Read straight out of the content provider (`content://…/widget_17_mode_light.png`) rather than trusting the launcher, which caches bitmaps. This also exercises `refreshWidgets` with only *one* of the two providers placed, confirming `getWidgetInfo` on an unplaced provider returns empty rather than rejecting and killing the whole `Promise.all`.

The same run confirms the config landed: `dumpsys appwidget` reports `updatePeriodMillis=21600000` and `resizeMode=1`. Incidental finding — that 4×4 cell measured **483dp** tall, well past the design's 336dp, which is exactly why a fixed `maxLines` was never going to hold.

## Tests

23 passing. Cover the cache paths (serve last good verse on throw and on an API error shape; ignore a cache older than yesterday) and guard that the explanation stays inside a weighted box — moving it back out would silently restore the bug with every other test still green.


## 3 — Widget and daily push showed different verses

Found while checking whether the notification had its own verse logic. It does not: `sendDailyVerse` calls the same `DailyVerseService.getVerseOfTheDay()` the widget's endpoint calls, and the pick is **persisted** per `(date, userId)` — whichever resolves first fixes the verse and the other reads that row. There is no second selection to drift.

They diverged on the **inputs**. The pick is seeded:

```ts
const seed = userId ? `${date}:${userId}` : date;   // daily-verse.service.ts:189
```

so a mismatched `date` or `userId` is a different verse by construction. `userId === null` is the shared *global* pick; a real id gets a personal one. Three client-side fixes:

**`userId`** — the widget has no auth header and depends on the `pid` mirrored into AsyncStorage. `AuthProvider` mounts with `user = null` and the effect wrote that straight through, clearing the stored id on **every cold start** before `restoreSession` could resolve. The widget runs in its own headless process, so a fetch landing in that window sent no `pid` and got the **global** verse while the push — which always has a real user id — carried the **personal** one. Now gated on `isLoading`, so only a settled null clears.

**`date`** — the widget sent the *device's* local date; the worker uses `todayServerLocal()`. The endpoint already defaults to its own server-local today when `date` is omitted, so omitting it aligns them by construction. This also removes an outright failure: the endpoint accepts only today-or-yesterday server-local, so a device in a UTC+ zone requested a date still in the server's future, got a 400, and rendered an empty widget — the same `invalid_date` issue flagged in §1, seen from the other side.

> **Tradeoff, decided:** this gives up local-midnight rollover — the verse now turns over on the server's clock. We're taking that deliberately; matching the push is worth more than local rollover. Getting both back means per-user timezones in the push worker, which `verse-notification.queue.ts` documents as a v1 limitation ("single global tick") — a separate backend change, not a blocker here.

**`versionKey`** — changes the translation, not the verse. `setBibleVersion` only syncs server-side *on change* (GH-281), so a user who chose their translation before that shipped still has the column default `NASB1995`. The push renders from that column while the widget sends `bible_version` explicitly — which is what made the mismatch look arbitrary. Backfilled once per install when a session settles as logged in; flag-guarded, best-effort, retried next launch on failure.

### Tests

106 passing across the touched suites. New: the widget must never send a `date` (the param would silently reintroduce the split), plus the backfill's once-per-install, retry-on-failure, and never-chose-a-translation paths.

