### PR TITLE
GH-265: size the widgets from the measured cell, not a constant

### DIFF
--- a/__tests__/widgets/verse-of-the-day-widget.test.tsx
+++ b/__tests__/widgets/verse-of-the-day-widget.test.tsx
@@ -12,6 +12,8 @@
  */
 import { buildWidgetTree } from 'react-native-android-widget/src/api/build-widget-tree';
 import { VerseOfTheDayWidget } from '@/widgets/VerseOfTheDayWidget';
+import { planLayout } from '@/widgets/widget-layout';
+import { widgetStrings } from '@/widgets/widget-strings';
 
 const VERSES = [
   { verseNumber: 14, text: 'I am fearfully and wonderfully made; wonderful are Your works.' },
@@ -24,6 +26,9 @@ const BASE = {
   noteDeepLink: 'versemate:///bible/19/139?verseStart=14&src=widget&tab=summary',
   fallbackText: "Open VerseMate to see today's verse",
   versionLabel: 'NASB1995',
+  // Measured 4x4 on a Pixel emulator — the layout budget keys off this.
+  height: 483,
+  strings: widgetStrings('en'),
 } as const;
 
 /** Collect every node of a built tree, depth-first. */
@@ -63,13 +68,20 @@ describe('VerseOfTheDayWidget', () => {
     ).not.toThrow();
   });
 
-  it('clamps the compact verse to 3 lines and pins the reference row', () => {
+  // Was "clamps to 3 lines". The constant is gone on purpose: a fixed clamp is
+  // what left the compact widget with a gap on cells taller than the 148dp it
+  // was drawn for (~200dp measured on an S22 Ultra).
+  it('sizes the compact verse from the measured cell, and pins the reference row', () => {
     const tree = buildWidgetTree(<VerseOfTheDayWidget {...BASE} size="compact" theme="dark" />);
 
+    const expected = planLayout({ height: BASE.height, size: 'compact', hasNote: false });
     const verse = flatten(tree).find(
-      (n) => n.type === 'TextWidget' && (n.props as { maxLines?: number }).maxLines === 3
+      (n) =>
+        n.type === 'TextWidget' &&
+        (n.props as { maxLines?: number }).maxLines === expected.verseMaxLines
     );
     expect(verse).toBeDefined();
+    expect(expected.verseMaxLines).toBeGreaterThan(3);
     expect(texts(tree)).toEqual(expect.arrayContaining(['Psalm 139:14', '✦ VerseMate']));
     // Design: progressive disclosure — no note copy at this size.
     expect(texts(tree)).not.toContain('WHY IT MATTERS');
@@ -96,19 +108,15 @@ describe('VerseOfTheDayWidget', () => {
     // Two tap zones: the verse block → chapter, the note block → summary tab.
     expect(clickUrls(tree)).toEqual(expect.arrayContaining([BASE.deepLink, BASE.noteDeepLink]));
 
-    // The explanation must sit inside a weighted box so it grows into whatever
-    // height the launcher actually gave the widget instead of clamping to a
-    // constant. `flex` becomes `weight` only on a FlexWidget — TextWidget styles
-    // drop it silently — so a "simplification" that moves the text back out
-    // reintroduces the reported blank rows with every test still green.
-    const box = flatten(tree).find(
-      (n) =>
-        (n.props as { weight?: number }).weight === 1 &&
-        (n.children ?? []).some((c) =>
-          (c.props as { text?: string }).text?.startsWith('David pictures')
-        )
+    // The explanation's line count must come from the MEASURED cell, not a
+    // constant. A constant is what left blank rows on tall launchers; a
+    // container bound is what clipped the last line mid-glyph. Reintroducing
+    // either fails here.
+    const expected = planLayout({ height: BASE.height, size: 'expanded', hasNote: true });
+    const note = flatten(tree).find((n) =>
+      (n.props as { text?: string }).text?.startsWith('David pictures')
     );
-    expect(box).toBeDefined();
+    expect((note?.props as { maxLines?: number }).maxLines).toBe(expected.noteMaxLines);
   });
 
   it('falls back to a verse-only expanded layout when no explanation is served', () => {
@@ -116,13 +124,57 @@ describe('VerseOfTheDayWidget', () => {
       <VerseOfTheDayWidget {...BASE} size="expanded" theme="dark" explanation={null} />
     );
 
-    // No empty panel, and the verse takes the freed rows.
+    // No empty panel, and the verse takes the freed rows (AMB-001).
     expect(texts(tree)).not.toContain('WHY IT MATTERS');
     expect(texts(tree)).not.toContain('Read the full note →');
+    const noNote = planLayout({ height: BASE.height, size: 'expanded', hasNote: false });
+    const withNote = planLayout({ height: BASE.height, size: 'expanded', hasNote: true });
+    expect(noNote.verseMaxLines).toBeGreaterThan(withNote.verseMaxLines);
     const verse = flatten(tree).find(
-      (n) => n.type === 'TextWidget' && (n.props as { maxLines?: number }).maxLines === 9
+      (n) =>
+        n.type === 'TextWidget' &&
+        (n.props as { maxLines?: number }).maxLines === noNote.verseMaxLines
     );
     expect(verse).toBeDefined();
+  });
+
+  // The widget paints into a bitmap, so every word is pixels — without a
+  // content description TalkBack announces "VerseMate, image" and the verse is
+  // unreadable. This has never worked; it is not a regression guard but a
+  // first-time one.
+  it.each(['compact', 'expanded'] as const)('labels the %s widget for screen readers', (size) => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget {...BASE} size={size} theme="light" explanation="Why it matters." />
+    );
+
+    const label = (tree.props as { accessibilityLabel?: string }).accessibilityLabel ?? '';
+    expect(label).toContain('fearfully and wonderfully made');
+    expect(label).toContain('Psalm 139:14');
+  });
+
+  // Content localised long before the frame did — a Portuguese reader got a
+  // Portuguese verse in an English shell.
+  it('renders chrome in the stored language', () => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget
+        {...BASE}
+        strings={widgetStrings('pt-BR')}
+        size="expanded"
+        theme="light"
+        explanation="Por que importa."
+      />
+    );
+
+    expect(texts(tree)).toEqual(expect.arrayContaining(['VERSÍCULO DO DIA', 'POR QUE IMPORTA']));
+    expect(texts(tree)).not.toContain('VERSE OF THE DAY');
+  });
+
+  it('falls back to English when no language is stored', () => {
+    const tree = buildWidgetTree(
+      <VerseOfTheDayWidget {...BASE} strings={widgetStrings(null)} size="expanded" theme="light" />
+    );
+
+    expect(texts(tree)).toContain('VERSE OF THE DAY');
   });
 
   it('shows the fallback message with no reference when the pool is empty', () => {

--- a/__tests__/widgets/widget-layout.test.ts
+++ b/__tests__/widgets/widget-layout.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Line-budget tests for the Verse-of-the-Day widget (GH-265 UX follow-up).
+ *
+ * The budget converts a MEASURED widget height into a line count. Two
+ * properties matter more than any single number:
+ *
+ *  1. It never depends on the text. How many characters fit on a line is
+ *     language- and script-dependent (Portuguese and German average longer
+ *     words, CJK glyphs are far wider), and getting it wrong fails silently —
+ *     it looks like a layout bug. `planLayout` therefore takes no content at
+ *     all, and the tests below lock that in.
+ *  2. The worst-case stack never exceeds the cell. Overflow is what produced
+ *     the two shipped bugs in this widget: text clipped mid-glyph, and a
+ *     footer pushed out of the layout entirely.
+ */
+import { LINE_HEIGHT_FACTOR, planLayout } from '@/widgets/widget-layout';
+
+// Measured this session — see the spec's exploration.md.
+const PIXEL_4X4 = 483;
+const SAMSUNG_4X4 = 430;
+const DESIGN_4X4 = 336;
+
+describe('planLayout — expanded', () => {
+  it('gives more room on a taller cell', () => {
+    const small = planLayout({ height: DESIGN_4X4, size: 'expanded', hasNote: true });
+    const large = planLayout({ height: PIXEL_4X4, size: 'expanded', hasNote: true });
+
+    expect(large.noteMaxLines).toBeGreaterThan(small.noteMaxLines);
+  });
+
+  it('never returns fewer lines as the cell grows (monotonic)', () => {
+    let previous = 0;
+    for (let height = 250; height <= 600; height += 10) {
+      const plan = planLayout({ height, size: 'expanded', hasNote: true });
+      const total = plan.verseMaxLines + plan.noteMaxLines;
+      expect(total).toBeGreaterThanOrEqual(previous);
+      previous = total;
+    }
+  });
+
+  // The property that protects the language-independence decision. If someone
+  // reintroduces a chars-per-line estimate, the signature has to change and
+  // this stops compiling — which is the point.
+  it('depends only on height and composition, never on the text', () => {
+    const a = planLayout({ height: SAMSUNG_4X4, size: 'expanded', hasNote: true });
+    const b = planLayout({ height: SAMSUNG_4X4, size: 'expanded', hasNote: true });
+
+    expect(a).toEqual(b);
+    expect(Object.keys(a).sort()).toEqual(['noteMaxLines', 'showTags', 'verseMaxLines'].sort());
+  });
+
+  // Overflow is the failure mode that shipped twice. The worst case is every
+  // block rendering to its full allocation at once.
+  it('worst-case stack fits inside the measured cell', () => {
+    for (const height of [DESIGN_4X4, SAMSUNG_4X4, PIXEL_4X4, 250, 600]) {
+      const plan = planLayout({ height, size: 'expanded', hasNote: true });
+      const used =
+        plan.verseMaxLines * 16 * LINE_HEIGHT_FACTOR + plan.noteMaxLines * 13 * LINE_HEIGHT_FACTOR;
+      expect(used).toBeLessThanOrEqual(height);
+    }
+  });
+
+  it('keeps a legible minimum on a cell smaller than the design', () => {
+    const plan = planLayout({ height: 200, size: 'expanded', hasNote: true });
+
+    expect(plan.verseMaxLines).toBeGreaterThanOrEqual(2);
+    expect(plan.noteMaxLines).toBeGreaterThanOrEqual(2);
+  });
+
+  it('gives the note nothing when the API served no summary', () => {
+    const plan = planLayout({ height: PIXEL_4X4, size: 'expanded', hasNote: false });
+
+    expect(plan.noteMaxLines).toBe(0);
+    // AMB-001: with no note to promote, the verse takes the freed rows.
+    const withNote = planLayout({ height: PIXEL_4X4, size: 'expanded', hasNote: true });
+    expect(plan.verseMaxLines).toBeGreaterThan(withNote.verseMaxLines);
+  });
+
+  it('only offers tags once the cell is genuinely large', () => {
+    expect(planLayout({ height: DESIGN_4X4, size: 'expanded', hasNote: true }).showTags).toBe(
+      false
+    );
+    expect(planLayout({ height: PIXEL_4X4, size: 'expanded', hasNote: true }).showTags).toBe(true);
+  });
+});
+
+// Half the original report. The first draft of the spec ignored compact
+// entirely; the user's screenshot showed it just as empty as expanded.
+describe('planLayout — compact', () => {
+  it('grows the verse into a taller-than-designed cell', () => {
+    const design = planLayout({ height: 148, size: 'compact', hasNote: false });
+    const real = planLayout({ height: 200, size: 'compact', hasNote: false });
+
+    expect(real.verseMaxLines).toBeGreaterThan(design.verseMaxLines);
+  });
+
+  it('never shows a note or tags', () => {
+    const plan = planLayout({ height: 260, size: 'compact', hasNote: true });
+
+    expect(plan.noteMaxLines).toBe(0);
+    expect(plan.showTags).toBe(false);
+  });
+
+  it('worst-case stack fits inside the measured cell', () => {
+    for (const height of [148, 200, 260]) {
+      const plan = planLayout({ height, size: 'compact', hasNote: false });
+      expect(plan.verseMaxLines * 15 * LINE_HEIGHT_FACTOR).toBeLessThanOrEqual(height);
+    }
+  });
+});

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ import {
 import { clearTokenCache } from '@/lib/api/client-interceptors';
 import { analytics, AnalyticsEvent } from '@/lib/analytics';
 import { backfillPreferredBibleVersion } from '@/hooks/use-bible-version';
-import { syncWidgetUserId } from '@/hooks/use-shared-widget-prefs';
+import { syncWidgetStrings, syncWidgetUserId } from '@/hooks/use-shared-widget-prefs';
 import { unregisterPushOnLogout } from '@/lib/notifications/push-registration';
 import {
   getAuthSession,
@@ -239,6 +239,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     // `user.preferred_bible_version`, which is only written on change, so a
     // translation chosen before that sync existed never reached the server.
     if (widgetUserId) void backfillPreferredBibleVersion();
+    // Mirror the resolved widget chrome for iOS, whose widget process cannot
+    // reach the JS locale catalogs. Android reads them directly.
+    void AsyncStorage.getItem('@versemate:preferred_language').then(syncWidgetStrings);
   }, [widgetUserId, isLoading]);
 
   /**

--- a/hooks/use-shared-widget-prefs.ts
+++ b/hooks/use-shared-widget-prefs.ts
@@ -9,9 +9,12 @@
  *
  * Authored without an Apple toolchain — verify the App Group writes on device.
  */
+import { ExtensionStorage } from '@bacons/apple-targets';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Platform } from 'react-native';
 import SharedGroupPreferences from 'react-native-shared-group-preferences';
+
+import { widgetStrings } from '@/widgets/widget-strings';
 
 const APP_GROUP = 'group.org.versemate.app';
 const VERSION_KEY = 'preferred_bible_version';
@@ -21,12 +24,58 @@ const VERSION_KEY = 'preferred_bible_version';
 // (PD-7). Cleared on logout so the widget reverts to the global verse.
 const USER_ID_ASYNC_KEY = 'widget-user-id';
 const USER_ID_GROUP_KEY = 'widget_user_id';
+// Pre-resolved widget chrome. The iOS widget is a separate Swift process and
+// cannot reach the JS catalogs, so the app resolves and mirrors them; Android
+// reads the catalogs directly in its headless task (widgets/widget-strings.ts).
+const STRINGS_GROUP_KEY = 'widget_strings';
+
+/**
+ * Ask WidgetKit to rebuild the widget's timeline now.
+ *
+ * Without this an identity change — signing in, switching translation — takes
+ * up to 6h to reach the iOS widget, because its timeline policy is the only
+ * refresh trigger. Android repaints on app foreground instead.
+ *
+ * No native module needed: `@bacons/apple-targets`, already a dependency for
+ * the widget target itself, exposes WidgetCenter for exactly this. iOS-only and
+ * best-effort — a failed reload must never surface in the app.
+ */
+function reloadIosWidget(): void {
+  if (Platform.OS !== 'ios') return;
+  try {
+    ExtensionStorage.reloadWidget();
+  } catch (error) {
+    if (__DEV__) console.warn('[widget] reload failed:', error);
+  }
+}
+
+/**
+ * Mirror the resolved chrome for a language into the App Group.
+ *
+ * Called whenever the app's language changes and on session restore, so the
+ * widget's frame matches the app's. Falls back to English when the key was
+ * never written — the same limitation that already applies to version and pid.
+ */
+export async function syncWidgetStrings(languageCode: string | null): Promise<void> {
+  if (Platform.OS !== 'ios') return;
+  try {
+    await SharedGroupPreferences.setItem(
+      STRINGS_GROUP_KEY,
+      JSON.stringify(widgetStrings(languageCode)),
+      APP_GROUP
+    );
+    reloadIosWidget();
+  } catch (error) {
+    if (__DEV__) console.warn('[widget] failed to sync strings:', error);
+  }
+}
 
 export async function syncWidgetBibleVersion(version: string): Promise<void> {
   // iOS-only: Android's widget reads AsyncStorage in its own JS task handler.
   if (Platform.OS !== 'ios') return;
   try {
     await SharedGroupPreferences.setItem(VERSION_KEY, version, APP_GROUP);
+    reloadIosWidget();
   } catch (error) {
     if (__DEV__) {
       console.warn('[widget] failed to sync Bible version to App Group:', error);
@@ -53,6 +102,7 @@ export async function syncWidgetUserId(userId: string | null): Promise<void> {
     if (Platform.OS === 'ios') {
       // No delete API — store empty string to represent "no user".
       await SharedGroupPreferences.setItem(USER_ID_GROUP_KEY, userId ?? '', APP_GROUP);
+      reloadIosWidget();
     }
   } catch (error) {
     if (__DEV__) {

--- a/locales/de.json
+++ b/locales/de.json
@@ -5,7 +5,6 @@
     "version": "1.0.0",
     "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
   },
-
   "auth": {
     "login": {
       "title": "Anmelden",
@@ -38,14 +37,12 @@
       "network_error": "Netzwerkfehler. Überprüfe deine Verbindung."
     }
   },
-
   "onboarding": {
     "skip": "Überspringen",
     "next": "Weiter",
     "get_started": "Loslegen",
     "login": "Anmelden"
   },
-
   "settings": {
     "title": "Einstellungen",
     "account": "Konto",
@@ -89,7 +86,6 @@
       "save_language": "Spracheinstellung konnte nicht gespeichert werden"
     }
   },
-
   "chapter_reader": {
     "loading": "Kapitel wird geladen…",
     "error": "Dieses Kapitel konnte nicht geladen werden. Tippe zum Wiederholen.",
@@ -101,7 +97,6 @@
     "no_translation_available": "Englisch wird angezeigt (keine Übersetzung verfügbar)",
     "offline_indicator": "Offline — zwischengespeicherte Inhalte werden angezeigt"
   },
-
   "bookmarks": {
     "title": "Lesezeichen",
     "empty": "Noch keine Lesezeichen. Tippe beim Lesen auf das Lesezeichen-Symbol.",
@@ -111,7 +106,6 @@
     "login_subtitle": "Melde dich an, um deine Lieblings-Bibelkapitel zu speichern und abzurufen",
     "remove_confirm": "Dieses Lesezeichen entfernen?"
   },
-
   "highlights": {
     "title": "Markierungen",
     "empty": "Noch keine Markierungen. Halte einen Vers gedrückt und wähle eine Farbe.",
@@ -121,7 +115,6 @@
     "my_highlights": "Meine Markierungen",
     "remove_confirm": "Diese Markierung entfernen?"
   },
-
   "notes": {
     "title": "Notizen",
     "empty": "Noch keine Notizen. Tippe auf einen Vers, um eine hinzuzufügen.",
@@ -136,7 +129,6 @@
     "cancel": "Abbrechen",
     "placeholder": "Notiz schreiben…"
   },
-
   "sharing": {
     "chapter": {
       "title": "{{book}} {{chapter}}",
@@ -151,7 +143,6 @@
       "body": "Eine Notiz, die ich zu {{book}} {{chapter}} gemacht habe:\n\n\"{{content}}\"\n\n{{url}}"
     }
   },
-
   "common": {
     "ok": "OK",
     "cancel": "Abbrechen",
@@ -167,7 +158,6 @@
     "error_title": "Fehler",
     "unknown_error": "Unbekannter Fehler"
   },
-
   "names_of_god": {
     "title": "Namen Gottes",
     "testament_ot": "Altes Testament",
@@ -190,5 +180,11 @@
     "filter_all": "Alle",
     "names_count": "{{count}} Namen",
     "no_results": "Kein Name entspricht deiner Suche."
+  },
+  "widget": {
+    "eyebrow": "VERS DES TAGES",
+    "why": "WARUM ES WICHTIG IST",
+    "readNote": "Ganze Notiz lesen →",
+    "fallback": "Öffne VerseMate für den heutigen Vers"
   }
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -5,7 +5,6 @@
     "version": "1.0.0",
     "note": "Source-of-truth catalog. Per spec feat-mobile-ui-i18n (D-016). Engineer-edited; other locales translated from this."
   },
-
   "auth": {
     "login": {
       "title": "Sign In",
@@ -38,14 +37,12 @@
       "network_error": "Network error. Check your connection."
     }
   },
-
   "onboarding": {
     "skip": "Skip",
     "next": "Next",
     "get_started": "Get Started",
     "login": "Log In"
   },
-
   "settings": {
     "title": "Settings",
     "account": "Account",
@@ -89,7 +86,6 @@
       "save_language": "Failed to save language preference"
     }
   },
-
   "chapter_reader": {
     "loading": "Loading chapter…",
     "error": "Couldn't load this chapter. Tap to retry.",
@@ -101,7 +97,6 @@
     "no_translation_available": "Showing English (no translation available)",
     "offline_indicator": "Offline — showing cached content"
   },
-
   "bookmarks": {
     "title": "Bookmarks",
     "empty": "No bookmarks yet. Tap the bookmark icon while reading.",
@@ -111,7 +106,6 @@
     "login_subtitle": "Sign in to save and access your favorite Bible chapters",
     "remove_confirm": "Remove this bookmark?"
   },
-
   "highlights": {
     "title": "Highlights",
     "empty": "No highlights yet. Long-press a verse and pick a color.",
@@ -121,7 +115,6 @@
     "my_highlights": "My Highlights",
     "remove_confirm": "Remove this highlight?"
   },
-
   "notes": {
     "title": "Notes",
     "empty": "No notes yet. Tap a verse to add one.",
@@ -136,7 +129,6 @@
     "cancel": "Cancel",
     "placeholder": "Write your note…"
   },
-
   "sharing": {
     "chapter": {
       "title": "{{book}} {{chapter}}",
@@ -151,7 +143,6 @@
       "body": "A note I made on {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
     }
   },
-
   "common": {
     "ok": "OK",
     "cancel": "Cancel",
@@ -167,7 +158,6 @@
     "error_title": "Error",
     "unknown_error": "Unknown error"
   },
-
   "names_of_god": {
     "title": "Names of God",
     "testament_ot": "Old Testament",
@@ -190,5 +180,11 @@
     "filter_all": "All",
     "names_count": "{{count}} names",
     "no_results": "No names match your search."
+  },
+  "widget": {
+    "eyebrow": "VERSE OF THE DAY",
+    "why": "WHY IT MATTERS",
+    "readNote": "Read the full note →",
+    "fallback": "Open VerseMate to see today's verse"
   }
 }

--- a/locales/es.json
+++ b/locales/es.json
@@ -5,7 +5,6 @@
     "version": "1.0.0",
     "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
   },
-
   "auth": {
     "login": {
       "title": "Iniciar sesión",
@@ -38,14 +37,12 @@
       "network_error": "Error de red. Comprueba tu conexión."
     }
   },
-
   "onboarding": {
     "skip": "Omitir",
     "next": "Siguiente",
     "get_started": "Comenzar",
     "login": "Iniciar sesión"
   },
-
   "settings": {
     "title": "Ajustes",
     "account": "Cuenta",
@@ -89,7 +86,6 @@
       "save_language": "Error al guardar la preferencia de idioma"
     }
   },
-
   "chapter_reader": {
     "loading": "Cargando capítulo…",
     "error": "No se pudo cargar este capítulo. Toca para reintentar.",
@@ -101,7 +97,6 @@
     "no_translation_available": "Mostrando en inglés (traducción no disponible)",
     "offline_indicator": "Sin conexión — mostrando contenido en caché"
   },
-
   "bookmarks": {
     "title": "Marcadores",
     "empty": "Aún no hay marcadores. Toca el ícono de marcador mientras lees.",
@@ -111,7 +106,6 @@
     "login_subtitle": "Inicia sesión para guardar y acceder a tus capítulos favoritos de la Biblia",
     "remove_confirm": "¿Eliminar este marcador?"
   },
-
   "highlights": {
     "title": "Resaltados",
     "empty": "Aún no hay resaltados. Mantén presionado un versículo y elige un color.",
@@ -121,7 +115,6 @@
     "my_highlights": "Mis resaltados",
     "remove_confirm": "¿Eliminar este resaltado?"
   },
-
   "notes": {
     "title": "Notas",
     "empty": "Aún no hay notas. Toca un versículo para añadir una.",
@@ -136,7 +129,6 @@
     "cancel": "Cancelar",
     "placeholder": "Escribe tu nota…"
   },
-
   "sharing": {
     "chapter": {
       "title": "{{book}} {{chapter}}",
@@ -151,7 +143,6 @@
       "body": "Una nota que hice sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
     }
   },
-
   "common": {
     "ok": "Aceptar",
     "cancel": "Cancelar",
@@ -167,7 +158,6 @@
     "error_title": "Error",
     "unknown_error": "Error desconocido"
   },
-
   "names_of_god": {
     "title": "Nombres de Dios",
     "testament_ot": "Antiguo Testamento",
@@ -190,5 +180,11 @@
     "filter_all": "Todos",
     "names_count": "{{count}} nombres",
     "no_results": "Ningún nombre coincide con tu búsqueda."
+  },
+  "widget": {
+    "eyebrow": "VERSÍCULO DEL DÍA",
+    "why": "POR QUÉ IMPORTA",
+    "readNote": "Leer la nota completa →",
+    "fallback": "Abre VerseMate para ver el versículo de hoy"
   }
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -5,7 +5,6 @@
     "version": "1.0.0",
     "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
   },
-
   "auth": {
     "login": {
       "title": "Connexion",
@@ -38,14 +37,12 @@
       "network_error": "Erreur réseau. Vérifiez votre connexion."
     }
   },
-
   "onboarding": {
     "skip": "Passer",
     "next": "Suivant",
     "get_started": "Commencer",
     "login": "Se connecter"
   },
-
   "settings": {
     "title": "Paramètres",
     "account": "Compte",
@@ -89,7 +86,6 @@
       "save_language": "Échec de l'enregistrement de la préférence de langue"
     }
   },
-
   "chapter_reader": {
     "loading": "Chargement du chapitre…",
     "error": "Impossible de charger ce chapitre. Appuyez pour réessayer.",
@@ -101,7 +97,6 @@
     "no_translation_available": "Affichage en anglais (aucune traduction disponible)",
     "offline_indicator": "Hors ligne — affichage du contenu mis en cache"
   },
-
   "bookmarks": {
     "title": "Signets",
     "empty": "Aucun signet pour l'instant. Appuyez sur l'icône de signet pendant la lecture.",
@@ -111,7 +106,6 @@
     "login_subtitle": "Connectez-vous pour sauvegarder et accéder à vos chapitres bibliques favoris",
     "remove_confirm": "Supprimer ce signet ?"
   },
-
   "highlights": {
     "title": "Surlignages",
     "empty": "Aucun surlignage pour l'instant. Appuyez longuement sur un verset et choisissez une couleur.",
@@ -121,7 +115,6 @@
     "my_highlights": "Mes surlignages",
     "remove_confirm": "Supprimer ce surlignage ?"
   },
-
   "notes": {
     "title": "Notes",
     "empty": "Aucune note pour l'instant. Appuyez sur un verset pour en ajouter une.",
@@ -136,7 +129,6 @@
     "cancel": "Annuler",
     "placeholder": "Rédigez votre note…"
   },
-
   "sharing": {
     "chapter": {
       "title": "{{book}} {{chapter}}",
@@ -151,7 +143,6 @@
       "body": "Une note que j'ai faite sur {{book}} {{chapter}} :\n\n\"{{content}}\"\n\n{{url}}"
     }
   },
-
   "common": {
     "ok": "OK",
     "cancel": "Annuler",
@@ -167,7 +158,6 @@
     "error_title": "Erreur",
     "unknown_error": "Erreur inconnue"
   },
-
   "names_of_god": {
     "title": "Noms de Dieu",
     "testament_ot": "Ancien Testament",
@@ -190,5 +180,11 @@
     "filter_all": "Tous",
     "names_count": "{{count}} noms",
     "no_results": "Aucun nom ne correspond à votre recherche."
+  },
+  "widget": {
+    "eyebrow": "VERSET DU JOUR",
+    "why": "POURQUOI C'EST IMPORTANT",
+    "readNote": "Lire la note complète →",
+    "fallback": "Ouvre VerseMate pour voir le verset du jour"
   }
 }

--- a/locales/pt.json
+++ b/locales/pt.json
@@ -5,7 +5,6 @@
     "version": "1.0.0",
     "note": "Translated from en.json. Per spec feat-mobile-ui-i18n (D-016)."
   },
-
   "auth": {
     "login": {
       "title": "Entrar",
@@ -38,14 +37,12 @@
       "network_error": "Erro de rede. Verifique sua conexão."
     }
   },
-
   "onboarding": {
     "skip": "Pular",
     "next": "Próximo",
     "get_started": "Começar",
     "login": "Entrar"
   },
-
   "settings": {
     "title": "Configurações",
     "account": "Conta",
@@ -89,7 +86,6 @@
       "save_language": "Falha ao salvar a preferência de idioma"
     }
   },
-
   "chapter_reader": {
     "loading": "Carregando capítulo…",
     "error": "Não foi possível carregar este capítulo. Toque para tentar novamente.",
@@ -101,7 +97,6 @@
     "no_translation_available": "Exibindo em inglês (tradução não disponível)",
     "offline_indicator": "Offline — exibindo conteúdo em cache"
   },
-
   "bookmarks": {
     "title": "Favoritos",
     "empty": "Ainda sem favoritos. Toque no ícone de favorito durante a leitura.",
@@ -111,7 +106,6 @@
     "login_subtitle": "Entre para salvar e acessar seus capítulos bíblicos favoritos",
     "remove_confirm": "Remover este favorito?"
   },
-
   "highlights": {
     "title": "Destaques",
     "empty": "Ainda sem destaques. Pressione um versículo e escolha uma cor.",
@@ -121,7 +115,6 @@
     "my_highlights": "Meus destaques",
     "remove_confirm": "Remover este destaque?"
   },
-
   "notes": {
     "title": "Notas",
     "empty": "Ainda sem notas. Toque em um versículo para adicionar uma.",
@@ -136,7 +129,6 @@
     "cancel": "Cancelar",
     "placeholder": "Escreva sua nota…"
   },
-
   "sharing": {
     "chapter": {
       "title": "{{book}} {{chapter}}",
@@ -151,7 +143,6 @@
       "body": "Uma nota que fiz sobre {{book}} {{chapter}}:\n\n\"{{content}}\"\n\n{{url}}"
     }
   },
-
   "common": {
     "ok": "OK",
     "cancel": "Cancelar",
@@ -167,7 +158,6 @@
     "error_title": "Erro",
     "unknown_error": "Erro desconhecido"
   },
-
   "names_of_god": {
     "title": "Nomes de Deus",
     "testament_ot": "Antigo Testamento",
@@ -190,5 +180,11 @@
     "filter_all": "Todos",
     "names_count": "{{count}} nomes",
     "no_results": "Nenhum nome corresponde à sua pesquisa."
+  },
+  "widget": {
+    "eyebrow": "VERSÍCULO DO DIA",
+    "why": "POR QUE IMPORTA",
+    "readNote": "Ler a nota completa →",
+    "fallback": "Abra o VerseMate para ver o versículo de hoje"
   }
 }

--- a/targets/widget/index.swift
+++ b/targets/widget/index.swift
@@ -50,6 +50,10 @@ private let userIdDefaultsKey = "widget_user_id"
 // CachedVerse). A fresh key rather than a migration — the old value decodes to
 // nothing, which simply looks like a cold cache for one refresh.
 private let cacheKey = "votd_last_response_v2"
+// Pre-resolved widget chrome, mirrored by the app (hooks/use-shared-widget-prefs.ts).
+// This extension is a separate process and cannot reach the JS locale catalogs,
+// so the app resolves them and writes the result here.
+private let stringsDefaultsKey = "widget_strings"
 private let apiBaseURL = "https://api.versemate.org"
 // KNOWN PROD-ONLY CONSTANT (GH-265 / L-003): the iOS widget extension is a
 // separate process and cannot read the JS `EXPO_PUBLIC_WEB_URL` at runtime, so
@@ -107,6 +111,24 @@ private func personalizationId() -> String? {
 
 /// Device-local date, used ONLY as the cache's staleness clock — never sent to
 /// the API. See `fetchVerseOfTheDay` for why the `date` param is omitted.
+/// Localised chrome. English is the floor: the key is absent until the app has
+/// run at least once, which is the same limitation that already applies to the
+/// preferred translation and the personalization id.
+struct WidgetStrings: Codable {
+  var eyebrow: String = "VERSE OF THE DAY"
+  var why: String = "WHY IT MATTERS"
+  var readNote: String = "Read the full note →"
+  var fallback: String = "Open VerseMate to see today's verse"
+}
+
+private func widgetStrings() -> WidgetStrings {
+  guard let raw = sharedDefaults()?.string(forKey: stringsDefaultsKey),
+    let data = raw.data(using: .utf8),
+    let decoded = try? JSONDecoder().decode(WidgetStrings.self, from: data)
+  else { return WidgetStrings() }
+  return decoded
+}
+
 private func localDateString() -> String {
   let f = DateFormatter()
   f.dateFormat = "yyyy-MM-dd"
@@ -359,6 +381,16 @@ struct VerseOfTheDayWidgetView: View {
   let entry: VerseEntry
 
   private var palette: Palette { colorScheme == .dark ? .dark : .light }
+  /// Localised chrome, read fresh so a language change picked up by the next
+  /// timeline reload takes effect without any extra plumbing.
+  private var strings: WidgetStrings { widgetStrings() }
+
+  /// What VoiceOver reads. The widget is a SwiftUI view rather than a bitmap
+  /// here, so the default would be the concatenated subviews — but the reading
+  /// order across the two zones is not obvious, so state it explicitly.
+  private var accessibilitySummary: String {
+    isFallback ? verseText : "\(strings.eyebrow). \(verseText) \(reference)"
+  }
 
   private var isFallback: Bool {
     guard let v = entry.verse, v.empty == false, let verses = v.verses else { return true }
@@ -367,7 +399,7 @@ struct VerseOfTheDayWidgetView: View {
 
   private var verseText: String {
     guard let v = entry.verse, v.empty == false, let verses = v.verses, !verses.isEmpty else {
-      return entry.verse?.fallbackMessage ?? "Open VerseMate to see today's verse"
+      return entry.verse?.fallbackMessage ?? strings.fallback
     }
     return verses.map { $0.text }.joined(separator: " ")
   }
@@ -405,6 +437,10 @@ struct VerseOfTheDayWidgetView: View {
       // for its own region with a Link (design: "Android allows a few regions,
       // iOS uses Link").
       .widgetURL(chapterURL)
+      // One coherent announcement instead of VoiceOver walking the eyebrow,
+      // verse, reference and wordmark as four unrelated fragments.
+      .accessibilityElement(children: .ignore)
+      .accessibilityLabel(accessibilitySummary)
   }
 
   @ViewBuilder
@@ -461,7 +497,7 @@ struct VerseOfTheDayWidgetView: View {
 
       VStack(alignment: .leading, spacing: 0) {
         HStack {
-          Eyebrow(text: "VERSE OF THE DAY", color: palette.eyebrow)
+          Eyebrow(text: strings.eyebrow, color: palette.eyebrow)
           Spacer()
           Text(versionLabel)
             .font(.system(size: 10))
@@ -512,7 +548,7 @@ struct VerseOfTheDayWidgetView: View {
   private var verseZone: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack {
-        Eyebrow(text: "VERSE OF THE DAY", color: palette.largeEyebrow)
+        Eyebrow(text: strings.eyebrow, color: palette.largeEyebrow)
         Spacer()
         Text(dateAndVersion)
           .font(.system(size: 10))
@@ -521,7 +557,11 @@ struct VerseOfTheDayWidgetView: View {
       }
       Text(verseText)
         // Without the note zone the verse owns the freed rows.
-        .lineLimit(explanation == nil ? 12 : 4)
+        // Raised with the server cap (220 -> 800). systemLarge is a fixed
+        // 364x382pt, so unlike Android these can be exact constants — SwiftUI
+        // ellipsizes cleanly at a line limit, so over-allocating only ever
+        // truncates, never clips mid-glyph.
+        .lineLimit(explanation == nil ? 14 : 5)
         .font(serif(17))
         .truncationMode(.tail)
         .foregroundColor(palette.verseText)
@@ -548,10 +588,11 @@ struct VerseOfTheDayWidgetView: View {
 
   private func noteZone(_ explanation: String) -> some View {
     VStack(alignment: .leading, spacing: 8) {
-      Eyebrow(text: "WHY IT MATTERS", color: palette.eyebrow)
+      Eyebrow(text: strings.why, color: palette.eyebrow)
       Text(explanation)
         .font(serif(13, .light))
-        .lineLimit(6)
+        // Was 6 against a 220-char server clamp; real summaries run to 606.
+        .lineLimit(9)
         .truncationMode(.tail)
         .foregroundColor(palette.explanation)
       Spacer(minLength: 0)
@@ -560,7 +601,7 @@ struct VerseOfTheDayWidgetView: View {
           .fill(palette.footerHairline)
           .frame(height: 1)
         HStack {
-          Text("Read the full note →")
+          Text(strings.readNote)
             .font(.system(size: 11, weight: .medium))
             .foregroundColor(palette.gold)
             .lineLimit(1)

--- a/widgets/VerseOfTheDayWidget.tsx
+++ b/widgets/VerseOfTheDayWidget.tsx
@@ -17,6 +17,8 @@
  * so every day's verse occupies the same slots regardless of length.
  */
 import { FlexWidget, TextWidget } from "react-native-android-widget";
+import { planLayout } from "./widget-layout";
+import type { WidgetStrings } from "./widget-strings";
 
 export interface VerseData {
   verseNumber: number;
@@ -40,11 +42,23 @@ export interface VerseOfTheDayWidgetProps {
   /** Which composition to paint, derived from the host cell size. */
   size?: WidgetSize;
   /**
-   * Short "why it matters" summary (≤220 chars per the design). Only the
-   * `expanded` size has room for it; when absent that size paints a verse-only
-   * composition rather than an empty panel.
+   * Short "why it matters" summary. Only the `expanded` size has room for it;
+   * when absent that size paints a verse-only composition rather than an empty
+   * panel. No longer server-clamped to 220 chars — the client decides what fits
+   * from `height` (GH-265 UX follow-up).
    */
   explanation?: string | null;
+  /**
+   * MEASURED cell height in dp (`props.widgetInfo.height`). Drives every line
+   * count below. Trustworthy only while the providers stay `resizeMode:
+   * "horizontal"` — min and max height are equal there, so the reported max IS
+   * the cell. Re-enabling vertical resize silently invalidates all of it.
+   */
+  height: number;
+  /** Localised chrome; see widget-strings.ts for why this is not i18next. */
+  strings: WidgetStrings;
+  /** Topic tags from the API, e.g. ["faith","hope"]. Shown only on large cells. */
+  tags?: string[];
   /** Deep link for the explanation tab; used by the note block's tap zone. */
   noteDeepLink?: string;
   /** Translation label shown in the expanded header, e.g. "NASB1995". */
@@ -140,6 +154,42 @@ function footerRow(reference: string, palette: Palette, referenceSize: number) {
   );
 }
 
+/**
+ * Topic chips for the largest cells only — the last rung of the content ladder.
+ *
+ * A PLAIN FUNCTION for the same reason as footerRow: anything rendered through
+ * buildWidgetTree that is a React component gets instrumented with useMemoCache,
+ * which throws with no React dispatcher and silently paints the fallback tree.
+ */
+function tagRow(tags: string[], palette: Palette) {
+  return (
+    <FlexWidget
+      style={{
+        flexDirection: "row",
+        width: "match_parent",
+        flexGap: 6,
+        marginTop: 10,
+      }}
+    >
+      {tags.slice(0, 3).map((tag) => (
+        <TextWidget
+          key={tag}
+          text={tag}
+          maxLines={1}
+          style={{
+            fontSize: 10,
+            color: palette.eyebrow,
+            backgroundColor: palette.panel,
+            paddingHorizontal: 8,
+            paddingVertical: 3,
+            borderRadius: 10,
+          }}
+        />
+      ))}
+    </FlexWidget>
+  );
+}
+
 export function VerseOfTheDayWidget({
   verses,
   reference,
@@ -150,6 +200,9 @@ export function VerseOfTheDayWidget({
   explanation,
   noteDeepLink,
   versionLabel,
+  height,
+  strings,
+  tags,
 }: VerseOfTheDayWidgetProps) {
   // React Compiler (app.config.js `experiments.reactCompiler`) instruments this
   // component with a `useMemoCache` call. react-native-android-widget renders
@@ -171,6 +224,18 @@ export function VerseOfTheDayWidget({
   // size paints a verse-only composition instead of an empty surface.
   const showNote = size === "expanded" && !isFallback && !!explanation;
 
+  // Line counts come from the MEASURED cell, never from the text — see
+  // widget-layout.ts for why counting characters is the wrong instrument.
+  const plan = planLayout({ height, size, hasNote: showNote });
+  const showTags = plan.showTags && !isFallback && !!tags?.length;
+
+  // Screen readers see a bitmap in an ImageView — every word here is painted
+  // pixels, so without this the widget announces as "VerseMate, image" and the
+  // verse is simply unreadable. The library maps this to setContentDescription.
+  const a11y = isFallback
+    ? fallbackText
+    : `${strings.eyebrow}. ${bodyText} ${reference}`;
+
   const surface = {
     height: "match_parent",
     width: "match_parent",
@@ -187,16 +252,23 @@ export function VerseOfTheDayWidget({
       <FlexWidget
         style={{
           ...surface,
-          justifyContent: isFallback ? "center" : "space-between",
+          // Centred, not space-between. A pinned footer on a cell taller than
+          // the design (measured ~200dp against 148dp) parks the verse at the
+          // top and the reference at the bottom with a hole between them —
+          // half of the original bug report. Centring lets the layout engine
+          // distribute slack around the real rendered heights, which is the
+          // only way to do it without measuring text.
+          justifyContent: "center",
           paddingVertical: 16,
           paddingHorizontal: 18,
         }}
         clickAction="OPEN_VERSE"
         clickActionData={{ url: deepLink }}
+        accessibilityLabel={a11y}
       >
         <TextWidget
           text={bodyText}
-          maxLines={3}
+          maxLines={plan.verseMaxLines}
           truncate="END"
           style={{ fontSize: 15, color: palette.verseText, fontFamily: "serif" }}
         />
@@ -208,7 +280,17 @@ export function VerseOfTheDayWidget({
   }
 
   return (
-    <FlexWidget style={surface}>
+    <FlexWidget
+      style={{
+        ...surface,
+        // Same reasoning as compact: blocks hug their real content and the root
+        // centres them, so leftover space becomes symmetric framing rather than
+        // a hole. The median summary is 234 chars against ~11 lines of room, so
+        // "content shorter than the cell" is the common case, not the edge.
+        justifyContent: "center",
+      }}
+      accessibilityLabel={a11y}
+    >
       {/* Verse block — its own tap zone, deep-links to the chapter. */}
       <FlexWidget
         style={{
@@ -218,8 +300,6 @@ export function VerseOfTheDayWidget({
           paddingTop: 18,
           paddingHorizontal: 18,
           paddingBottom: 14,
-          // Without the note panel this block owns the whole surface.
-          ...(showNote ? {} : { flex: 1 }),
         }}
         clickAction="OPEN_VERSE"
         clickActionData={{ url: deepLink }}
@@ -233,7 +313,7 @@ export function VerseOfTheDayWidget({
           }}
         >
           <TextWidget
-            text="VERSE OF THE DAY"
+            text={strings.eyebrow}
             maxLines={1}
             style={{
               fontSize: 9,
@@ -251,8 +331,9 @@ export function VerseOfTheDayWidget({
 
         <TextWidget
           text={bodyText}
-          // Without the note panel the verse takes the freed rows.
-          maxLines={showNote ? 4 : 9}
+          // From the measured cell, not a constant. With no note to promote
+          // into the slack, the budget hands those rows to the verse instead.
+          maxLines={plan.verseMaxLines}
           truncate="END"
           style={{ fontSize: 16, color: palette.verseText, fontFamily: "serif" }}
         />
@@ -272,7 +353,9 @@ export function VerseOfTheDayWidget({
       {showNote ? (
         <FlexWidget
           style={{
-            flex: 1,
+            // Hugs its content rather than stretching. Stretching is what left
+            // a gap between the summary and the read-more link; the root's
+            // centring now absorbs slack for the whole card at once.
             width: "match_parent",
             flexDirection: "column",
             marginHorizontal: 12,
@@ -285,7 +368,7 @@ export function VerseOfTheDayWidget({
           clickActionData={{ url: noteDeepLink ?? deepLink }}
         >
           <TextWidget
-            text="WHY IT MATTERS"
+            text={strings.why}
             maxLines={1}
             style={{
               fontSize: 9,
@@ -294,41 +377,24 @@ export function VerseOfTheDayWidget({
               color: palette.panelLabel,
             }}
           />
-          {/* The explanation sits in its own weighted box so it uses ALL the
-              room the panel has left instead of a fixed line count. A 4×4 cell
-              is far taller on One UI than on the Pixel launcher, so any constant
-              clamps the copy while the panel still has blank rows — the reported
-              "description cutoff but more space avail." `maxLines` is a ceiling
-              now, not the binding constraint.
-
-              The weight has to sit on a FlexWidget: `flex` maps to LinearLayout
-              weight in this library and is silently dropped from TextWidget
-              styles. `height: "match_parent"` on the text is NOT a substitute —
-              a vertical LinearLayout gives a MATCH_PARENT child every remaining
-              pixel before it measures later siblings, which is what dropped the
-              link in the earlier nested-flex attempt. Weight is resolved after
-              all children are measured, so the link keeps its row. */}
-          <FlexWidget style={{ flex: 1, width: "match_parent", marginTop: 8 }}>
-            <TextWidget
-              text={explanation ?? ""}
-              // Deliberately far beyond any panel: a measured 4×4 cell came in
-              // at 483dp, where ~14 lines of 13sp copy is about the whole
-              // panel — so a 14 ceiling was close enough to bind again on the
-              // tallest launchers and bring the blank rows back at a rarer
-              // size. The weighted box does the clipping; this only has to be
-              // high enough never to be the constraint, and costs nothing when
-              // the copy is shorter (the API's summaries run ~6 lines).
-              maxLines={40}
-              truncate="END"
-              style={{
-                fontSize: 13,
-                color: palette.explanation,
-                fontFamily: "serif",
-              }}
-            />
-          </FlexWidget>
+          {/* Budgeted from the measured cell, so this ellipsizes cleanly at a
+              line count rather than being clipped mid-glyph by a container
+              bound — RemoteViews can only truncate at maxLines, never at a
+              height. The weighted box this replaces filled the space but cut
+              the last line in half. */}
           <TextWidget
-            text="Read the full note →"
+            text={explanation ?? ""}
+            maxLines={plan.noteMaxLines}
+            truncate="END"
+            style={{
+              fontSize: 13,
+              color: palette.explanation,
+              fontFamily: "serif",
+              marginTop: 8,
+            }}
+          />
+          <TextWidget
+            text={strings.readNote}
             maxLines={1}
             style={{
               fontSize: 11,
@@ -337,6 +403,7 @@ export function VerseOfTheDayWidget({
               marginTop: 10,
             }}
           />
+          {showTags && tags ? tagRow(tags, palette) : null}
         </FlexWidget>
       ) : null}
     </FlexWidget>

--- a/widgets/widget-layout.ts
+++ b/widgets/widget-layout.ts
@@ -1,0 +1,116 @@
+/**
+ * Line budget for the Verse-of-the-Day widget (GH-265 UX follow-up).
+ *
+ * Converts the MEASURED widget height into per-block line counts, so the
+ * composition fills the cell it actually got rather than the one the design
+ * assumed. Real cells run far larger than the 336dp design — 483dp measured on
+ * a Pixel emulator, ~430dp on a Samsung S22 Ultra — which is why the widget
+ * rendered mostly empty.
+ *
+ * TWO RULES HOLD THIS TOGETHER.
+ *
+ * 1. The budget NEVER looks at the text. How many characters fit on a line is
+ *    language- and script-dependent, and an estimate that is wrong fails
+ *    silently — it reads as a layout bug rather than a miscalibration. We decide
+ *    only how many LINES there is room for; the TextView decides what fits on
+ *    each one. `planLayout` therefore takes no content, and a test locks the
+ *    signature in.
+ *
+ * 2. The worst case must fit. `RemoteViews` can only ellipsize at `maxLines`,
+ *    never at a container bound, so a budget that over-allocates produces text
+ *    clipped mid-glyph — or, worse, a footer pushed out of the layout entirely.
+ *    Both have shipped from this file before. The allocation below is
+ *    constructed so every block at its full allocation still fits.
+ *
+ * Space left over when the copy is shorter than its allocation is NOT reclaimed
+ * here — it can't be, without measuring text. The widget centres its content
+ * instead (`justifyContent: 'center'` maps to `CENTER_VERTICAL`), so the layout
+ * engine distributes the slack using real rendered heights and it reads as
+ * framing rather than a hole. That is the common case: the median summary is
+ * 234 characters against ~11 lines of room.
+ */
+
+/**
+ * Android's default line height is roughly 1.2× the font size (ascent + descent
+ * + leading). 1.25 rounds against us on purpose — over-estimating the line box
+ * under-fills slightly, which is recoverable; under-estimating overflows, which
+ * is the failure mode above.
+ */
+export const LINE_HEIGHT_FACTOR = 1.25;
+
+export type WidgetSize = 'compact' | 'expanded';
+
+export interface LayoutPlan {
+  verseMaxLines: number;
+  /** 0 when there is no summary to show, or on the compact composition. */
+  noteMaxLines: number;
+  showTags: boolean;
+}
+
+interface PlanInput {
+  /** Measured cell height in dp — `props.widgetInfo.height`. */
+  height: number;
+  size: WidgetSize;
+  /** Whether the API served an `explanation` for today's verse. */
+  hasNote: boolean;
+}
+
+/**
+ * Non-text vertical space per composition, in dp: paddings, margins, gaps, and
+ * the single-line rows (eyebrow, reference/wordmark footer, note label, note
+ * link). Derived from the style values in `VerseOfTheDayWidget.tsx` — if those
+ * change, these change with them.
+ */
+const CHROME = {
+  compact: 48, // paddingVertical 16×2 + footer row ~16
+  expandedWithNote: 166, // verse block 82 + panel 84 (margin, padding, label, link)
+  expandedNoNote: 82, // paddingTop 18 + eyebrow 13 + gaps 20 + footer 17 + paddingBottom 14
+} as const;
+
+const FONT = { compactVerse: 15, expandedVerse: 16, note: 13 } as const;
+
+/** Below this measured height, tags are noise rather than filler. */
+const TAGS_MIN_HEIGHT = 460;
+
+const lineBox = (fontSize: number) => fontSize * LINE_HEIGHT_FACTOR;
+
+const clamp = (n: number, min: number, max: number) => Math.min(Math.max(n, min), max);
+
+export function planLayout({ height, size, hasNote }: PlanInput): LayoutPlan {
+  if (size === 'compact') {
+    // No note at this size by design — progressive disclosure. All the text
+    // space is the verse's, which is what fixes the compact widget's gap: on a
+    // 200dp cell it can run to 8 lines instead of a hard 3.
+    const space = height - CHROME.compact;
+    const verseMaxLines = clamp(Math.floor(space / lineBox(FONT.compactVerse)), 2, 10);
+    return { verseMaxLines, noteMaxLines: 0, showTags: false };
+  }
+
+  if (!hasNote) {
+    // AMB-001: nothing to promote into the slack, so the verse takes it.
+    const space = height - CHROME.expandedNoNote;
+    const verseMaxLines = clamp(Math.floor(space / lineBox(FONT.expandedVerse)), 3, 14);
+    return { verseMaxLines, noteMaxLines: 0, showTags: false };
+  }
+
+  const space = height - CHROME.expandedWithNote;
+  const verseBox = lineBox(FONT.expandedVerse);
+  const noteBox = lineBox(FONT.note);
+
+  // Ladder order: the verse is the product, so it takes slack first — but only
+  // up to a cap, because a wall of verse with a two-line note reads worse than
+  // a balanced card. Everything past the cap goes to the summary.
+  const NOTE_MIN = 2;
+  const verseMaxLines = clamp(
+    Math.floor((space - NOTE_MIN * noteBox) / verseBox),
+    3,
+    6
+  );
+  const noteMaxLines = clamp(
+    Math.floor((space - verseMaxLines * verseBox) / noteBox),
+    NOTE_MIN,
+    24
+  );
+
+  return { verseMaxLines, noteMaxLines, showTags: height >= TAGS_MIN_HEIGHT };
+}

--- a/widgets/widget-strings.ts
+++ b/widgets/widget-strings.ts
@@ -1,0 +1,55 @@
+/**
+ * Localised chrome for the Verse-of-the-Day widget (GH-265 UX follow-up).
+ *
+ * The widget's *content* has always localised — the backend resolves the summary
+ * language from the selected translation — but its frame did not: "VERSE OF THE
+ * DAY", "WHY IT MATTERS", the read-more link and the fallback message were
+ * English string literals. A Portuguese reader got a Portuguese verse in an
+ * English shell, which is more jarring than an untranslated app.
+ *
+ * WHY NOT i18next. The app's i18n module (`lib/i18n`) pulls in `react-i18next`
+ * and `expo-localization` and needs an async init. The widget runs in a HEADLESS
+ * JS task with no React tree, where every extra import is a new way to throw
+ * before anything renders — and a throw there paints the fallback tree, which
+ * looks like "the verse never loads". This file reads the same statically
+ * bundled catalogs directly instead: no init, no React, no async, no new
+ * dependency. Four strings do not justify the blast radius.
+ *
+ * Kept in sync with `locales/*.json` by construction — the catalogs are the
+ * source, this only selects from them.
+ */
+import de from '@/locales/de.json';
+import en from '@/locales/en.json';
+import es from '@/locales/es.json';
+import fr from '@/locales/fr.json';
+import pt from '@/locales/pt.json';
+
+/** Same key the app's i18n resolver reads (`lib/i18n/index.ts`). */
+export const LANGUAGE_KEY = '@versemate:preferred_language';
+
+const CATALOGS = { en, es, fr, de, pt } as const;
+type Catalog = keyof typeof CATALOGS;
+
+export interface WidgetStrings {
+  eyebrow: string;
+  why: string;
+  readNote: string;
+  fallback: string;
+}
+
+const ENGLISH = en.widget as WidgetStrings;
+
+/**
+ * Resolve the widget's chrome for a stored language code.
+ *
+ * Accepts full locales ("pt-BR") and selects the catalog ("pt"), matching the
+ * app's own behaviour. Anything unknown, absent, or malformed falls back to
+ * English — including the case where the widget is placed before the app has
+ * ever run and written the key, which is the same limitation that already
+ * applies to the preferred translation and the personalization id.
+ */
+export function widgetStrings(languageCode: string | null): WidgetStrings {
+  const base = (languageCode ?? '').trim().toLowerCase().split(/[-_]/)[0];
+  const catalog = CATALOGS[base as Catalog];
+  return (catalog?.widget as WidgetStrings | undefined) ?? ENGLISH;
+}

--- a/widgets/widget-task-handler.tsx
+++ b/widgets/widget-task-handler.tsx
@@ -13,6 +13,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { Linking } from "react-native";
 import type { WidgetTaskHandlerProps } from "react-native-android-widget";
 import { VerseOfTheDayWidget, type WidgetSize } from "./VerseOfTheDayWidget";
+import { LANGUAGE_KEY, widgetStrings } from "./widget-strings";
 
 const BIBLE_VERSION_KEY = "bible-version";
 const DEFAULT_VERSION = "NASB1995";
@@ -64,6 +65,8 @@ interface VerseResponse {
    * expanded size falls back to a verse-only composition until then.
    */
   explanation?: string | null;
+  /** Topic tags, e.g. ["faith","hope"]. Shown only on the largest cells. */
+  tags?: string[];
 }
 
 /**
@@ -123,8 +126,10 @@ export interface WidgetVerseData {
   noteDeepLink: string;
   /** Translation label for the expanded header; empty when unknown. */
   versionLabel: string;
-  /** "Why it matters" summary; null until the API serves one. */
+  /** "Why it matters" summary; no longer server-clamped (GH-265 follow-up). */
   explanation: string | null;
+  /** Topic tags from the API; empty when absent. */
+  tags: string[];
 }
 
 /**
@@ -239,6 +244,7 @@ export async function fetchVerse(): Promise<WidgetVerseData> {
       fallbackText: FALLBACK_MESSAGE,
       versionLabel: data.versionKey ?? "",
       explanation: data.explanation ?? null,
+      tags: data.tags ?? [],
     };
     await writeCache({ date: today, pid, version, data: verse });
     return verse;
@@ -261,7 +267,21 @@ function emptyState(fallbackText: string): WidgetVerseData {
     fallbackText,
     versionLabel: "",
     explanation: null,
+    tags: [],
   };
+}
+
+/**
+ * Localised chrome for the current user. Read from the same AsyncStorage key the
+ * app's i18n resolver uses; English when absent (widget placed before the app
+ * ever ran), which matches how version and pid already behave.
+ */
+async function currentStrings() {
+  try {
+    return widgetStrings(await AsyncStorage.getItem(LANGUAGE_KEY));
+  } catch {
+    return widgetStrings(null);
+  }
 }
 
 /** Both providers the app registers (app.config.js `react-native-android-widget`). */
@@ -300,15 +320,19 @@ export async function refreshWidgets(): Promise<void> {
     if (placed.every((widgets) => widgets.length === 0)) return;
 
     const data = await fetchVerse();
+    const strings = await currentStrings();
     await Promise.all(
       WIDGET_NAMES.map((widgetName) =>
         requestWidgetUpdate({
           widgetName,
           renderWidget: (info) => {
             const size = pickWidgetSize(info.widgetName);
+            // info.height is the MEASURED cell — the whole layout budget keys
+            // off it. See widget-layout.ts.
+            const shared = { ...data, size, height: info.height, strings };
             return {
-              light: <VerseOfTheDayWidget {...data} size={size} theme="light" />,
-              dark: <VerseOfTheDayWidget {...data} size={size} theme="dark" />,
+              light: <VerseOfTheDayWidget {...shared} theme="light" />,
+              dark: <VerseOfTheDayWidget {...shared} theme="dark" />,
             };
           },
         }),
@@ -330,17 +354,27 @@ export async function widgetTaskHandler(props: WidgetTaskHandlerProps) {
       // light + dark variant so the widget matches the launcher's theme.
       // Which provider was placed picks the composition (design 2B: 4×2 vs 4×4).
       const size = pickWidgetSize(props.widgetInfo.widgetName);
+      const height = props.widgetInfo.height;
       try {
         const data = await fetchVerse();
+        const strings = await currentStrings();
+        const shared = { ...data, size, height, strings };
         props.renderWidget({
-          light: <VerseOfTheDayWidget {...data} size={size} theme="light" />,
-          dark: <VerseOfTheDayWidget {...data} size={size} theme="dark" />,
+          light: <VerseOfTheDayWidget {...shared} theme="light" />,
+          dark: <VerseOfTheDayWidget {...shared} theme="dark" />,
         });
       } catch {
-        const fallback = emptyState(FALLBACK_MESSAGE);
+        // The catch path must not depend on anything that can throw again —
+        // English chrome is the safe floor here.
+        const fallback = {
+          ...emptyState(FALLBACK_MESSAGE),
+          size,
+          height,
+          strings: widgetStrings(null),
+        };
         props.renderWidget({
-          light: <VerseOfTheDayWidget {...fallback} size={size} theme="light" />,
-          dark: <VerseOfTheDayWidget {...fallback} size={size} theme="dark" />,
+          light: <VerseOfTheDayWidget {...fallback} theme="light" />,
+          dark: <VerseOfTheDayWidget {...fallback} theme="dark" />,
         });
       }
       break;


### PR DESCRIPTION
Companion to verse-mate/verse-mate#308 — **land that first**, this lays out copy the API doesn't send yet.

## The finding that drove this

The two merged PRs fixed content loading and removed a fixed line clamp — and the widget still rendered mostly empty. Here's why: the constraint had moved from the clamp to the content.

| | measured |
|---|---|
| Real 4×4 cell | **483dp** (Pixel emulator, 945×1268px ÷ 2.625) · ~430dp (S22 Ultra) |
| Design assumed | 336dp |
| Server cap | 220 chars |
| Real summaries (n=336) | 73–606, **median 234** |

Even uncapped, the median summary is ~5 lines against ~11 lines of room. **More text alone was never going to fix it** — that's what a naive second attempt would have missed, and it's why this is compositional rather than a constant bump.

## What changed

**Line budget from the measured cell.** `widget-layout.ts` turns `props.widgetInfo.height` into per-block line counts. That value is trustworthy now: with `resizeMode: 'horizontal'` the provider's min and max heights are equal, so the reported max *is* the cell — confirmed by the rendered bitmap matching exactly. An older note in this project says the value is useless; that was measured against a `horizontal|vertical` provider, where max genuinely is a resize bound.

**The budget never looks at the text.** Characters-per-line is language- and script-dependent and fails *silently* when wrong — it reads as a layout bug. We decide how many lines fit; the TextView decides what goes on each. A test asserts the signature takes no content, so reintroducing an estimate stops compiling.

**Centred, hugging blocks.** Panels no longer stretch, the footer is no longer pinned. The root centres its children, so the layout engine distributes slack using *real rendered heights* — the only way to handle short copy without measuring text. Short copy is the common case, not the edge.

**Compact too.** Half the original report; the first draft of the spec ignored it.

**Accessibility** — the widget paints into a bitmap, so TalkBack announced "VerseMate, image". The verse has never been readable to a screen reader. Fixed and verified on the launcher.

**Localisation** — content localised long before the frame did. Android reads the bundled catalogs directly rather than initialising i18next: the headless task has no React tree, and every extra import there is a new way to throw before anything renders. iOS reads pre-resolved strings from the App Group.

**iOS** also gets raised line limits and `WidgetCenter.reloadWidget()` on identity change (was up to 6h). No native module needed — `@bacons/apple-targets` already exposes it.

## Verified on device, not just green

- 8 compositions through `WidgetPreview` at 148/200/336/430/483dp × 73/234/606-char copy
- Real widget read from the content provider at 360×483dp with live data and tags
- **336dp + max copy ellipsizes cleanly** (`This places Hi…`) with the link intact — no mid-glyph clip
- **483dp + max copy renders all 606 chars** — was 5 lines and an ellipsis
- Portuguese chrome renders; TalkBack reads back verse + reference
- Swift localisation checked against the real source with a harness, because WidgetKit serves persisted renderings and won't show a fallback branch on screen

1919 tests pass, typecheck and lint clean.

Spec: `devspace/specs/2026-08-16-1800-votd-widget-size-adaptive-ux` (validated 89/100).
